### PR TITLE
README: drop the 'fully local, no box' plugin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,6 @@ It installs Docker, generates secrets, gets a real HTTPS certificate (uses `<you
 
 Then point Claude at the box and run `/setoku:onboard` in a business repo — it wires up your database (the credential stays in your env; only the env-var *name* goes in config), checks the connection, and generates the first knowledge from your code.
 
-> Prefer not to run a server? Install the Claude Code plugin and run `/setoku:onboard` against an existing Postgres — fully local, no box needed.
-> ```bash
-> claude plugin marketplace add Hedgy-Labs/setoku && claude plugin install setoku@setoku
-> ```
-
 ## High level architecture
 
 Everything is one `docker compose` on one VPS. Only the web proxy faces the internet; the databases are never exposed.


### PR DESCRIPTION
Removes the local plugin-only deployment blurb so there's **one** way to run Setoku — the box. Simpler story, no 'or run it locally' fork.

Scope: README only. The stdio gateway (`plugin/gateway/server.ts` + `.mcp.json`) still exists internally because it's currently how `/setoku:generate` and `/setoku:curate` get their curated-write tools (curator mode) and how the e2e/lake test suites run. **Fully excising the local mode** is a separate, bigger change: move the curator write-path onto the box (per `docs/curator-write-path.md`), migrate those two test suites to the HTTP harness, then delete `server.ts`/`.mcp.json`. Happy to do that next if you want the deeper cleanup.