### PR TITLE
First-run UX refinement: honest tool states, session recovery, readable knowledge labels (v0.18.2)

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -19,6 +19,12 @@ gateway is the **`server`** service. Code lives under `DIR`; secrets live in `DI
 `SETOKU_DEPLOY_DOMAIN`. Create `deploy/target.local` once per machine and any agent in this
 repo can deploy with `bun run deploy` — no box-specific knowledge required.
 
+> ⚠ `bun run deploy` rebuilds **only the `server` (gateway) container.** It rsyncs the
+> rest, but a changed connector image (`ingest/*-poller`) is **not** rebuilt and an edited
+> `deploy/vector/vector.yaml` is **not** reloaded — both fail silently (no error, data just
+> never flows). After connector/vector changes, also run on the box:
+> `docker compose up -d --build <poller>` and/or `docker compose up -d vector`.
+
 The two models below are what that script automates (and what a git-clone box does instead).
 
 ### A. Git clone (the default — `bootstrap.sh` does `git clone … /opt/setoku`)
@@ -83,6 +89,11 @@ ssh BOX 'cd DIR && git checkout <previous-sha> && docker compose up -d --build s
   `SETOKU_DATABASE_URL` points at the wrong DB (e.g. staging vs prod). Re-grant
   `USAGE`+`SELECT` on the right project, or repoint the URL. For Supabase, use the
   **direct/non-pooling** URL for role/grant DDL (the pooler can cache stale grants).
+- **A new lake table never receives data (custom ClickHouse connector)** → `ingest/schemas/*.sql`
+  run **only once, on first init of an empty `ch_data` volume** (the `/docker-entrypoint-initdb.d`
+  mount, exactly like Postgres). On an *existing* box a newly-added schema file is silently
+  ignored, so the connector pushes rows Vector can't sink. Apply it by hand once:
+  `docker compose exec -T clickhouse clickhouse-client < ingest/schemas/0XX_yours.sql`.
 - **A connector "fails to connect"** → check `https://DOMAIN/health`, then
   `docker compose logs server` on the box. A stale local/old connector pointing at a
   dead URL (e.g. a torn-down host) 5xx's independently of the live box.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -82,10 +82,10 @@ one.
   `ingest/mercury-poller`), draft the connector + lake schema + compose wiring,
   and propose it. You provide the credential and approve the apply.
 - **Safety / membrane throughout** — the agent *proposes*; a human approves the
-  credential and the actual apply (editing the box `.env`, restarting). Each step
-  is recorded in `provisioning_log` (idempotency key → re-runs skip what's done;
-  secrets redacted). Connecting a source is inherently human-gated (buying infra,
-  provider creds, DB roles — see I9).
+  credential and the actual apply (editing the box `.env`, restarting). Steps land
+  in the store's audit log (there is no dedicated `provisioning_log` tool — see the
+  changelog note above). Connecting a source is inherently human-gated (buying
+  infra, provider creds, DB roles — see I9).
 
 ### 3 — Verify it understands the data *(the important part)*
 Connecting isn't done when bytes flow — it's done when the agent has *checked its
@@ -133,11 +133,10 @@ connected, what was learned, and the open questions worth a human's attention.
    ones fall back to improvisation. (Largely already encoded in `deploy/` and
    `ingest/`; this just indexes them for the skill.)
 3. Optional gateway support, nice-to-have, not required for v1:
-   - a `list_sources` MCP tool (reuse the Sources gather logic) so the skill can
-     see what's connected without SSH;
-   - expose `log_provisioning` as a curator tool so `connect` records steps in
-     `provisioning_log` for idempotency + audit (today it's a store method with
-     no tool).
+   - ~~a `list_sources` MCP tool~~ — **done**: `list_sources` ships and the
+     `connect` skill uses it to see what's connected without SSH;
+   - a `log_provisioning` curator tool for durable idempotency + audit was
+     considered and **not built** — steps land in the existing audit log instead.
 4. Reuse as-is: `deploy/bootstrap.sh`, `deploy/readonly-role.sql`, the
    `ingest/*-poller` patterns, compose profiles, the curator write-path.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "setoku",
   "displayName": "Setoku",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Governed agentic BI on your Claude subscription. Setoku gives Claude a verified business-context layer (derived from your codebase) plus read-only, audited access to your database \u2014 so it answers business questions accurately instead of guessing from column names.",
   "author": {
     "name": "Hedgy Labs"

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -15,7 +15,7 @@ import {
   resolveLakeUrl,
   type SetokuConfig,
 } from "./lib/config";
-import { introspectSchema, runReadOnlyQuery } from "./lib/db";
+import { diagnoseNoTables, introspectSchema, runReadOnlyQuery } from "./lib/db";
 import { runLakeQuery } from "./lib/lake";
 import { matchByTokens, matchGotchas, scoreDocs } from "./lib/search";
 import { KnowledgeStore, type DocType } from "./lib/store";
@@ -156,8 +156,11 @@ server.registerTool(
     }
     if (top.length === 0) {
       out.push(
-        "No matching context docs. Proceed with get_schema, state your assumptions explicitly in the answer, " +
-          "and use report_correction to capture anything the user clarifies.",
+        pending.length
+          ? // we already surfaced unverified knowledge above — don't then claim there's none
+            "No committed context docs yet — rely on the unverified team knowledge above (treat as likely true; attribute it), and capture anything the user clarifies with report_correction."
+          : "No matching context docs. Proceed with get_schema, state your assumptions explicitly in the answer, " +
+              "and use report_correction to capture anything the user clarifies.",
       );
     }
     for (const { doc } of top) {
@@ -206,8 +209,17 @@ server.registerTool(
   },
   async () => {
     const docs = store.listDocs();
-    if (docs.length === 0) return text(NO_KNOWLEDGE_HINT);
+    const pendingCount = store.pendingCount;
+    // Only truly empty (no committed docs AND no pending proposals) shows the
+    // "nothing here yet" hint. With pending proposals present we fall through so
+    // the "# pending corrections" section below actually surfaces them.
+    if (docs.length === 0 && pendingCount === 0) return text(NO_KNOWLEDGE_HINT);
     const lines: string[] = [];
+    if (docs.length === 0)
+      lines.push(
+        "No committed knowledge yet — only unverified proposals (below). Curate them to make them count.",
+        "",
+      );
     const sections: [DocType, string][] = [
       ["overview", "overview"],
       ["entity", "entities"],
@@ -479,11 +491,21 @@ server.registerTool(
       if (config && db.ok) {
         const tables = await introspectSchema(db.url, config);
         const names = tables.map((t) => `${t.schema}.${t.name}`);
-        lines.push(
-          "",
-          `BUSINESS DATABASE (Postgres) — run_query, default dialect — ${names.length} tables:`,
-          "  " + names.slice(0, 40).join(", ") + (names.length > 40 ? ", …" : "") + "  (get_schema for columns)",
-        );
+        if (names.length === 0) {
+          const denied = await diagnoseNoTables(db.url);
+          lines.push(
+            "",
+            denied
+              ? `BUSINESS DATABASE (Postgres): configured but the read-only role can see no tables — ${denied}`
+              : "BUSINESS DATABASE (Postgres): configured, but no tables match the allow-list (or the database is empty).",
+          );
+        } else {
+          lines.push(
+            "",
+            `BUSINESS DATABASE (Postgres) — run_query, default dialect — ${names.length} tables:`,
+            "  " + names.slice(0, 40).join(", ") + (names.length > 40 ? ", …" : "") + "  (get_schema for columns)",
+          );
+        }
       } else {
         lines.push("", "BUSINESS DATABASE: not configured.");
       }
@@ -580,6 +602,11 @@ server.registerTool(
           lines.push(
             "No allowed tables matched. Call get_schema with no arguments to list allowed tables.",
           );
+      } else if (schema.length === 0) {
+        // 0 tables is ambiguous: empty allow-list vs revoked grants. Probe the
+        // catalog so a permission wall reads as one, not as an empty database.
+        const denied = await diagnoseNoTables(url);
+        lines.push(denied ?? "0 allowed tables (the allow-list matched nothing, or the database is empty).");
       } else {
         lines.push(`${schema.length} allowed tables:`);
         for (const t of schema) {
@@ -718,8 +745,14 @@ server.registerTool(
       // excluded, refunds not netted, status-vs-event-log confusion). Make that
       // provisional state visible so the answer carries the caveat to the human.
       if (store.docCount === 0) {
+        // Distinguish "nothing here at all" from "knowledge exists but is still
+        // unverified" — otherwise the warning tells the agent to report_correction
+        // the very gotcha it just filed (the "I did the right thing and nothing
+        // changed" footgun).
         lines.unshift(
-          "⚠ No curated business context exists yet, so this is computed from raw schema and may be WRONG (e.g. internal/test accounts not excluded, refunds not netted). Tell the user the number is provisional, and add context via /setoku:generate or report_correction.",
+          store.pendingCount > 0
+            ? "⚠ Business context for this data is UNVERIFIED — it exists only as pending proposals awaiting human approval. If your query applied the relevant pending knowledge the number should be right; either way call it provisional until a human approves it (/setoku:curate)."
+            : "⚠ No curated business context exists yet, so this is computed from raw schema and may be WRONG (e.g. internal/test accounts not excluded, refunds not netted). Tell the user the number is provisional, and add context via /setoku:generate or report_correction.",
           "",
         );
       }

--- a/plugin/gateway/lib/db.ts
+++ b/plugin/gateway/lib/db.ts
@@ -283,6 +283,56 @@ export async function introspectSchema(
   }
 }
 
+/**
+ * Why did introspection return zero tables? Distinguishes "the read-only role's
+ * grants were revoked" from "the database is genuinely empty". This closes a
+ * real diagnostic gap: information_schema only lists tables the role can touch,
+ * so a revoked GRANT and an empty DB look identical ("0 allowed tables") — the
+ * exact failure mode that made a prod mispointing hard to diagnose. We probe the
+ * catalog (readable by everyone) for tables that physically exist but the role
+ * can't see, and return a copy-pasteable re-grant hint, or null if the DB really
+ * has no tables (or the role can read some, i.e. it's an allow-list/empty issue).
+ */
+export async function diagnoseNoTables(url: string): Promise<string | null> {
+  const client = await poolFor(url).connect();
+  try {
+    const res = await client.query(`
+      SELECT n.nspname AS schema,
+             count(c.oid) AS total,
+             count(c.oid) FILTER (
+               WHERE has_table_privilege(current_user, c.oid, 'SELECT')
+             ) AS readable,
+             has_schema_privilege(current_user, n.nspname, 'USAGE') AS usage
+      FROM pg_namespace n
+      LEFT JOIN pg_class c
+        ON c.relnamespace = n.oid AND c.relkind IN ('r','v','m','p','f')
+      WHERE n.nspname NOT IN ('pg_catalog','information_schema','pg_toast')
+        AND n.nspname NOT LIKE 'pg_temp%'
+        AND n.nspname NOT LIKE 'pg_toast_temp%'
+      GROUP BY n.nspname, n.oid`);
+    const withTables = res.rows.filter((r) => Number(r.total) > 0);
+    if (!withTables.length) return null; // genuinely empty database
+    // tables exist, but the role can read none in any of those schemas → grants gone
+    const blocked = withTables.filter(
+      (r) => !r.usage || Number(r.readable) === 0,
+    );
+    if (blocked.length < withTables.length) return null; // role can read some → not a perms wall
+    const schemas = blocked.map((r) => r.schema);
+    const ex = schemas[0];
+    return (
+      `permission denied — the read-only role can't see any of the ${withTables.reduce((n, r) => n + Number(r.total), 0)} table(s) ` +
+      `that exist in schema(s) ${schemas.join(", ")}. The grants were almost certainly revoked. Re-grant, e.g.:\n` +
+      `  GRANT USAGE ON SCHEMA ${ex} TO <read-only-role>;\n` +
+      `  GRANT SELECT ON ALL TABLES IN SCHEMA ${ex} TO <read-only-role>;\n` +
+      `(or just re-run deploy/connect-postgres.sh, which sets these up idempotently).`
+    );
+  } catch {
+    return null; // diagnosis is best-effort; never mask the original result
+  } finally {
+    client.release();
+  }
+}
+
 export async function closePools(): Promise<void> {
   await Promise.all([...pools.values()].map((p) => p.end().catch(() => {})));
   pools.clear();

--- a/plugin/gateway/lib/store.ts
+++ b/plugin/gateway/lib/store.ts
@@ -221,6 +221,19 @@ export class KnowledgeStore {
     return row.n;
   }
 
+  /**
+   * Count of pending (proposed, not-yet-approved) corrections. Cheap — the
+   * empty-store hints gate on this alongside docCount so a box that has *only*
+   * unverified knowledge doesn't claim to be empty right after an agent files a
+   * correction (the "I did the right thing and nothing changed" footgun).
+   */
+  get pendingCount(): number {
+    const row = this.db
+      .query("SELECT count(*) AS n FROM corrections WHERE status = 'pending'")
+      .get() as { n: number };
+    return row.n;
+  }
+
   getDoc(type: DocType | null, name: string): KnowledgeDoc | null {
     const needle = name.toLowerCase();
     const all = this.listDocs().filter((d) => (type ? d.type === type : true));

--- a/plugin/skills/connect/SKILL.md
+++ b/plugin/skills/connect/SKILL.md
@@ -79,8 +79,24 @@ config and restart. The credential lives on the box, never in a repo.
    warehouse) or a **pull-bridge** (poll the API → Vector → the lake), modeled on
    `ingest/mercury-poller/` (the reference pattern; `provisioner/sources/*.ts`
    shows the push/drain variants). Minimize sensitive fields at ingest.
-3. **Draft** the connector + a typed lake schema + the compose wiring, and show
-   the human the plan. They provide the credential and approve the apply.
+3. **Draft** the connector and wire it. A pull-bridge modeled on
+   `ingest/mercury-poller/` is **6 coordinated touchpoints** — miss one and it
+   fails *silently* (no error, data just never lands):
+   1. `ingest/<name>-poller/poll.ts` + its `Dockerfile`;
+   2. a compose **service block** for the poller;
+   3. `ingest/schemas/0XX_<name>.sql` — the typed lake table. ⚠ **initdb runs this
+      only once, on a fresh `ch_data` volume.** On an existing box apply it by hand:
+      `docker compose exec -T clickhouse clickhouse-client < ingest/schemas/0XX_<name>.sql`;
+   4. add the new profile to the **`clickhouse` (and `vector`) service `profiles:` list**
+      in `docker-compose.yml` — else `--profile <name>` starts the poller but not the
+      lake/Vector it pushes to;
+   5. three edits to `deploy/vector/vector.yaml`: a `router` route, a `*_parse` remap,
+      and a `lake_*` ClickHouse sink;
+   6. an inbound *webhook* connector (not a poller) also needs a `handle /ingest/<name>/*`
+      block in the `Caddyfile` with token-path auth + a Caddy reload.
+   Show the human the plan. They provide the credential and approve the apply. Remember
+   `bun run deploy` rebuilds only `server` — rebuild the poller (`up -d --build <poller>`)
+   and reload Vector (`up -d vector`) yourself.
 4. Keep an improvised connector **box-local first**; once it's run clean for a
    while, PR it to the repo so it becomes a proven recipe. (You build what the
    customer needs; we harden what recurs.)
@@ -167,7 +183,7 @@ Then go for the two bigger wins — this is where Setoku beats Claude-on-Postgre
 - **Share it with the team.** The knowledge you just captured is now everyone's.
   Easiest: the human clicks **Invite** on `https://<domain>/admin/team` — it mints
   a read-only connector and shows the dev one-liner + claude.ai steps right there.
-  From the CLI it's `docker compose exec server bun gateway/admin-cli.ts add-teammate <their-email>`. Offer to add a couple of teammates either way.
+  From the CLI it's `docker compose exec server bun gateway/admin-cli.ts add-teammate <identity>` (the identity is conventionally their email). Offer to add a couple of teammates either way.
 - **The non-technical magic moment.** For a founder/PM/ops teammate this may be the
   *first time they can query and visualize their own data in plain language* — and
   get the right number, because your annotations ride along. Tee it up: have them
@@ -278,7 +294,7 @@ cd /opt/setoku && git pull && docker compose up -d --build server
 #   (rsync-based box, or a deeper deploy / rollback: see docs/deploy.md)
 
 # share with a teammate — prints dev one-liner + claude.ai connector steps (Phase 4)
-docker compose exec server bun gateway/admin-cli.ts add-teammate <email>
+docker compose exec server bun gateway/admin-cli.ts add-teammate <identity>
 
 # mint a curator connector token (Phase 3 — only when committing knowledge directly)
 docker compose exec server bun gateway/admin-cli.ts create-curator-token <identity>

--- a/plugin/skills/onboard/SKILL.md
+++ b/plugin/skills/onboard/SKILL.md
@@ -46,7 +46,7 @@ engine — follow it; this adds the repo-specific bits.
    (`report_correction`/`upsert_context`) so the artifact compounds from day one.
 6. **Share with the team (the real payoff).** The knowledge is now everyone's.
    Offer to add a teammate or two — the human can click **Invite** on
-   `https://<domain>/admin/team`, or from the CLI: `docker compose exec server bun gateway/admin-cli.ts add-teammate <email>`. Both show a dev one-liner + claude.ai steps.
+   `https://<domain>/admin/team`, or from the CLI: `docker compose exec server bun gateway/admin-cli.ts add-teammate <identity>`. Both show a dev one-liner + claude.ai steps.
    Call out the non-technical win — a founder/PM querying *and visualizing* their
    own data in plain language, getting the right number because the annotations
    ride along — it's often the biggest magic moment.


### PR DESCRIPTION
A fresh-eyes review of the first-run UX (three subagent critics + exercising the connect flow, a live source take-down, and the admin SPA) surfaced a set of places where the product **misrepresented its own state** or **dead-ended the user**. This PR fixes all of them. Verified live on local boxes; `tsc` clean, tests pass.

## Gateway tools — empty-store state machine (connect critic's "single biggest fix")
The empty-store hints gated on `docCount` alone, so the instant an agent did the right thing — filed a `report_correction` — `run_query` / `find_context` / `list_entities` *still* insisted the store was empty and told it to "add context via report_correction" (the thing it just did). They now account for **pending proposals**:

| state | before | after |
|---|---|---|
| empty (no docs/pending) | "No curated knowledge yet" | unchanged |
| pending proposal filed | "store is empty, add context" ❌ | "UNVERIFIED — pending approval, treat as provisional" ✅ |

`find_context` no longer prints unverified knowledge and then "No matching context docs" in the same breath.

## Gateway tools — revoked-grant legibility
`get_schema` / `list_sources` returned a silent **"0 allowed tables"** when the read-only role's grants were revoked — indistinguishable from an empty DB (the prod-mispointing failure mode). New `diagnoseNoTables()` probes the catalog and surfaces *"permission denied — re-grant USAGE/SELECT"* with a copy-pasteable fix, falling back to the empty-DB wording only when the database genuinely has no tables.

## Admin SPA — P0: expired-session recovery
`AuthProvider` resolved the session once on mount, so an expiry mid-use left every tab rendering signed-in chrome over a bare red "not signed in" error — only escape was a manual reload. `api.ts` now fires a handler on **any** `/admin/api/*` 401; `AuthProvider` clears `me` (→ Login) and shows **"Your session expired — please sign in again."** Verified via CDP: invalidate the session server-side, click a nav tab → bounces to Login with the notice, chrome gone.

## Admin SPA — P1: readable labels for approved knowledge
A folded gotcha was named by a naive 48-char slice of the fact (`…c2c-are-exc`) and, when its `relates_to` subject didn't exist, stood alone titled by that slug. Now the doc name is a short word-boundary slug prefixed by `relates_to`, and a standalone gotcha's subject group is titled by its **readable claim**. Gotchas whose `relates_to` resolves fold into that subject (verified: a net_revenue-related gotcha attaches to the net_revenue metric subject).

## Dev-ex docs (deploy/extend critic)
- **deploy.md**: `bun run deploy` rebuilds only `server` (poller/vector changes are silent); the ClickHouse `initdb`-is-first-boot-only footgun for custom lake schemas.
- **connect SKILL**: the 6 coordinated touchpoints of a custom pull-bridge connector (was one line); `add-teammate <identity>` not `<email>`.
- **onboarding.md**: drop stale `provisioning_log` references; mark `list_sources` shipped.

## Testing
Live across clean boxes: empty → pending → grants-revoked transitions read correctly; genuinely-empty path unchanged; admin expired-session bounce + approved-gotcha grouping verified. `tsc --noEmit` clean; 132 unit tests pass; committed admin bundle (`app.css` + `dist/app.js`) rebuilt.