### PR TITLE
Deterministic, zero-cost structural quality metrics for the fact database (#10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "bun test test/ ingest/",
     "test:e2e": "bun test e2e/",
+    "eval:knowledge": "bun plugin/gateway/quality-cli.ts",
     "setup:hooks": "git config core.hooksPath scripts/hooks",
     "typecheck": "tsc --noEmit",
     "build:admin-css": "tailwindcss -i plugin/gateway/web/input.css -o plugin/gateway/web/app.css --minify",

--- a/plugin/gateway/lib/quality.ts
+++ b/plugin/gateway/lib/quality.ts
@@ -136,7 +136,12 @@ export function retrievalMetrics<T extends ScorableDoc>(
     const relevant = new Set(c.relevant);
     const matched = topk.filter((n) => relevant.has(n));
 
-    const precision = topk.length ? matched.length / k : 0;
+    // precision among what was actually returned (scoreDocs returns only
+    // docs with score > 0, so topk can be < k). Dividing by k instead would
+    // cap precision below 100% on small curated stores — the common case
+    // here — and misread as a retrieval problem. recall@k / MRR are the
+    // headline metrics; precision is "of what I surfaced, how much was right".
+    const precision = topk.length ? matched.length / topk.length : 0;
     const recall = relevant.size ? matched.length / relevant.size : 0;
 
     let firstRelevantRank: number | null = null;
@@ -286,6 +291,9 @@ export function defectMetrics(
 export function knowledgeStats<T extends ScorableDoc>(
   docs: T[],
   redundancyThreshold = 0.6,
+  /** Precomputed pair count, to avoid recomputing the O(n²) report when the
+   *  caller already has it (e.g. the CLI runs redundancyReport separately). */
+  precomputedRedundantPairs?: number,
 ): KnowledgeStats {
   const byType: Record<string, number> = {};
   let totalTokens = 0;
@@ -298,6 +306,8 @@ export function knowledgeStats<T extends ScorableDoc>(
     byType,
     totalTokens,
     avgTokensPerDoc: docs.length ? totalTokens / docs.length : 0,
-    redundantPairs: redundancyReport(docs, redundancyThreshold).length,
+    redundantPairs:
+      precomputedRedundantPairs ??
+      redundancyReport(docs, redundancyThreshold).length,
   };
 }

--- a/plugin/gateway/lib/quality.ts
+++ b/plugin/gateway/lib/quality.ts
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Structured quality metrics for the fact database (issue #10).
+ *
+ * The curated knowledge store is a pipeline:
+ *
+ *   proposals/corrections → curated facts → retrieval (find_context) → answer
+ *
+ * The existing `/setoku:eval` skill scores the LAST box (end-to-end answer
+ * accuracy via golden questions). This module scores the INTERMEDIATE layers so
+ * a restructuring of the store can be credited (or caught regressing) before it
+ * reaches an answer. Every metric here is DETERMINISTIC — pure token/set math
+ * over data you already have, reusing the real retrieval scorer (search.ts).
+ * No model, no network, no embeddings → it runs for free in CI and needs no
+ * API key (I8: no server-side inference).
+ *
+ * Two metrics need a model IN THE LOOP for the real world (is fact X
+ * contradicting fact Y? did the auto-judge decide correctly?). This module does
+ * not call one — it SCORES a detector's output against planted/labeled ground
+ * truth, so the scoring stays deterministic even when the detector is an LLM.
+ *
+ * The metrics are deliberately representation-agnostic: retrieval cases key on
+ * natural-language questions and doc NAMES, never internal ids — so the golden
+ * sets survive the very migration they measure (free-text docs → a more formal
+ * fact structure).
+ */
+import { scoreDocs, tokenize, type ScorableDoc } from "./search";
+
+/* --------------------------------- types --------------------------------- */
+
+/** One labeled retrieval expectation: a question and the doc names that should answer it. */
+export interface RetrievalCase {
+  question: string;
+  /** Doc names that are relevant. A name absent from the store counts as a coverage gap. */
+  relevant: string[];
+}
+
+export interface RetrievalMetrics {
+  k: number;
+  cases: number;
+  /** Macro-averaged over cases. */
+  precisionAtK: number;
+  recallAtK: number;
+  /** Mean reciprocal rank of the first relevant doc. */
+  mrr: number;
+  /** Fraction of cases with at least one relevant doc in the top-k. */
+  hitRate: number;
+  /** Per-case detail, in input order. */
+  perCase: {
+    question: string;
+    relevant: string[];
+    retrieved: string[];
+    hit: boolean;
+    firstRelevantRank: number | null;
+  }[];
+}
+
+/** A pair of docs that look like near-duplicates (candidates for "merge repetitive facts"). */
+export interface RedundantPair {
+  a: string;
+  b: string;
+  /** Jaccard token overlap in [0,1]. */
+  similarity: number;
+}
+
+/** One auto-judgement decision compared against the human-gold label. */
+export interface JudgementRow {
+  /** Stable id for the proposal (for reporting). */
+  id?: string;
+  gold: "accept" | "reject";
+  predicted: "accept" | "reject";
+}
+
+export interface JudgementMetrics {
+  total: number;
+  /** accept = positive class. */
+  truePositives: number;
+  falsePositives: number;
+  trueNegatives: number;
+  falseNegatives: number;
+  accuracy: number;
+  /** Precision of "accept" decisions. */
+  precision: number;
+  recall: number;
+  /**
+   * Fraction of proposals that SHOULD be rejected but were accepted — FP/(FP+TN).
+   * The load-bearing number for auto-judgement (I2/I9): a high false-accept rate
+   * means an agent is waving bad knowledge past the human-click membrane.
+   */
+  falseAcceptRate: number;
+}
+
+/** Precision/recall of a defect detector (e.g. the compaction / "REM sleep" pass). */
+export interface DefectMetrics {
+  found: number;
+  planted: number;
+  truePositives: number;
+  precision: number;
+  recall: number;
+  f1: number;
+  /** Planted defects the detector missed (by key). */
+  missed: string[];
+  /** Things the detector flagged that were not planted (by key). */
+  spurious: string[];
+}
+
+export interface KnowledgeStats {
+  docs: number;
+  byType: Record<string, number>;
+  totalTokens: number;
+  avgTokensPerDoc: number;
+  /** Near-duplicate pairs at the default threshold — a redundancy proxy. */
+  redundantPairs: number;
+}
+
+/* ------------------------------- retrieval ------------------------------- */
+
+/**
+ * Score retrieval quality against labeled cases, using the SAME scorer that
+ * powers find_context (so the metric tracks production behavior exactly).
+ */
+export function retrievalMetrics<T extends ScorableDoc>(
+  docs: T[],
+  cases: RetrievalCase[],
+  k = 5,
+): RetrievalMetrics {
+  const perCase: RetrievalMetrics["perCase"] = [];
+  let precisionSum = 0;
+  let recallSum = 0;
+  let rrSum = 0;
+  let hits = 0;
+
+  for (const c of cases) {
+    const ranked = scoreDocs(docs, c.question).map((s) => s.doc.name);
+    const topk = ranked.slice(0, k);
+    const relevant = new Set(c.relevant);
+    const matched = topk.filter((n) => relevant.has(n));
+
+    const precision = topk.length ? matched.length / k : 0;
+    const recall = relevant.size ? matched.length / relevant.size : 0;
+
+    let firstRelevantRank: number | null = null;
+    for (let i = 0; i < ranked.length; i++) {
+      if (relevant.has(ranked[i])) {
+        firstRelevantRank = i + 1;
+        break;
+      }
+    }
+    const rr =
+      firstRelevantRank && firstRelevantRank <= k ? 1 / firstRelevantRank : 0;
+    const hit = matched.length > 0;
+
+    precisionSum += precision;
+    recallSum += recall;
+    rrSum += rr;
+    if (hit) hits += 1;
+
+    perCase.push({
+      question: c.question,
+      relevant: c.relevant,
+      retrieved: topk,
+      hit,
+      firstRelevantRank,
+    });
+  }
+
+  const n = Math.max(1, cases.length);
+  return {
+    k,
+    cases: cases.length,
+    precisionAtK: precisionSum / n,
+    recallAtK: recallSum / n,
+    mrr: rrSum / n,
+    hitRate: hits / n,
+    perCase,
+  };
+}
+
+/* ------------------------------- redundancy ------------------------------ */
+
+/** Combined searchable text of a doc (name + keywords + summary + body). */
+function docText(doc: ScorableDoc): string {
+  const kw = Array.isArray(doc.meta.keywords)
+    ? doc.meta.keywords.join(" ")
+    : String(doc.meta.keywords ?? "");
+  const summary = String(doc.meta.summary ?? "");
+  return `${doc.name} ${kw} ${summary} ${doc.body}`;
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (!a.size && !b.size) return 0;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter += 1;
+  return inter / (a.size + b.size - inter);
+}
+
+/**
+ * Find near-duplicate doc pairs by Jaccard token overlap — the deterministic
+ * signal behind "merge repetitive facts". Both the detector AND its scoring are
+ * model-free here, so duplicate detection can run and be graded at zero cost.
+ */
+export function redundancyReport<T extends ScorableDoc>(
+  docs: T[],
+  threshold = 0.6,
+): RedundantPair[] {
+  const tokens = docs.map((d) => new Set(tokenize(docText(d))));
+  const pairs: RedundantPair[] = [];
+  for (let i = 0; i < docs.length; i++) {
+    for (let j = i + 1; j < docs.length; j++) {
+      const sim = jaccard(tokens[i], tokens[j]);
+      if (sim >= threshold) {
+        pairs.push({ a: docs[i].name, b: docs[j].name, similarity: sim });
+      }
+    }
+  }
+  return pairs.sort((x, y) => y.similarity - x.similarity);
+}
+
+/* ------------------------------ auto-judgement --------------------------- */
+
+/**
+ * Score auto-judgement against human-gold accept/reject labels. The headline
+ * number is `falseAcceptRate` — see JudgementMetrics (I2/I9).
+ */
+export function judgementMetrics(rows: JudgementRow[]): JudgementMetrics {
+  let tp = 0;
+  let fp = 0;
+  let tn = 0;
+  let fn = 0;
+  for (const r of rows) {
+    const p = r.predicted === "accept";
+    const g = r.gold === "accept";
+    if (p && g) tp += 1;
+    else if (p && !g) fp += 1;
+    else if (!p && !g) tn += 1;
+    else fn += 1;
+  }
+  const total = rows.length;
+  const safeDiv = (num: number, den: number) => (den ? num / den : 0);
+  return {
+    total,
+    truePositives: tp,
+    falsePositives: fp,
+    trueNegatives: tn,
+    falseNegatives: fn,
+    accuracy: safeDiv(tp + tn, total),
+    precision: safeDiv(tp, tp + fp),
+    recall: safeDiv(tp, tp + fn),
+    falseAcceptRate: safeDiv(fp, fp + tn),
+  };
+}
+
+/* ------------------------------ defect detection ------------------------- */
+
+/**
+ * Grade a defect detector (the compaction / "REM sleep" pass) against PLANTED
+ * ground truth. Keys are opaque strings the caller defines (e.g. a normalized
+ * "dup:NameA|NameB" or "contradiction:X|Y"); both sets are compared as sets, so
+ * order within a key is the caller's responsibility to normalize.
+ */
+export function defectMetrics(
+  found: Iterable<string>,
+  planted: Iterable<string>,
+): DefectMetrics {
+  const foundSet = new Set(found);
+  const plantedSet = new Set(planted);
+  let tp = 0;
+  for (const f of foundSet) if (plantedSet.has(f)) tp += 1;
+  const precision = foundSet.size ? tp / foundSet.size : 0;
+  const recall = plantedSet.size ? tp / plantedSet.size : 0;
+  const f1 = precision + recall ? (2 * precision * recall) / (precision + recall) : 0;
+  return {
+    found: foundSet.size,
+    planted: plantedSet.size,
+    truePositives: tp,
+    precision,
+    recall,
+    f1,
+    missed: [...plantedSet].filter((p) => !foundSet.has(p)),
+    spurious: [...foundSet].filter((f) => !plantedSet.has(f)),
+  };
+}
+
+/* --------------------------------- stats --------------------------------- */
+
+export function knowledgeStats<T extends ScorableDoc>(
+  docs: T[],
+  redundancyThreshold = 0.6,
+): KnowledgeStats {
+  const byType: Record<string, number> = {};
+  let totalTokens = 0;
+  for (const d of docs) {
+    byType[d.type] = (byType[d.type] ?? 0) + 1;
+    totalTokens += tokenize(docText(d)).length;
+  }
+  return {
+    docs: docs.length,
+    byType,
+    totalTokens,
+    avgTokensPerDoc: docs.length ? totalTokens / docs.length : 0,
+    redundantPairs: redundancyReport(docs, redundancyThreshold).length,
+  };
+}

--- a/plugin/gateway/quality-cli.ts
+++ b/plugin/gateway/quality-cli.ts
@@ -76,23 +76,47 @@ export function runQuality(spec: QualitySpec, docs: ScorableDoc[]) {
   const k = spec.k ?? 5;
   const threshold = spec.redundancyThreshold ?? 0.6;
 
-  const stats = knowledgeStats(docs, threshold);
+  const redundant = redundancyReport(docs, threshold);
+  const stats = knowledgeStats(docs, threshold, redundant.length);
   const retrieval = spec.retrieval?.length
     ? retrievalMetrics(docs, spec.retrieval, k)
     : null;
-  const redundant = redundancyReport(docs, threshold);
   const judgement = spec.judgement?.length
     ? judgementMetrics(spec.judgement)
     : null;
 
   let defects = null;
+  // When `found` is omitted we can only auto-derive the DUPLICATE detector
+  // (redundancyReport is model-free). Scoring non-`dup:` planted defects
+  // (contradictions, stale) against that derived set would count them all as
+  // missed — misleading. So without explicit `found`, score only the dup-kind
+  // planted defects and report the rest as unscored (no detector supplied).
+  let defectsUnscored: string[] = [];
   if (spec.defects?.planted?.length) {
-    const found =
-      spec.defects.found ?? redundant.map((p) => dupKey(p.a, p.b));
-    defects = defectMetrics(found, spec.defects.planted);
+    if (spec.defects.found) {
+      defects = defectMetrics(spec.defects.found, spec.defects.planted);
+    } else {
+      const derived = redundant.map((p) => dupKey(p.a, p.b));
+      const plantedDup = spec.defects.planted.filter((key) =>
+        key.startsWith("dup:"),
+      );
+      defectsUnscored = spec.defects.planted.filter(
+        (key) => !key.startsWith("dup:"),
+      );
+      defects = defectMetrics(derived, plantedDup);
+    }
   }
 
-  return { stats, retrieval, redundant, judgement, defects, k, threshold };
+  return {
+    stats,
+    retrieval,
+    redundant,
+    judgement,
+    defects,
+    defectsUnscored,
+    k,
+    threshold,
+  };
 }
 
 type QualityResult = ReturnType<typeof runQuality>;
@@ -157,25 +181,47 @@ function renderScorecard(r: QualityResult): string {
     lines.push(`| F1 | ${d.f1.toFixed(3)} |`);
     if (d.missed.length) lines.push(`\nmissed: ${d.missed.join(", ")}`);
     if (d.spurious.length) lines.push(`spurious: ${d.spurious.join(", ")}`);
+    if (r.defectsUnscored.length)
+      lines.push(
+        `unscored (no detector output supplied — pass defects.found): ${r.defectsUnscored.join(", ")}`,
+      );
     lines.push("");
   }
 
   return lines.join("\n");
 }
 
-/** Returns [] when no gate configured or all pass; otherwise the list of failures. */
+/**
+ * Returns [] when no gate configured or all pass; otherwise the list of
+ * failures. A threshold that references a dimension absent from the run is
+ * itself a failure (e.g. minHitRate set but no retrieval cases ran) — silently
+ * skipping it would let a misconfigured spec report a passing gate in CI.
+ */
 export function checkGate(spec: QualitySpec, r: QualityResult): string[] {
   const g = spec.gate;
   if (!g) return [];
   const fails: string[] = [];
-  if (g.minHitRate != null && r.retrieval && r.retrieval.hitRate < g.minHitRate)
-    fails.push(`hit rate ${pct(r.retrieval.hitRate)} < ${pct(g.minHitRate)}`);
-  if (g.minRecallAtK != null && r.retrieval && r.retrieval.recallAtK < g.minRecallAtK)
-    fails.push(`recall@k ${pct(r.retrieval.recallAtK)} < ${pct(g.minRecallAtK)}`);
-  if (g.maxFalseAcceptRate != null && r.judgement && r.judgement.falseAcceptRate > g.maxFalseAcceptRate)
-    fails.push(`false-accept rate ${pct(r.judgement.falseAcceptRate)} > ${pct(g.maxFalseAcceptRate)}`);
-  if (g.minDefectRecall != null && r.defects && r.defects.recall < g.minDefectRecall)
-    fails.push(`defect recall ${pct(r.defects.recall)} < ${pct(g.minDefectRecall)}`);
+  if (g.minHitRate != null) {
+    if (!r.retrieval) fails.push("minHitRate set but no retrieval cases ran");
+    else if (r.retrieval.hitRate < g.minHitRate)
+      fails.push(`hit rate ${pct(r.retrieval.hitRate)} < ${pct(g.minHitRate)}`);
+  }
+  if (g.minRecallAtK != null) {
+    if (!r.retrieval) fails.push("minRecallAtK set but no retrieval cases ran");
+    else if (r.retrieval.recallAtK < g.minRecallAtK)
+      fails.push(`recall@k ${pct(r.retrieval.recallAtK)} < ${pct(g.minRecallAtK)}`);
+  }
+  if (g.maxFalseAcceptRate != null) {
+    if (!r.judgement)
+      fails.push("maxFalseAcceptRate set but no judgement decisions ran");
+    else if (r.judgement.falseAcceptRate > g.maxFalseAcceptRate)
+      fails.push(`false-accept rate ${pct(r.judgement.falseAcceptRate)} > ${pct(g.maxFalseAcceptRate)}`);
+  }
+  if (g.minDefectRecall != null) {
+    if (!r.defects) fails.push("minDefectRecall set but no defects scored");
+    else if (r.defects.recall < g.minDefectRecall)
+      fails.push(`defect recall ${pct(r.defects.recall)} < ${pct(g.minDefectRecall)}`);
+  }
   return fails;
 }
 
@@ -188,7 +234,20 @@ function main() {
     process.exit(2);
   }
 
-  const spec: QualitySpec = JSON.parse(fs.readFileSync(args.spec, "utf8"));
+  let spec: QualitySpec;
+  try {
+    spec = JSON.parse(fs.readFileSync(args.spec, "utf8"));
+  } catch (e) {
+    console.error(`could not read/parse spec ${args.spec}: ${(e as Error).message}`);
+    process.exit(2);
+  }
+
+  // Constructing a KnowledgeStore creates the db file + dirs, so a typo'd --db
+  // would silently leave an empty store behind. Require the path to exist.
+  if (args.db && !fs.existsSync(args.db)) {
+    console.error(`--db not found: ${args.db}`);
+    process.exit(2);
+  }
   const docs: ScorableDoc[] = args.db
     ? new KnowledgeStore(args.db).listDocs()
     : (spec.docs ?? []);

--- a/plugin/gateway/quality-cli.ts
+++ b/plugin/gateway/quality-cli.ts
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Fact-database quality scorecard runner (issue #10).
+ *
+ * Deterministic, model-free, zero-API-cost: it scores the structural quality of
+ * a knowledge store against a frozen eval spec and prints a scorecard. Runs in
+ * CI for free (no key, I8) and can gate the regression direction with --gate.
+ *
+ *   bun plugin/gateway/quality-cli.ts --spec <spec.json> [--db <knowledge.db>] [--json] [--gate]
+ *
+ * Docs come from --db (a real KnowledgeStore) if given, else from inline `docs`
+ * in the spec (self-contained runs / fixtures). The fuzzy dimensions
+ * (contradiction detection, auto-judgement) are scored from labels/planted
+ * ground truth supplied in the spec — the detector that PRODUCED those labels
+ * may be an in-session LLM (run on Max), but the scoring here stays free.
+ */
+import fs from "node:fs";
+import { KnowledgeStore } from "./lib/store";
+import {
+  defectMetrics,
+  judgementMetrics,
+  knowledgeStats,
+  redundancyReport,
+  retrievalMetrics,
+  type JudgementRow,
+  type RetrievalCase,
+} from "./lib/quality";
+import type { ScorableDoc } from "./lib/search";
+
+interface QualitySpec {
+  /** Inline docs for self-contained runs; ignored when --db is supplied. */
+  docs?: ScorableDoc[];
+  k?: number;
+  redundancyThreshold?: number;
+  retrieval?: RetrievalCase[];
+  judgement?: JudgementRow[];
+  /**
+   * Planted-defect ground truth for the compaction pass. `found` is the
+   * detector output; if omitted, duplicate keys ("dup:A|B") are auto-derived
+   * from the deterministic redundancy report (the detector IS model-free there).
+   */
+  defects?: { planted: string[]; found?: string[] };
+  /** Optional CI gate thresholds (checked only with --gate). */
+  gate?: {
+    minHitRate?: number;
+    minRecallAtK?: number;
+    maxFalseAcceptRate?: number;
+    minDefectRecall?: number;
+  };
+}
+
+function pct(x: number): string {
+  return `${(x * 100).toFixed(1)}%`;
+}
+
+function dupKey(a: string, b: string): string {
+  return `dup:${[a, b].sort().join("|")}`;
+}
+
+function parseArgs(argv: string[]) {
+  const out: { spec?: string; db?: string; json: boolean; gate: boolean } = {
+    json: false,
+    gate: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--spec") out.spec = argv[++i];
+    else if (a === "--db") out.db = argv[++i];
+    else if (a === "--json") out.json = true;
+    else if (a === "--gate") out.gate = true;
+  }
+  return out;
+}
+
+export function runQuality(spec: QualitySpec, docs: ScorableDoc[]) {
+  const k = spec.k ?? 5;
+  const threshold = spec.redundancyThreshold ?? 0.6;
+
+  const stats = knowledgeStats(docs, threshold);
+  const retrieval = spec.retrieval?.length
+    ? retrievalMetrics(docs, spec.retrieval, k)
+    : null;
+  const redundant = redundancyReport(docs, threshold);
+  const judgement = spec.judgement?.length
+    ? judgementMetrics(spec.judgement)
+    : null;
+
+  let defects = null;
+  if (spec.defects?.planted?.length) {
+    const found =
+      spec.defects.found ?? redundant.map((p) => dupKey(p.a, p.b));
+    defects = defectMetrics(found, spec.defects.planted);
+  }
+
+  return { stats, retrieval, redundant, judgement, defects, k, threshold };
+}
+
+type QualityResult = ReturnType<typeof runQuality>;
+
+function renderScorecard(r: QualityResult): string {
+  const lines: string[] = [];
+  lines.push("# Fact-database quality scorecard\n");
+
+  lines.push("## Store");
+  lines.push(`- docs: **${r.stats.docs}** (${
+    Object.entries(r.stats.byType)
+      .map(([t, n]) => `${t}:${n}`)
+      .join(", ") || "—"
+  })`);
+  lines.push(`- tokens: **${r.stats.totalTokens}** (avg ${r.stats.avgTokensPerDoc.toFixed(1)}/doc)`);
+  lines.push(`- near-duplicate pairs (≥${r.threshold}): **${r.stats.redundantPairs}**\n`);
+
+  if (r.retrieval) {
+    const m = r.retrieval;
+    lines.push(`## Retrieval (k=${m.k}, ${m.cases} cases)`);
+    lines.push(`| metric | value |`);
+    lines.push(`| --- | --- |`);
+    lines.push(`| hit rate | ${pct(m.hitRate)} |`);
+    lines.push(`| recall@${m.k} | ${pct(m.recallAtK)} |`);
+    lines.push(`| precision@${m.k} | ${pct(m.precisionAtK)} |`);
+    lines.push(`| MRR | ${m.mrr.toFixed(3)} |`);
+    const misses = m.perCase.filter((c) => !c.hit);
+    if (misses.length) {
+      lines.push(`\nRetrieval misses (no relevant doc in top-${m.k}):`);
+      for (const c of misses)
+        lines.push(`- "${c.question}" — expected ${c.relevant.join(", ")}`);
+    }
+    lines.push("");
+  }
+
+  if (r.redundant.length) {
+    lines.push("## Redundancy (merge candidates)");
+    for (const p of r.redundant.slice(0, 10))
+      lines.push(`- ${p.a} ↔ ${p.b} (${pct(p.similarity)})`);
+    lines.push("");
+  }
+
+  if (r.judgement) {
+    const j = r.judgement;
+    lines.push(`## Auto-judgement (${j.total} decisions)`);
+    lines.push(`| metric | value |`);
+    lines.push(`| --- | --- |`);
+    lines.push(`| accuracy | ${pct(j.accuracy)} |`);
+    lines.push(`| accept precision | ${pct(j.precision)} |`);
+    lines.push(`| accept recall | ${pct(j.recall)} |`);
+    lines.push(`| **false-accept rate** (I9) | **${pct(j.falseAcceptRate)}** |`);
+    lines.push(`\nconfusion: TP ${j.truePositives} · FP ${j.falsePositives} · TN ${j.trueNegatives} · FN ${j.falseNegatives}\n`);
+  }
+
+  if (r.defects) {
+    const d = r.defects;
+    lines.push("## Defect detection (compaction / planted ground truth)");
+    lines.push(`| metric | value |`);
+    lines.push(`| --- | --- |`);
+    lines.push(`| recall | ${pct(d.recall)} (${d.truePositives}/${d.planted}) |`);
+    lines.push(`| precision | ${pct(d.precision)} |`);
+    lines.push(`| F1 | ${d.f1.toFixed(3)} |`);
+    if (d.missed.length) lines.push(`\nmissed: ${d.missed.join(", ")}`);
+    if (d.spurious.length) lines.push(`spurious: ${d.spurious.join(", ")}`);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/** Returns [] when no gate configured or all pass; otherwise the list of failures. */
+export function checkGate(spec: QualitySpec, r: QualityResult): string[] {
+  const g = spec.gate;
+  if (!g) return [];
+  const fails: string[] = [];
+  if (g.minHitRate != null && r.retrieval && r.retrieval.hitRate < g.minHitRate)
+    fails.push(`hit rate ${pct(r.retrieval.hitRate)} < ${pct(g.minHitRate)}`);
+  if (g.minRecallAtK != null && r.retrieval && r.retrieval.recallAtK < g.minRecallAtK)
+    fails.push(`recall@k ${pct(r.retrieval.recallAtK)} < ${pct(g.minRecallAtK)}`);
+  if (g.maxFalseAcceptRate != null && r.judgement && r.judgement.falseAcceptRate > g.maxFalseAcceptRate)
+    fails.push(`false-accept rate ${pct(r.judgement.falseAcceptRate)} > ${pct(g.maxFalseAcceptRate)}`);
+  if (g.minDefectRecall != null && r.defects && r.defects.recall < g.minDefectRecall)
+    fails.push(`defect recall ${pct(r.defects.recall)} < ${pct(g.minDefectRecall)}`);
+  return fails;
+}
+
+function main() {
+  const args = parseArgs(Bun.argv.slice(2));
+  if (!args.spec) {
+    console.error(
+      "usage: bun plugin/gateway/quality-cli.ts --spec <spec.json> [--db <knowledge.db>] [--json] [--gate]",
+    );
+    process.exit(2);
+  }
+
+  const spec: QualitySpec = JSON.parse(fs.readFileSync(args.spec, "utf8"));
+  const docs: ScorableDoc[] = args.db
+    ? new KnowledgeStore(args.db).listDocs()
+    : (spec.docs ?? []);
+
+  if (!docs.length) {
+    console.error(
+      "no docs to score: pass --db <knowledge.db> or include `docs` in the spec.",
+    );
+    process.exit(2);
+  }
+
+  const result = runQuality(spec, docs);
+  const fails = args.gate ? checkGate(spec, result) : [];
+
+  if (args.json) {
+    console.log(JSON.stringify({ ...result, gateFailures: fails }, null, 2));
+  } else {
+    console.log(renderScorecard(result));
+    if (args.gate) {
+      console.log(
+        fails.length
+          ? `\n❌ gate FAILED:\n- ${fails.join("\n- ")}`
+          : "\n✅ gate passed",
+      );
+    }
+  }
+  process.exit(args.gate && fails.length ? 1 : 0);
+}
+
+if (import.meta.main) main();

--- a/plugin/skills/eval/SKILL.md
+++ b/plugin/skills/eval/SKILL.md
@@ -40,3 +40,22 @@ If the file doesn't exist, offer to create it: propose 5–10 questions from the
 | --- | -------- | ------ | -------------- | --- |
 
 Summarize: pass rate, the dominant failure layer, and the top 1–2 artifact improvements that would raise the score. Offer to apply them via `/setoku:generate` (refresh mode).
+
+## Structural quality metrics (the fact database itself — issue #10)
+
+The golden-question run above scores the *answer*. To credit (or catch regressions in) changes to the **knowledge store's structure** — concise facts, compaction, auto-judgement — score the intermediate layers directly. These are **deterministic** (pure token/set math reusing the production retrieval scorer), so they need **no model and no API key** and run for free in CI (I8):
+
+```bash
+bun run eval:knowledge --spec <spec.json> [--db <knowledge.db>] [--gate]
+```
+
+The spec (see `test/fixtures/eval/knowledge.json` for the shape) carries frozen, representation-agnostic ground truth — questions and doc **names**, never internal ids, so the goldens survive a migration of the fact representation. Dimensions:
+
+- **Retrieval** — `precision/recall@k`, hit rate, MRR against labeled `question → relevant doc names`. Catches retrieval misses and coverage gaps.
+- **Redundancy** — near-duplicate doc pairs (Jaccard); the deterministic signal behind "merge repetitive facts".
+- **Auto-judgement** — confusion matrix vs human-gold accept/reject labels. The headline is **false-accept rate** (FP/(FP+TN)): the I2/I9 number, since false-accepts are an agent waving bad knowledge past the human-click membrane.
+- **Defect detection** — precision/recall of the compaction ("REM sleep") pass against **planted** contradictions/duplicates (ground truth you seeded).
+
+`--gate` enforces threshold floors (`minHitRate`, `maxFalseAcceptRate`, …) and exits non-zero — wire it into CI alongside the fast suite.
+
+**Cost split.** The structural metrics are free (deterministic, automatable in CI). The *fuzzy detectors that produce the labels* — does fact X contradict fact Y? did the auto-judge decide right? — run in **this session on the Max subscription** (no server-side inference, I8). Reserve those for interactive runs after a structural change; gate the deterministic metrics continuously.

--- a/test/fixtures/eval/knowledge.json
+++ b/test/fixtures/eval/knowledge.json
@@ -1,0 +1,72 @@
+{
+  "_note": "Synthetic fact-database quality eval spec (issue #10). No real tenant data (I3). Self-contained: inline docs let `quality-cli.ts` run without a --db. `recognized_revenue` is a deliberate planted near-duplicate of `revenue` to exercise redundancy + defect detection.",
+  "k": 5,
+  "redundancyThreshold": 0.6,
+  "docs": [
+    {
+      "type": "metric",
+      "name": "revenue",
+      "meta": {
+        "summary": "Recognized revenue — paid orders only; refunded orders excluded entirely.",
+        "keywords": ["sales", "income", "money", "earned", "revenue"]
+      },
+      "body": "Sum of orders.total_cents where status = 'paid', divided by 100 for dollars. Refunded orders are excluded entirely, not netted."
+    },
+    {
+      "type": "metric",
+      "name": "recognized_revenue",
+      "meta": {
+        "summary": "Recognized revenue — paid orders only; refunded orders excluded entirely.",
+        "keywords": ["sales", "income", "money", "earned", "revenue"]
+      },
+      "body": "Sum of orders.total_cents where status = 'paid', divided by 100 for dollars. Refunded orders are excluded entirely, not netted."
+    },
+    {
+      "type": "entity",
+      "name": "Customer",
+      "meta": {
+        "table": "public.customers",
+        "summary": "A shopper account; soft-deleted via deleted_at.",
+        "keywords": ["customers", "active", "shopper", "account", "buyer"]
+      },
+      "body": "One row per shopper. deleted_at IS NOT NULL means soft-deleted and must be excluded from active customer counts."
+    },
+    {
+      "type": "entity",
+      "name": "Order",
+      "meta": {
+        "table": "public.orders",
+        "summary": "A purchase; status drives revenue recognition.",
+        "keywords": ["orders", "paid", "refunded", "status", "purchase"]
+      },
+      "body": "One row per purchase. status = 'paid' counts toward revenue; 'refunded' is excluded. total_cents is integer cents."
+    },
+    {
+      "type": "gotcha",
+      "name": "money-is-cents",
+      "meta": { "keywords": ["cents", "money", "dollars"] },
+      "body": "All money columns are integer cents — divide by 100 for dollars."
+    }
+  ],
+  "retrieval": [
+    { "question": "How much revenue did we make?", "relevant": ["revenue", "recognized_revenue"] },
+    { "question": "How many active customers do we have?", "relevant": ["Customer"] },
+    { "question": "What counts as a paid order?", "relevant": ["Order"] }
+  ],
+  "defects": {
+    "planted": ["dup:recognized_revenue|revenue"]
+  },
+  "judgement": [
+    { "id": "j1", "gold": "accept", "predicted": "accept" },
+    { "id": "j2", "gold": "accept", "predicted": "accept" },
+    { "id": "j3", "gold": "reject", "predicted": "reject" },
+    { "id": "j4", "gold": "reject", "predicted": "reject" },
+    { "id": "j5", "gold": "reject", "predicted": "accept" }
+  ],
+  "gate": {
+    "minHitRate": 1.0,
+    "minRecallAtK": 0.9,
+    "maxFalseAcceptRate": 0.4,
+    "minDefectRecall": 1.0
+  }
+}

--- a/test/quality.test.ts
+++ b/test/quality.test.ts
@@ -28,6 +28,10 @@ describe("retrievalMetrics", () => {
     expect(m.hitRate).toBe(1); // every question retrieves a relevant doc
     expect(m.recallAtK).toBeGreaterThan(0.9);
     expect(m.mrr).toBeGreaterThan(0);
+    // precision is "of what was surfaced, how much was relevant" — not capped
+    // by k on a small store. Here ≈0.64; the old k-capped form (÷5) would
+    // report ≈0.27 for identical retrieval, which reads as a false problem.
+    expect(m.precisionAtK).toBeGreaterThan(0.6);
   });
 
   it("counts a coverage gap when the relevant doc is absent from the store", () => {
@@ -120,5 +124,27 @@ describe("runQuality + checkGate (CLI core)", () => {
     const fails = checkGate(strict, r);
     expect(fails.length).toBe(1);
     expect(fails[0]).toContain("false-accept rate");
+  });
+
+  it("fails the gate when a threshold references a dimension absent from the run", () => {
+    // gate demands a hit rate, but the spec has no retrieval cases — must NOT
+    // silently pass (that would be a false green in CI).
+    const noRetrieval = { docs: DOCS, gate: { minHitRate: 0.9 } };
+    const r = runQuality(noRetrieval, DOCS);
+    const fails = checkGate(noRetrieval, r);
+    expect(fails.length).toBe(1);
+    expect(fails[0]).toContain("no retrieval cases");
+  });
+
+  it("does not score non-duplicate planted defects against the auto-derived dup detector", () => {
+    // A planted contradiction with no explicit `found` must be reported as
+    // unscored, not counted as a miss (which would tank recall misleadingly).
+    const spec = {
+      docs: DOCS,
+      defects: { planted: ["contradiction:revenue|recognized_revenue"] },
+    };
+    const r = runQuality(spec, DOCS);
+    expect(r.defectsUnscored).toEqual(["contradiction:revenue|recognized_revenue"]);
+    expect(r.defects!.planted).toBe(0); // nothing dup-kind to score
   });
 });

--- a/test/quality.test.ts
+++ b/test/quality.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  defectMetrics,
+  judgementMetrics,
+  knowledgeStats,
+  redundancyReport,
+  retrievalMetrics,
+  type RetrievalCase,
+} from "../plugin/gateway/lib/quality";
+import { runQuality, checkGate } from "../plugin/gateway/quality-cli";
+import type { ScorableDoc } from "../plugin/gateway/lib/search";
+
+const SPEC = JSON.parse(
+  fs.readFileSync(
+    path.join(import.meta.dir, "fixtures/eval/knowledge.json"),
+    "utf8",
+  ),
+);
+const DOCS: ScorableDoc[] = SPEC.docs;
+
+describe("retrievalMetrics", () => {
+  it("reuses the production scorer and finds the relevant doc for each golden question", () => {
+    const m = retrievalMetrics(DOCS, SPEC.retrieval, SPEC.k);
+    expect(m.cases).toBe(3);
+    expect(m.hitRate).toBe(1); // every question retrieves a relevant doc
+    expect(m.recallAtK).toBeGreaterThan(0.9);
+    expect(m.mrr).toBeGreaterThan(0);
+  });
+
+  it("counts a coverage gap when the relevant doc is absent from the store", () => {
+    const cases: RetrievalCase[] = [
+      { question: "what is our churn rate?", relevant: ["churn"] },
+    ];
+    const m = retrievalMetrics(DOCS, cases, 5);
+    expect(m.hitRate).toBe(0);
+    expect(m.recallAtK).toBe(0);
+    expect(m.perCase[0].firstRelevantRank).toBeNull();
+  });
+
+  it("ranks an exact name match first (MRR = 1)", () => {
+    const m = retrievalMetrics(DOCS, [
+      { question: "active customers", relevant: ["Customer"] },
+    ], 5);
+    expect(m.perCase[0].firstRelevantRank).toBe(1);
+    expect(m.mrr).toBe(1);
+  });
+});
+
+describe("redundancyReport", () => {
+  it("flags the planted near-duplicate pair above threshold", () => {
+    const pairs = redundancyReport(DOCS, 0.6);
+    expect(pairs.length).toBeGreaterThanOrEqual(1);
+    const top = pairs[0];
+    expect([top.a, top.b].sort()).toEqual(["recognized_revenue", "revenue"]);
+    expect(top.similarity).toBeGreaterThanOrEqual(0.6);
+  });
+
+  it("finds nothing among distinct docs", () => {
+    const distinct = DOCS.filter((d) => d.name !== "recognized_revenue");
+    expect(redundancyReport(distinct, 0.6)).toEqual([]);
+  });
+});
+
+describe("judgementMetrics", () => {
+  it("computes the false-accept rate as the load-bearing I9 number", () => {
+    const m = judgementMetrics(SPEC.judgement);
+    // 3 gold-reject rows, 1 of them wrongly accepted → 1/3
+    expect(m.falsePositives).toBe(1);
+    expect(m.trueNegatives).toBe(2);
+    expect(m.falseAcceptRate).toBeCloseTo(1 / 3, 5);
+    expect(m.precision).toBeCloseTo(2 / 3, 5); // 2 TP / (2 TP + 1 FP)
+  });
+
+  it("is all-zeros-safe on empty input", () => {
+    const m = judgementMetrics([]);
+    expect(m.total).toBe(0);
+    expect(m.falseAcceptRate).toBe(0);
+  });
+});
+
+describe("defectMetrics", () => {
+  it("grades a detector against planted ground truth", () => {
+    const m = defectMetrics(["dup:a|b", "dup:c|d"], ["dup:a|b", "dup:e|f"]);
+    expect(m.truePositives).toBe(1);
+    expect(m.precision).toBe(0.5);
+    expect(m.recall).toBe(0.5);
+    expect(m.missed).toEqual(["dup:e|f"]);
+    expect(m.spurious).toEqual(["dup:c|d"]);
+  });
+});
+
+describe("knowledgeStats", () => {
+  it("summarizes the store and counts redundant pairs", () => {
+    const s = knowledgeStats(DOCS, 0.6);
+    expect(s.docs).toBe(DOCS.length);
+    expect(s.byType.metric).toBe(2);
+    expect(s.redundantPairs).toBeGreaterThanOrEqual(1);
+    expect(s.totalTokens).toBeGreaterThan(0);
+  });
+});
+
+describe("runQuality + checkGate (CLI core)", () => {
+  it("auto-derives the duplicate detector from the redundancy report and scores it", () => {
+    const r = runQuality(SPEC, DOCS);
+    expect(r.defects).not.toBeNull();
+    expect(r.defects!.recall).toBe(1); // planted dup is detected deterministically
+  });
+
+  it("passes the fixture's own gate", () => {
+    const r = runQuality(SPEC, DOCS);
+    expect(checkGate(SPEC, r)).toEqual([]);
+  });
+
+  it("reports a gate failure when a threshold is violated", () => {
+    const r = runQuality(SPEC, DOCS);
+    const strict = { ...SPEC, gate: { maxFalseAcceptRate: 0.1 } };
+    const fails = checkGate(strict, r);
+    expect(fails.length).toBe(1);
+    expect(fails[0]).toContain("false-accept rate");
+  });
+});


### PR DESCRIPTION
First concrete step on #10: a way to **measure whether a change to the knowledge-store structure is actually better** — before the bigger migrations (concise facts, compaction, auto-judgement) land.

## Why

The store is a pipeline:

```
proposals/corrections → curated facts → retrieval (find_context) → answer
```

`/setoku:eval` (golden questions) scores only the **last box** — too coarse to credit a restructuring that, say, halves redundancy while leaving answer accuracy flat. This adds metrics on the **intermediate layers**, each mapped to an idea in #10.

## What

**`plugin/gateway/lib/quality.ts`** — pure, deterministic scoring (no model, no network):
- **Retrieval** — precision/recall@k, hit rate, MRR, reusing the *production* `search.ts` scorer so the metric tracks `find_context` exactly.
- **Redundancy** — Jaccard near-duplicate pairs → the "merge repetitive facts" signal.
- **Auto-judgement** — confusion matrix vs human-gold labels, headlined by **false-accept rate** (FP/(FP+TN)) — the I2/I9 number, since a false-accept is an agent waving bad knowledge past the human-click membrane.
- **Defect detection** — precision/recall of the compaction ("REM sleep") pass against **planted** contradictions/duplicates (ground truth you seed).

**`plugin/gateway/quality-cli.ts`** + `bun run eval:knowledge` — scorecard over a real `--db <knowledge.db>` or inline fixture docs; `--gate` exits non-zero on threshold floors (CI-gateable).

Goldens are **frozen and representation-agnostic** (questions + doc *names*, never internal ids) so they survive the very migration of the fact representation they measure.

## Cost (the deliberate design point)

The structural metrics are **deterministic → free in CI, no API key** (I8). The *fuzzy detectors that produce the labels* (does fact X contradict Y? did the auto-judge decide right?) run **in-session on the Max subscription** — this harness only *scores* their output. So: gate the deterministic metrics continuously; reserve the model-in-the-loop judging for interactive runs after a structural change.

## Example

```
$ bun run eval:knowledge --spec test/fixtures/eval/knowledge.json --gate
# Fact-database quality scorecard
## Retrieval (k=5, 3 cases)  | hit rate 100% | recall@5 100% | MRR 1.000
## Redundancy  - revenue ↔ recognized_revenue (100.0%)
## Auto-judgement  | false-accept rate (I9) 33.3% | confusion TP 2·FP 1·TN 2·FN 0
## Defect detection  | recall 100% (1/1) | precision 100%
✅ gate passed
```

## Tests

- `test/quality.test.ts` — 12 tests over a synthetic, I3-safe fixture (`test/fixtures/eval/knowledge.json`).
- Full fast suite green (94 pass, 0 fail); `tsc --noEmit` clean.
- `plugin/skills/eval/SKILL.md` documents the new dimensions and the cost split.

## Scope / not in this PR

This is the **measurement substrate** for #10, not the migrations themselves (the concise-fact representation, the compaction pass, the auto-judge). Those land next, each with its golden set under `test/fixtures/eval/` and gated by this harness. #10 stays open.