### PR TITLE
Drop the numeric-contradiction heuristic (v0.18.1)

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "setoku",
   "displayName": "Setoku",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Governed agentic BI on your Claude subscription. Setoku gives Claude a verified business-context layer (derived from your codebase) plus read-only, audited access to your database \u2014 so it answers business questions accurately instead of guessing from column names.",
   "author": {
     "name": "Hedgy Labs"

--- a/plugin/gateway/lib/facts.ts
+++ b/plugin/gateway/lib/facts.ts
@@ -322,25 +322,6 @@ function opposingGroups(g1: number, g2: number): boolean {
  *  conflict (vs. free-prose definitions, where it never would be). */
 const ATOMIC_PREDICATES = new Set(["unit", "status", "type", "grain", "format"]);
 
-const NUM_RE = /-?\d[\d,]*\.?\d*/g;
-
-/** Numbers in text, excluding 4-digit years (1900–2099). Years are dates, not
- *  quantities to compare — treating one as a quantity produced a false
- *  contradiction on the real store ("2026" read as disagreeing with "7"). We
- *  trade catching year-vs-year conflicts for precision; this is a
- *  recommend-only pass, so a false flag costs more than a miss. */
-function numbers(text: string): string[] {
-  return (text.match(NUM_RE) ?? [])
-    .map((n) => n.replace(/,/g, ""))
-    .filter((n) => !/^(?:19|20)\d{2}$/.test(n));
-}
-
-/** Token set of a claim with numbers stripped — for the "same statement,
- *  different number" check. */
-function nonNumericTokens(text: string): Set<string> {
-  return new Set(tokenize(text.replace(NUM_RE, " ")));
-}
-
 /**
  * Near-duplicate facts (avenue 2 merge candidates). Same-subject pairs flag at
  * `threshold`; different-subject pairs need much stronger evidence
@@ -430,21 +411,12 @@ function conflictReason(a: Fact, b: Fact): string | null {
     }
   }
 
-  // 3 — numeric mismatch: only when the two claims are otherwise nearly the
-  // SAME statement (so we're comparing the same quantity), not merely two
-  // claims that each happen to contain a number.
-  if (a.predicate === b.predicate) {
-    const na = numbers(a.claim);
-    const nb = numbers(b.claim);
-    if (
-      na.length &&
-      nb.length &&
-      Number(na[0]) !== Number(nb[0]) && // numeric compare: "100" == "100.0"
-      jaccard(nonNumericTokens(a.claim), nonNumericTokens(b.claim)) >= 0.5
-    )
-      return `numbers disagree: ${na[0]} vs ${nb[0]}`;
-  }
-
+  // NOTE: no deterministic numeric-mismatch rule. Telling a salient quantity
+  // ("divide by 100" vs "1000") from an incidental reference ("member 100" vs
+  // "member 101", a year, an id) is semantic — it false-fired on real data more
+  // than it helped. Numeric/semantic contradictions are found by the in-session
+  // /setoku:compact pass; the deterministic detector keeps only the
+  // high-precision signals above (atomic-predicate mismatch, antonym clash).
   return null;
 }
 

--- a/test/facts.test.ts
+++ b/test/facts.test.ts
@@ -170,36 +170,15 @@ describe("findContradictions (avenue 2)", () => {
     expect(c[0].reason).toContain("opposing");
   });
 
-  it("catches a numeric mismatch when the claims are otherwise the same statement", () => {
+  it("does NOT deterministically flag numeric differences (left to in-session compaction)", () => {
+    // numbers can't be told apart structurally — a salient quantity vs an
+    // incidental id (member 100 vs 101) vs a year. The heuristic false-fired on
+    // real data, so it's gone; /setoku:compact judges these semantically.
     const facts: Fact[] = [
-      { subject: "metric:revenue", predicate: "unit", object: "", claim: "Divide total_cents by 100 for dollars", origin: "doc", ref: "a" },
-      { subject: "metric:revenue", predicate: "unit", object: "", claim: "Divide total_cents by 1000 for dollars", origin: "correction", ref: "b" },
-    ];
-    expect(findContradictions(facts)[0].reason).toContain("numbers disagree");
-  });
-
-  it("does NOT treat a year as a quantity (real-store false positive)", () => {
-    // two pending corrections on one topic; one mentions a year, one a count.
-    const facts: Fact[] = [
-      { subject: "topic:launch", predicate: "metric", object: "", claim: "The v2 dashboard shipped in 2026 to the pilot cohort", origin: "correction", ref: "a" },
-      { subject: "topic:launch", predicate: "metric", object: "", claim: "It supports 7 chart types", origin: "correction", ref: "b" },
-    ];
-    expect(findContradictions(facts)).toHaveLength(0);
-  });
-
-  it("does NOT flag numbers that differ only by formatting (100 vs 100.0)", () => {
-    const facts: Fact[] = [
-      { subject: "metric:revenue", predicate: "unit", object: "", claim: "Divide total_cents by 100 for dollars", origin: "doc", ref: "a" },
-      { subject: "metric:revenue", predicate: "unit", object: "", claim: "Divide total_cents by 100.0 for dollars", origin: "correction", ref: "b" },
-    ];
-    expect(findContradictions(facts)).toHaveLength(0);
-  });
-
-  it("does NOT flag two unrelated numbers on the same subject", () => {
-    // different statements that each contain a number must not collide.
-    const facts: Fact[] = [
-      { subject: "metric:revenue", predicate: "metric", object: "", claim: "Revenue grew 20 percent last quarter", origin: "doc", ref: "a" },
-      { subject: "metric:revenue", predicate: "metric", object: "", claim: "We have 5 sales reps covering it", origin: "correction", ref: "b" },
+      { subject: "topic:member-origin", predicate: "metric", object: "", claim: "Manual review by steven for member 100", origin: "correction", ref: "a" },
+      { subject: "topic:member-origin", predicate: "metric", object: "", claim: "Manual review by steven for member 101", origin: "correction", ref: "b" },
+      { subject: "metric:revenue", predicate: "unit", object: "", claim: "Divide total_cents by 100 for dollars", origin: "doc", ref: "c" },
+      { subject: "metric:revenue", predicate: "unit", object: "", claim: "Divide total_cents by 1000 for dollars", origin: "correction", ref: "d" },
     ];
     expect(findContradictions(facts)).toHaveLength(0);
   });


### PR DESCRIPTION
The deterministic numeric-contradiction rule has false-fired on real data **twice** — first a year (`2026` read as disagreeing with `7`), now incidental ids (`member 100` vs `member 101` in templated pending entries: *"numbers disagree: 100 vs 101 / 894 vs 97"*).

Telling a **salient quantity** (`divide by 100` vs `1000`) from an **incidental reference** (an id, a year, a count) is semantic — it can't be done structurally, and the rule cost more than it caught. Now that compaction runs **in-session** (`/setoku:compact`), numeric/semantic contradictions are judged there by a model.

So the deterministic detector behind the `/admin/knowledge` health bar keeps only the **high-precision** signals: atomic-predicate object mismatch + antonym clash (`excluded` vs `includes`). Removes `numbers()` / `nonNumericTokens()` / `NUM_RE`.

**Effect on the live store:** the health-bar contradiction count drops from **12** (mostly id-number false positives in the queue) to the genuine antonym cases.

Tests updated (one test now locks that numeric-only differences are *not* flagged, using the actual `member 100`/`101` and `÷100`/`÷1000` shapes). 141 pass, typecheck clean. Version → 0.18.1; deploying after merge to ship this + sync the `/health` string.