### PR TITLE
demo: point README/e2e at the redeployed Bulldogs demo token

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ There's a public demo wired to a synthetic dataset for a fictional pro baseball 
 
 1. In **Claude.ai → Settings → Connectors → Add custom connector**, paste this as the server URL (there's no header field — the token rides in the URL):
    ```
-   https://demo.setoku.com/i/8cc638d87e2b6bfbbcde67ba8864cb20554f141323d50db3
+   https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9
    ```
 2. Ask in plain language. Setoku feeds Claude the curated definitions first (comps are free, `scanned` = attended, money is in cents), so it computes the number the way the business actually does instead of guessing from column names. Try:
    - *"How many unique fans do we have?"* — the CRM has duplicates and test records; Setoku dedupes by normalized email instead of a naive `COUNT(*)`.

--- a/demo/README.md
+++ b/demo/README.md
@@ -21,7 +21,7 @@ Deployed on the hedgy box:
 
 | | URL |
 |---|---|
-| **Claude connector (MCP)** | `https://demo.setoku.com/mcp/1097598a5d333b1e012d517e0380898f39ffea51e0830be9` |
+| **Claude connector (MCP)** | `https://demo.setoku.com/mcp/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9` |
 | **Admin / approval surface** | https://demo.setoku.com/admin |
 | **Health** | https://demo.setoku.com/health |
 

--- a/demo/e2e/knowledge-lint.ts
+++ b/demo/e2e/knowledge-lint.ts
@@ -18,7 +18,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 
 const datasetDir = process.argv[2] ?? "demo/bulldogs";
 const mcpUrl = process.argv[3] ?? process.env.DEMO_MCP_URL ??
-  "https://demo.setoku.com/mcp/28e53fdf11bd086f665064beea5f7d0f6c59292183af96d8";
+  "https://demo.setoku.com/mcp/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9";
 
 // value sanity heuristics keyed on the OUTPUT column name (model-free).
 const HEURISTICS: { match: RegExp; bad: (n: number) => boolean; why: string }[] = [

--- a/demo/e2e/probe.ts
+++ b/demo/e2e/probe.ts
@@ -12,7 +12,7 @@ import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const MCP_URL = process.env.DEMO_MCP_URL ?? "https://demo.setoku.com/mcp/28e53fdf11bd086f665064beea5f7d0f6c59292183af96d8";
+const MCP_URL = process.env.DEMO_MCP_URL ?? "https://demo.setoku.com/mcp/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9";
 
 // Each probe notes the TRAP — the gap it's hunting for.
 const PROBES: { ask: string; trap: string }[] = [

--- a/demo/e2e/run.ts
+++ b/demo/e2e/run.ts
@@ -21,7 +21,7 @@ import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const MCP_URL = process.env.DEMO_MCP_URL ?? "https://demo.setoku.com/mcp/28e53fdf11bd086f665064beea5f7d0f6c59292183af96d8";
+const MCP_URL = process.env.DEMO_MCP_URL ?? "https://demo.setoku.com/mcp/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9";
 
 type Check = { primary: RegExp; note: string; mustNot?: RegExp };
 type Q = { ask: string; checks: Check[] };


### PR DESCRIPTION
Follow-up to #22. The Stags → Bonita Bulldogs rename moved the public demo host to **demo.setoku.com** and the box was redeployed under a fresh compose project (`setoku-bulldogs`), which minted a new analyst token in `.env.bulldogs`. This updates the committed install/MCP URLs to the live token.

- Root `README.md` `/i/…` install URL → new token
- `demo/README.md` `/mcp/…` connector URL → new token
- `demo/e2e/{run,probe,knowledge-lint}.ts` default `DEMO_MCP_URL` → new token

The token is a read + propose-only bearer credential over **synthetic** data (no real PII), safe to commit — same posture as before.

**Deployment status (done out-of-band):** the box now runs the `setoku-bulldogs` demo (9 schemas, ~13M rows seeded), gateway healthy (`/health` ok), and Caddy serves it. Verified live via `https://demo.51-81-222-176.sslip.io/health` and an MCP `initialize` through Caddy with this token. Production (`hedgy.setoku.com`) is unaffected.

⚠️ **Needs a DNS record (registrar action — I can't do this):** add an A record `demo.setoku.com → 51.81.222.176`. Until then the friendly host won't get a cert; the sslip alias works immediately.