### PR TITLE
Mercury Bank integration: poll-based account/transaction ingest + optional webhook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           POSTGRES_PASSWORD: ci
           CLICKHOUSE_PASSWORD: ci
           CLICKHOUSE_RO_PASSWORD: ci
-          COMPOSE_PROFILES: lake,ingest,backup,slack,render
+          COMPOSE_PROFILES: lake,ingest,backup,slack,render,mercury
         run: docker compose -f docker-compose.yml config -q
 
   dco:

--- a/Caddyfile
+++ b/Caddyfile
@@ -30,6 +30,26 @@
 		}
 	}
 
+	# Mercury webhooks (OPTIONAL): Mercury POSTs transaction-change events to a URL
+	# you register in its dashboard. Like Render, we authenticate via a token in
+	# the URL PATH. Register the webhook URL as:
+	#   https://<domain>/ingest/mercury/<SETOKU_INGEST_TOKEN>
+	# The token segment is verified, then stripped so Vector routes it as
+	# /ingest/mercury → mercury_events. (Must precede the generic /ingest/* handle.)
+	# Note: the poller talks to Vector directly on the internal network, so its
+	# /ingest/mercury/accounts and /transactions paths never traverse Caddy.
+	# TODO hardening: also verify Mercury's HMAC signature on the raw body.
+	handle /ingest/mercury/* {
+		@ok path /ingest/mercury/{$SETOKU_INGEST_TOKEN} /ingest/mercury/{$SETOKU_INGEST_TOKEN}/*
+		handle @ok {
+			rewrite * /ingest/mercury
+			reverse_proxy vector:8080
+		}
+		handle {
+			respond "unauthorized" 401
+		}
+	}
+
 	# Ingest: bearer token checked at the edge; Vector never sees
 	# unauthenticated traffic. Vercel drains send Authorization: Bearer; app
 	# events POST it too. (Render uses the path-token route above.)

--- a/deploy/vector/tests.yaml
+++ b/deploy/vector/tests.yaml
@@ -192,3 +192,116 @@ tests:
               assert!(.service == "worker-2", "service falls back to .app")
               assert!(.message == "queue depth exceeded again", "message falls back to .log")
               assert!(.level == "info", "level defaults")
+
+  - name: mercury route splits accounts / transactions / events by path
+    inputs:
+      - insert_at: router
+        type: log
+        log_fields:
+          _path: /ingest/mercury/accounts
+          id: acct-route
+          snapshot_ts: "2026-06-12T18:00:00Z"
+          created_at: "2024-01-02T03:04:05Z"
+    outputs:
+      - extract_from: mercury_accounts_parse
+        conditions:
+          - type: vrl
+            source: assert!(.id == "acct-route")
+
+  - name: mercury account snapshot normalizes timestamps, keeps redacted fields
+    inputs:
+      - insert_at: mercury_accounts_parse
+        type: log
+        log_fields:
+          _path: /ingest/mercury/accounts
+          snapshot_ts: "2026-06-12T18:00:00.123Z"
+          id: acc_abc
+          name: Operating
+          account_number_last4: "4321"
+          routing_number: "021000021"
+          available_balance: 105000.55
+          current_balance: 110000.0
+          created_at: "2024-01-02T03:04:05Z"
+          raw: '{"accountNumber":"4321"}'
+    outputs:
+      - extract_from: mercury_accounts_parse
+        conditions:
+          - type: vrl
+            source: |
+              assert!(.id == "acc_abc", "id")
+              assert!(.account_number_last4 == "4321", "last4 only")
+              assert!(.available_balance == 105000.55, "available balance")
+              assert!(starts_with!(.snapshot_ts, "2026-06-12 18:00:00"), "snapshot_ts: " + string!(.snapshot_ts))
+              assert!(starts_with!(.created_at, "2024-01-02 03:04:05"), "created_at: " + string!(.created_at))
+
+  - name: mercury pending transaction keeps null posted_at; estimated date-only parsed
+    inputs:
+      - insert_at: mercury_transactions_parse
+        type: log
+        log_fields:
+          _path: /ingest/mercury/transactions
+          id: txn_pending
+          account_id: acc_abc
+          amount: -2500.0
+          status: pending
+          kind: externalTransfer
+          counterparty_name: AWS
+          created_at: "2026-06-11T09:00:00.500Z"
+          posted_at: ""
+          estimated_delivery: "2026-06-20"
+          ingested_at: "2026-06-12T18:00:00Z"
+    outputs:
+      - extract_from: mercury_transactions_parse
+        conditions:
+          - type: vrl
+            source: |
+              assert!(.amount == -2500.0, "signed amount preserved")
+              assert!(.status == "pending", "status")
+              assert!(.posted_at == null, "posted_at null while pending")
+              assert!(starts_with!(string!(.estimated_delivery), "2026-06-20 00:00:00"), "date-only fallback: " + string!(.estimated_delivery))
+              assert!(starts_with!(.created_at, "2026-06-11 09:00:00"), "created_at parsed")
+              assert!(starts_with!(.ingested_at, "2026-06-12 18:00:00"), "ingested_at parsed")
+
+  - name: mercury posted transaction fills posted_at
+    inputs:
+      - insert_at: mercury_transactions_parse
+        type: log
+        log_fields:
+          _path: /ingest/mercury/transactions
+          id: txn_sent
+          account_id: acc_abc
+          amount: 9000.0
+          status: sent
+          created_at: "2026-06-10T08:00:00Z"
+          posted_at: "2026-06-11T12:00:00Z"
+          ingested_at: "2026-06-12T18:00:00Z"
+    outputs:
+      - extract_from: mercury_transactions_parse
+        conditions:
+          - type: vrl
+            source: |
+              assert!(.status == "sent", "status")
+              assert!(starts_with!(string!(.posted_at), "2026-06-11 12:00:00"), "posted_at: " + string!(.posted_at))
+
+  - name: mercury webhook event extracts nested ids defensively, keeps raw
+    inputs:
+      - insert_at: mercury_events_parse
+        type: log
+        log_fields:
+          _path: /ingest/mercury
+          type: transaction.posted
+          createdAt: "2026-06-12T18:05:00Z"
+          transaction.id: txn_sent
+          transaction.status: sent
+          account.id: acc_abc
+    outputs:
+      - extract_from: mercury_events_parse
+        conditions:
+          - type: vrl
+            source: |
+              assert!(.event_type == "transaction.posted", "event_type")
+              assert!(.transaction_id == "txn_sent", "transaction id from nested .transaction.id")
+              assert!(.account_id == "acc_abc", "account id from nested .account.id")
+              assert!(.status == "sent", "status from nested .transaction.status")
+              assert!(starts_with!(.event_ts, "2026-06-12 18:05:00"), "event_ts: " + string!(.event_ts))
+              assert!(contains!(.raw, "txn_sent"), "raw preserved")

--- a/deploy/vector/vector.yaml
+++ b/deploy/vector/vector.yaml
@@ -3,10 +3,13 @@
 #
 # One authenticated HTTP source (Caddy enforces the bearer token at the edge)
 # routed by ingest path into typed per-source pipelines:
-#   /ingest/vercel  → logs_vercel   (NDJSON drain; schema per Vercel docs)
-#   /ingest/render  → logs_render   (HTTPS JSON; schema undocumented — defensive, see 011_logs_render.sql)
-#   /ingest/events  → app_events    (first-party contract: docs/events.md)
-#   anything else   → ingest_raw    (catch-all; nothing is silently dropped)
+#   /ingest/vercel               → logs_vercel   (NDJSON drain; schema per Vercel docs)
+#   /ingest/render               → logs_render   (HTTPS JSON; schema undocumented — defensive, see 011_logs_render.sql)
+#   /ingest/events               → app_events    (first-party contract: docs/events.md)
+#   /ingest/mercury/accounts     → mercury_accounts      (poller balance snapshots)
+#   /ingest/mercury/transactions → mercury_transactions  (poller, ReplacingMergeTree)
+#   /ingest/mercury              → mercury_events         (optional webhook stream)
+#   anything else                → ingest_raw    (catch-all; nothing is silently dropped)
 #
 # Buffer policy (I4): app events block when the disk buffer fills (never shed
 # the high-grade ore); platform request logs may drop_newest under backpressure.
@@ -35,6 +38,9 @@ transforms:
       vercel: '._path == "/ingest/vercel"'
       render: '._path == "/ingest/render"'
       events: '._path == "/ingest/events"'
+      mercury_acct: '._path == "/ingest/mercury/accounts"'
+      mercury_txn: '._path == "/ingest/mercury/transactions"'
+      mercury_event: '._path == "/ingest/mercury"'
 
   vercel_parse:
     type: remap
@@ -133,6 +139,85 @@ transforms:
         "raw": raw
       }
 
+  mercury_accounts_parse:
+    type: remap
+    inputs: [router.mercury_acct]
+    source: |
+      # Poller sends pre-normalized fields; we only normalize timestamps to the
+      # ClickHouse-friendly format (account number is already redacted upstream).
+      del(.source_type)
+      del(._path)
+      ts_snap, e1 = parse_timestamp(to_string(.snapshot_ts) ?? "", "%+")
+      if e1 != null { ts_snap = now() }
+      .snapshot_ts = format_timestamp!(ts_snap, "%F %T%.3f")
+      ts_cr, e2 = parse_timestamp(to_string(.created_at) ?? "", "%+")
+      if e2 != null { ts_cr = ts_snap }
+      .created_at = format_timestamp!(ts_cr, "%F %T%.3f")
+
+  mercury_transactions_parse:
+    type: remap
+    inputs: [router.mercury_txn]
+    source: |
+      del(.source_type)
+      del(._path)
+      ts_cr, e1 = parse_timestamp(to_string(.created_at) ?? "", "%+")
+      if e1 != null { ts_cr = now() }
+      .created_at = format_timestamp!(ts_cr, "%F %T%.3f")
+      ts_in, e2 = parse_timestamp(to_string(.ingested_at) ?? "", "%+")
+      if e2 != null { ts_in = now() }
+      .ingested_at = format_timestamp!(ts_in, "%F %T%.3f")
+      # nullable settle-time columns: keep null while unknown/unparseable
+      pa = .posted_at
+      if pa == null || pa == "" {
+        .posted_at = null
+      } else {
+        tp, ep = parse_timestamp(to_string(pa) ?? "", "%+")
+        if ep != null { .posted_at = null } else { .posted_at = format_timestamp!(tp, "%F %T%.3f") }
+      }
+      ed = .estimated_delivery
+      if ed == null || ed == "" {
+        .estimated_delivery = null
+      } else {
+        eds = to_string(ed) ?? ""
+        # Mercury sometimes sends a bare date; pad to a full instant so chrono parses it
+        if match(eds, r'^\d{4}-\d{2}-\d{2}$') { eds = eds + "T00:00:00Z" }
+        te, ee = parse_timestamp(eds, "%+")
+        if ee != null { .estimated_delivery = null } else { .estimated_delivery = format_timestamp!(te, "%F %T%.3f") }
+      }
+
+  mercury_events_parse:
+    type: remap
+    inputs: [router.mercury_event]
+    source: |
+      # Webhook payload shape is provider-specific (Events API / JSON Merge Patch);
+      # extract common identifiers defensively and keep the whole thing in raw.
+      del(.source_type)
+      del(._path)
+      raw = encode_json(.)
+      et = .createdAt
+      if et == null { et = .timestamp }
+      if et == null { et = .eventCreatedAt }
+      t, terr = parse_timestamp(to_string(et) ?? "", "%+")
+      if terr != null { t = now() }
+      etype = .type
+      if etype == null { etype = .eventType }
+      txid = .transactionId
+      if txid == null { txid = .transaction.id }
+      if txid == null { txid = .id }
+      acct = .accountId
+      if acct == null { acct = .account.id }
+      stat = .status
+      if stat == null { stat = .transaction.status }
+      . = {
+        "received_at": format_timestamp!(now(), "%F %T%.3f"),
+        "event_ts": format_timestamp!(t, "%F %T%.3f"),
+        "event_type": to_string(etype) ?? "",
+        "transaction_id": to_string(txid) ?? "",
+        "account_id": to_string(acct) ?? "",
+        "status": to_string(stat) ?? "",
+        "raw": raw
+      }
+
   to_raw:
     type: remap
     inputs: [router._unmatched]
@@ -178,6 +263,39 @@ sinks:
     compression: gzip
     batch: { timeout_secs: 10, max_events: 10000 }
     buffer: { type: disk, max_size: 2147483648, when_full: block } # never shed events (I4)
+
+  lake_mercury_accounts:
+    type: clickhouse
+    inputs: [mercury_accounts_parse]
+    endpoint: http://clickhouse:8123
+    database: setoku
+    table: mercury_accounts
+    auth: { strategy: basic, user: "${CLICKHOUSE_USER}", password: "${CLICKHOUSE_PASSWORD}" }
+    compression: gzip
+    batch: { timeout_secs: 10, max_events: 10000 }
+    buffer: { type: disk, max_size: 536870912, when_full: block } # financial data: never shed
+
+  lake_mercury_transactions:
+    type: clickhouse
+    inputs: [mercury_transactions_parse]
+    endpoint: http://clickhouse:8123
+    database: setoku
+    table: mercury_transactions
+    auth: { strategy: basic, user: "${CLICKHOUSE_USER}", password: "${CLICKHOUSE_PASSWORD}" }
+    compression: gzip
+    batch: { timeout_secs: 10, max_events: 10000 }
+    buffer: { type: disk, max_size: 1073741824, when_full: block }
+
+  lake_mercury_events:
+    type: clickhouse
+    inputs: [mercury_events_parse]
+    endpoint: http://clickhouse:8123
+    database: setoku
+    table: mercury_events
+    auth: { strategy: basic, user: "${CLICKHOUSE_USER}", password: "${CLICKHOUSE_PASSWORD}" }
+    compression: gzip
+    batch: { timeout_secs: 10, max_events: 10000 }
+    buffer: { type: disk, max_size: 536870912, when_full: block }
 
   lake_raw:
     type: clickhouse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       retries: 5
 
   clickhouse:
-    profiles: [lake, ingest, slack, render]
+    profiles: [lake, ingest, slack, render, mercury]
     image: clickhouse/clickhouse-server:25.3@sha256:b627d7a9bc0e0c1bac26cdbe9d2fc6316faa29c5d8a174f28f5abd57d0fa6ba2
     restart: unless-stopped
     environment:
@@ -119,7 +119,7 @@ services:
       start_period: 30s
 
   vector:
-    profiles: [ingest, render]
+    profiles: [ingest, render, mercury]
     image: timberio/vector:0.49.0-alpine@sha256:2a31648e67280953aaf6b219c1b04729ac5ed12820ec2bfb698630b2d989d135
     restart: unless-stopped
     environment:
@@ -197,6 +197,29 @@ services:
       vector:
         condition: service_healthy
 
+  # Mercury Bank → ingest bridge (profile: mercury). Mercury is API-only with no
+  # self-create push stream, so we poll: balance snapshots + a rolling window of
+  # transactions (ReplacingMergeTree handles pending→posted updates). State on a
+  # volume so restarts don't re-backfill. See ingest/mercury-poller/README.md.
+  mercury-poller:
+    profiles: [mercury]
+    build:
+      context: .
+      dockerfile: ingest/mercury-poller/Dockerfile
+    restart: unless-stopped
+    environment:
+      # poll.ts validates the token at runtime; :- default keeps `docker compose
+      # config` valid for non-mercury deploys (matches render-poller/slack).
+      MERCURY_API_TOKEN: ${MERCURY_API_TOKEN:-}
+      MERCURY_POLL_INTERVAL_MS: ${MERCURY_POLL_INTERVAL_MS:-300000}
+      MERCURY_WINDOW_DAYS: ${MERCURY_WINDOW_DAYS:-35}
+      MERCURY_BACKFILL_DAYS: ${MERCURY_BACKFILL_DAYS:-730}
+    volumes:
+      - mercury_state:/state
+    depends_on:
+      vector:
+        condition: service_healthy
+
   # ---- backup one-shots (profile: backup) — driven by deploy/backup/*.sh ----
 
   clickhouse-backup:
@@ -238,3 +261,4 @@ volumes:
   vector_buffer:
   slack_spool:
   render_state:
+  mercury_state:

--- a/ingest/mercury-poller/Dockerfile
+++ b/ingest/mercury-poller/Dockerfile
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# Mercury Bank → ingest bridge. Zero deps (Bun built-ins only).
+FROM oven/bun:1-slim
+WORKDIR /app
+COPY ingest/mercury-poller/poll.ts ./poll.ts
+VOLUME /state
+CMD ["bun", "poll.ts"]

--- a/ingest/mercury-poller/README.md
+++ b/ingest/mercury-poller/README.md
@@ -1,0 +1,65 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Mercury Bank ingest bridge
+
+Pulls Mercury account balances and transactions into the Setoku lake. Mercury is
+API-only with no self-serve push stream, so we poll — the same pull-bridge
+pattern as the Render logs bridge.
+
+## What it does each tick (default every 5 min)
+
+1. `GET /accounts` → one **balance snapshot** row per account →
+   `setoku.mercury_accounts` (append-only time series; trend it for runway).
+2. `GET /account/{id}/transactions?start=…` over a **rolling window** →
+   `setoku.mercury_transactions` (a `ReplacingMergeTree` keyed by id, so the
+   newest observation of a mutable transaction wins).
+
+The first run backfills `MERCURY_BACKFILL_DAYS` (default 730); after that it only
+re-scans `MERCURY_WINDOW_DAYS` (default 35), enough to catch `pending → posted`
+status changes and late `postedAt` fills. State (`backfilledThrough`) lives on the
+`mercury_state` volume so a restart neither re-backfills nor loses the window.
+
+## Why re-poll instead of append-only
+
+A bank transaction is **mutable**: it moves `pending → sent/posted` (or fails),
+and `postedAt` arrives later. An append-only log would freeze the first
+observation. Re-emitting the recent window + `ReplacingMergeTree(ingested_at)`
+keeps current state correct. **Query `mercury_transactions` with `FINAL`** (or
+`argMax`/`LIMIT 1 BY id`) so you read one current row per transaction and don't
+double-count `amount` over an in-flight update.
+
+## Data minimization
+
+Full account numbers are **never** stored. The poller redacts `accountNumber` to
+the last 4 digits in both the typed column and `raw` before anything leaves the
+process. Counterparty names / notes / memos are user free text — treat them as
+untrusted (the analyst reads the lake under the propose-only membrane, so they
+can't drive a curated write regardless).
+
+## Config
+
+| env | required | default | meaning |
+|-----|----------|---------|---------|
+| `MERCURY_API_TOKEN` | ✅ | — | `secret-token:mercury_…` read-only token (Mercury → Settings → Tokens) |
+| `MERCURY_POLL_INTERVAL_MS` | | `300000` | poll cadence |
+| `MERCURY_WINDOW_DAYS` | | `35` | steady-state lookback |
+| `MERCURY_BACKFILL_DAYS` | | `730` | first-run lookback |
+
+Run it: `docker compose --profile mercury up -d mercury-poller`.
+
+## Optional: webhooks (lower latency)
+
+Mercury can also POST real-time events when transactions change. Setoku captures
+these losslessly in `setoku.mercury_events` (append-only) — it does **not** merge
+partial webhook patches into `mercury_transactions` (that would clobber unchanged
+columns), so the poller stays the source of truth and the webhook is pure
+latency. To enable: in Mercury's dashboard set the webhook URL to
+
+```
+https://<your-domain>/ingest/mercury/<SETOKU_INGEST_TOKEN>
+```
+
+Caddy verifies the path token, strips it, and forwards to Vector's
+`/ingest/mercury` route. **Hardening TODO:** Mercury also signs webhooks (HMAC
+with a Partner Secret); we currently authenticate by the unguessable path token
+only (same posture as the Render route). Add signature verification on the raw
+bytes before trusting `mercury_events` for anything beyond observability.

--- a/ingest/mercury-poller/poll.ts
+++ b/ingest/mercury-poller/poll.ts
@@ -1,0 +1,235 @@
+#!/usr/bin/env bun
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Mercury Bank → Setoku ingest bridge (pull-based).
+ *
+ * Mercury exposes a read-only REST API but no push stream you can self-create
+ * (webhooks exist but must be registered in the dashboard and only notify — see
+ * README), so we poll, exactly like the Render bridge. Each tick we:
+ *   1. snapshot every account's balances  → POST /ingest/mercury/accounts
+ *   2. re-fetch a rolling window of transactions → POST /ingest/mercury/transactions
+ *
+ * Why re-fetch a window instead of only-new (the Render approach): a Mercury
+ * transaction is MUTABLE — it moves pending → sent/posted and posted_at fills in
+ * later. Append-only would freeze the first observation. So we re-emit recent
+ * transactions every tick and the lake table is a ReplacingMergeTree keyed by id
+ * (newest observation wins). The first run backfills a longer window.
+ *
+ * ⚠ Data minimization: account numbers are redacted to the last 4 digits before
+ * anything leaves this process; the full PAN is never sent to the lake.
+ *
+ * Env:
+ *   MERCURY_API_TOKEN     "secret-token:mercury_…" (read-only)        [required]
+ *   MERCURY_VECTOR_URL    default http://vector:8080  (base; paths appended)
+ *   MERCURY_POLL_INTERVAL_MS  default 300000 (5 min — banking isn't sub-minute)
+ *   MERCURY_WINDOW_DAYS   steady-state lookback, default 35 (covers settlement)
+ *   MERCURY_BACKFILL_DAYS first-run lookback, default 730
+ *   MERCURY_STATE_DIR     default /state
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const API = "https://api.mercury.com/api/v1";
+const TOKEN = required("MERCURY_API_TOKEN");
+const VECTOR_BASE = (process.env.MERCURY_VECTOR_URL ?? "http://vector:8080").replace(/\/+$/, "");
+const INTERVAL = Number(process.env.MERCURY_POLL_INTERVAL_MS ?? 300_000);
+const WINDOW_DAYS = Number(process.env.MERCURY_WINDOW_DAYS ?? 35);
+const BACKFILL_DAYS = Number(process.env.MERCURY_BACKFILL_DAYS ?? 730);
+const STATE_DIR = process.env.MERCURY_STATE_DIR ?? "/state";
+const STATE_FILE = path.join(STATE_DIR, "mercury-poller.json");
+const PAGE = 500;
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`mercury-poller: ${name} is required`);
+    process.exit(1);
+  }
+  return v;
+}
+
+interface MercuryAccount {
+  id: string;
+  name?: string;
+  legalBusinessName?: string;
+  kind?: string;
+  type?: string;
+  status?: string;
+  accountNumber?: string;
+  routingNumber?: string;
+  availableBalance?: number;
+  currentBalance?: number;
+  createdAt?: string;
+  [k: string]: unknown;
+}
+interface MercuryTxn {
+  id: string;
+  accountId?: string;
+  amount?: number;
+  status?: string;
+  kind?: string;
+  counterpartyName?: string;
+  counterpartyId?: string;
+  mercuryCategory?: string | null;
+  generalLedgerCodeName?: string | null;
+  note?: string | null;
+  bankDescription?: string | null;
+  externalMemo?: string | null;
+  createdAt?: string;
+  postedAt?: string | null;
+  estimatedDeliveryDate?: string | null;
+  dashboardLink?: string;
+  [k: string]: unknown;
+}
+interface State {
+  backfilledThrough?: string; // ISO date we've backfilled from; presence ⇒ steady-state
+}
+
+function loadState(): State {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+function saveState(s: State): void {
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.writeFileSync(STATE_FILE, JSON.stringify(s));
+}
+
+async function api<T>(pathAndQuery: string): Promise<T | null> {
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const r = await fetch(`${API}${pathAndQuery}`, {
+      headers: { authorization: `Bearer ${TOKEN}`, accept: "application/json" },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (r.status === 429 || r.status >= 500) {
+      await Bun.sleep(Number(r.headers.get("retry-after") ?? 2 ** attempt) * 1000);
+      continue;
+    }
+    if (!r.ok) {
+      console.error(`mercury-poller: GET ${pathAndQuery} → ${r.status} ${(await r.text().catch(() => "")).slice(0, 200)}`);
+      return null;
+    }
+    return (await r.json()) as T;
+  }
+  console.error(`mercury-poller: GET ${pathAndQuery} gave up after retries`);
+  return null;
+}
+
+async function pushToVector(suffix: string, lines: string[]): Promise<void> {
+  if (!lines.length) return;
+  const r = await fetch(`${VECTOR_BASE}/ingest/mercury/${suffix}`, {
+    method: "POST",
+    headers: { "content-type": "application/x-ndjson" },
+    body: lines.join("\n") + "\n",
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!r.ok) throw new Error(`vector ${r.status} ${(await r.text().catch(() => "")).slice(0, 200)}`);
+}
+
+const last4 = (n?: string): string => (n ? n.replace(/\D/g, "").slice(-4) : "");
+const isoDate = (d: Date): string => d.toISOString().slice(0, 10);
+
+async function snapshotAccounts(snapshotTs: string): Promise<MercuryAccount[]> {
+  const d = await api<{ accounts: MercuryAccount[] }>(`/accounts`);
+  const accounts = d?.accounts ?? [];
+  const lines = accounts.map((a) => {
+    // redact the PAN everywhere: typed field AND raw, before it leaves the process
+    const redacted = { ...a, accountNumber: last4(a.accountNumber) };
+    return JSON.stringify({
+      snapshot_ts: snapshotTs,
+      id: a.id,
+      name: a.name ?? "",
+      legal_business_name: a.legalBusinessName ?? "",
+      kind: a.kind ?? "",
+      type: a.type ?? "",
+      status: a.status ?? "",
+      account_number_last4: last4(a.accountNumber),
+      routing_number: a.routingNumber ?? "",
+      available_balance: a.availableBalance ?? 0,
+      current_balance: a.currentBalance ?? 0,
+      created_at: a.createdAt ?? "",
+      raw: JSON.stringify(redacted),
+    });
+  });
+  await pushToVector("accounts", lines);
+  return accounts;
+}
+
+async function fetchTxns(accountId: string, start: string): Promise<MercuryTxn[]> {
+  const out: MercuryTxn[] = [];
+  for (let offset = 0; offset < 100_000; offset += PAGE) {
+    const d = await api<{ total?: number; transactions?: MercuryTxn[] }>(
+      `/account/${accountId}/transactions?limit=${PAGE}&offset=${offset}&start=${start}`,
+    );
+    const page = d?.transactions ?? [];
+    out.push(...page);
+    if (page.length < PAGE) break; // last page
+  }
+  return out;
+}
+
+async function pollTransactions(accountIds: string[], ingestedAt: string): Promise<void> {
+  const st = loadState();
+  const days = st.backfilledThrough ? WINDOW_DAYS : BACKFILL_DAYS;
+  const start = isoDate(new Date(Date.now() - days * 86_400_000));
+
+  let total = 0;
+  for (const acct of accountIds) {
+    const txns = await fetchTxns(acct, start);
+    const lines = txns.map((t) =>
+      JSON.stringify({
+        id: t.id,
+        account_id: t.accountId ?? acct,
+        amount: t.amount ?? 0,
+        status: t.status ?? "",
+        kind: t.kind ?? "",
+        counterparty_name: t.counterpartyName ?? "",
+        counterparty_id: t.counterpartyId ?? "",
+        mercury_category: t.mercuryCategory ?? "",
+        gl_code: t.generalLedgerCodeName ?? "",
+        note: t.note ?? "",
+        bank_description: t.bankDescription ?? "",
+        external_memo: t.externalMemo ?? "",
+        created_at: t.createdAt ?? "",
+        posted_at: t.postedAt ?? null,
+        estimated_delivery: t.estimatedDeliveryDate ?? null,
+        dashboard_link: t.dashboardLink ?? "",
+        raw: JSON.stringify(t),
+        ingested_at: ingestedAt,
+      }),
+    );
+    await pushToVector("transactions", lines);
+    total += lines.length;
+  }
+  if (!st.backfilledThrough) saveState({ backfilledThrough: start });
+  console.error(`mercury-poller: forwarded ${total} transaction row(s) from ${start} (${st.backfilledThrough ? "window" : "backfill"})`);
+}
+
+async function tick(): Promise<void> {
+  const now = new Date().toISOString();
+  const accounts = await snapshotAccounts(now);
+  if (!accounts.length) {
+    console.error("mercury-poller: no accounts returned (token scope?)");
+    return;
+  }
+  await pollTransactions(accounts.map((a) => a.id), now);
+}
+
+async function main(): Promise<void> {
+  console.error(
+    `mercury-poller: polling every ${INTERVAL}ms → ${VECTOR_BASE}/ingest/mercury/* ` +
+      `(window ${WINDOW_DAYS}d, backfill ${BACKFILL_DAYS}d)`,
+  );
+  for (;;) {
+    try {
+      await tick();
+    } catch (e) {
+      console.error(`mercury-poller: tick failed: ${e}`);
+    }
+    await Bun.sleep(INTERVAL);
+  }
+}
+
+if (import.meta.main) void main();

--- a/ingest/schemas/040_mercury_accounts.sql
+++ b/ingest/schemas/040_mercury_accounts.sql
@@ -1,0 +1,30 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Mercury bank account balance snapshots. The poller records every account's
+-- balances on each tick, so this is an append-only time series — query the
+-- latest row per account for "current balance", or trend the series for runway.
+--
+-- ⚠ Data minimization: the full account number is a sensitive identifier and is
+-- NEVER stored. The poller redacts it to the last 4 digits before sending, and
+-- strips it from `raw`. Routing numbers are public-on-checks and kept as-is.
+-- Schema verified against the live GET /api/v1/accounts response (June 2026).
+CREATE TABLE IF NOT EXISTS setoku.mercury_accounts
+(
+    snapshot_ts          DateTime64(3)           COMMENT 'when this balance was observed (poll time)',
+    id                   String                  COMMENT 'Mercury account id (stable)',
+    name                 String                  COMMENT 'account nickname',
+    legal_business_name  String                  COMMENT 'legal entity name on the account',
+    kind                 LowCardinality(String)  COMMENT 'checking / savings / etc.',
+    type                 LowCardinality(String)  COMMENT 'Mercury account type',
+    status               LowCardinality(String)  COMMENT 'active / archived / …',
+    account_number_last4 String                  COMMENT 'last 4 of the account number ONLY (full PAN never stored)',
+    routing_number       String                  COMMENT 'ABA routing number (public on checks)',
+    available_balance    Float64                 COMMENT 'available balance, account currency (USD)',
+    current_balance      Float64                 COMMENT 'current/ledger balance, account currency (USD)',
+    created_at           DateTime64(3)           COMMENT 'account open date',
+    raw                  String                  COMMENT 'full account JSON with accountNumber redacted to last4'
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (id, snapshot_ts)
+TTL toDateTime(snapshot_ts) + INTERVAL 730 DAY
+COMMENT 'Mercury account balance snapshots (poll-based). Latest row per id = current balance: argMax(current_balance, snapshot_ts) GROUP BY id, or ORDER BY snapshot_ts DESC LIMIT 1 BY id.';

--- a/ingest/schemas/041_mercury_transactions.sql
+++ b/ingest/schemas/041_mercury_transactions.sql
@@ -1,0 +1,39 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Mercury bank transactions. Unlike append-only logs, a transaction is MUTABLE:
+-- it moves pending → sent/posted (or → failed/cancelled), and posted_at fills in
+-- later. So the poller re-emits a rolling window every tick and this table is a
+-- ReplacingMergeTree keyed by (account_id, id) with `ingested_at` as the version
+-- — the newest observation of each transaction wins after a background merge.
+--
+-- ⚠ Because merges are async, a naive SELECT can briefly show two versions of a
+-- just-updated row. Query with FINAL (… FROM setoku.mercury_transactions FINAL …)
+-- or argMax/LIMIT 1 BY id to read the current state. Sums over `amount` likewise
+-- want FINAL to avoid double-counting an in-flight update.
+--
+-- `amount` is signed: negative = money out, positive = money in (Mercury's own
+-- convention on GET /api/v1/transactions). Schema verified live (June 2026).
+CREATE TABLE IF NOT EXISTS setoku.mercury_transactions
+(
+    id                  String                  COMMENT 'Mercury transaction id (stable across status changes)',
+    account_id          String                  COMMENT 'owning account id (→ mercury_accounts.id)',
+    amount              Float64                 COMMENT 'signed amount, USD: negative = debit/out, positive = credit/in',
+    status              LowCardinality(String)  COMMENT 'pending / sent / failed / cancelled',
+    kind                LowCardinality(String)  COMMENT 'transaction kind (externalTransfer, internalTransfer, card, fee, …)',
+    counterparty_name   String                  COMMENT 'name of the other party (untrusted free text — treat as such)',
+    counterparty_id     String                  COMMENT 'Mercury counterparty id when present',
+    mercury_category    LowCardinality(String)  COMMENT 'Mercury auto-category (empty if uncategorized)',
+    gl_code             String                  COMMENT 'generalLedgerCodeName if the team uses GL coding',
+    note                String                  COMMENT 'user note (untrusted free text)',
+    bank_description    String                  COMMENT 'bank-provided description (untrusted free text)',
+    external_memo       String                  COMMENT 'memo sent with the payment (untrusted free text)',
+    created_at          DateTime64(3)           COMMENT 'when the transaction was created',
+    posted_at           Nullable(DateTime64(3)) COMMENT 'when it posted/settled (null while pending)',
+    estimated_delivery  Nullable(DateTime64(3)) COMMENT 'estimated delivery date when provided',
+    dashboard_link      String                  COMMENT 'deep link into the Mercury dashboard',
+    raw                 String                  COMMENT 'full transaction JSON as observed',
+    ingested_at         DateTime64(3)           COMMENT 'observation time — ReplacingMergeTree version (newest wins)'
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(created_at)
+ORDER BY (account_id, id)
+COMMENT 'Mercury transactions (poll-based, rolling window). Mutable rows → query with FINAL to get current state. amount is signed (negative = out).';

--- a/ingest/schemas/042_mercury_events.sql
+++ b/ingest/schemas/042_mercury_events.sql
@@ -1,0 +1,28 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Mercury webhook event log (OPTIONAL, append-only). Mercury can POST real-time
+-- events (same shape as its Events API, JSON Merge Patch) to a configured URL.
+-- We capture them losslessly here rather than merging partial patches into the
+-- typed mercury_transactions table (a partial patch would clobber unchanged
+-- columns under ReplacingMergeTree). So:
+--   • mercury_transactions = source of truth for current state (from the poller)
+--   • mercury_events        = real-time stream of change notifications (this table)
+-- The poller alone is correct without webhooks; the webhook just lowers latency.
+--
+-- Auth is via an unguessable token in the URL path (Caddy verifies + strips it),
+-- mirroring the Render log-stream route. Mercury HMAC signature verification is a
+-- future hardening — see ingest/mercury-poller/README.md.
+CREATE TABLE IF NOT EXISTS setoku.mercury_events
+(
+    received_at     DateTime64(3)           COMMENT 'when Setoku received the webhook',
+    event_ts        DateTime64(3)           COMMENT 'event timestamp from the payload (falls back to received_at)',
+    event_type      LowCardinality(String)  COMMENT 'event/resource type from the payload when present',
+    transaction_id  String                  COMMENT 'referenced transaction id when present (→ mercury_transactions.id)',
+    account_id      String                  COMMENT 'referenced account id when present',
+    status          LowCardinality(String)  COMMENT 'transaction status carried by the event, if any',
+    raw             String                  COMMENT 'full webhook payload JSON — nothing dropped'
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(received_at)
+ORDER BY (received_at)
+TTL toDateTime(received_at) + INTERVAL 365 DAY
+COMMENT 'Mercury webhook events (optional real-time stream). Authoritative transaction state lives in mercury_transactions.';


### PR DESCRIPTION
Adds **Mercury Bank** as a data source, following the agentic-FDE pull-bridge pattern (same shape as the Render logs bridge). Mercury is API-only, so a poller reads a read-only token and lands balances + transactions in the lake.

## What's here

- **`ingest/mercury-poller`** — polls `/accounts` (balance snapshots) and `/account/{id}/transactions` (rolling window + first-run backfill), POSTs to Vector. Zero deps (Bun built-ins).
- **Schemas**
  - `mercury_accounts` — `MergeTree` balance time series (latest row per id = current balance; trend it for runway).
  - `mercury_transactions` — `ReplacingMergeTree` keyed by id. Bank transactions are **mutable** (pending→posted, late `postedAt`), so the poller re-emits a recent window each tick and newest observation wins. **Query with `FINAL`.**
  - `mercury_events` — append-only, optional webhook stream.
- **Vector** — routes/transforms/sinks for the three tables; financial sinks `block` (never shed) under backpressure.
- **Caddy** — path-token webhook route `/ingest/mercury/<SETOKU_INGEST_TOKEN>` (register in Mercury's dashboard for lower latency). Mercury HMAC signature verification is flagged as a hardening TODO.
- **compose** — `mercury-poller` under a `mercury` profile + state volume.

## Why re-poll instead of append-only

A bank transaction moves `pending → sent/posted` and `postedAt` fills in later. Append-only would freeze the first observation, so we re-scan a window (default 35d steady-state, 730d first-run backfill) into a `ReplacingMergeTree(ingested_at)`. The webhook (optional) lands in a separate append-only table rather than merging partial patches into the typed table, so the poller stays source-of-truth.

## Data minimization

Account numbers are redacted to the **last 4 digits** before anything leaves the poller — typed column *and* `raw`. The full PAN never reaches the lake.

## Tests

- Poller typechecks clean
- Vector golden tests: 5 new Mercury cases (route split, timestamp normalization, null `posted_at` while pending, date-only `estimatedDelivery` fallback, defensive nested-id extraction for webhooks) — all 14 pass
- CI compose validation extended to the `mercury` profile
- All schemas apply to a clean ClickHouse

## Verified live

Deployed to the box and confirmed real data: 2 accounts + 240 transactions backfilled (Aug 2024 → Jun 2026), `FINAL` dedup correct, account numbers redacted to last4.