### PR TITLE
demo: alias stags.setoku.com onto the Bulldogs gateway (back-compat)

### DIFF
--- a/demo/caddy-bulldogs.snippet
+++ b/demo/caddy-bulldogs.snippet
@@ -5,10 +5,17 @@
 #   docker compose -p setoku up -d --force-recreate --no-deps caddy
 #
 # The hostnames below front the Bulldogs gateway. The sslip.io name works with
-# NO DNS change; demo.setoku.com is the friendly primary. Upstream is the
-# gateway container, reachable because docker-compose.edge.yml joined it here.
+# NO DNS change; demo.setoku.com is the friendly primary (needs an A record →
+# the box). Upstream is the gateway container, reachable because
+# docker-compose.edge.yml joined it here.
+#
+# stags.setoku.com / stags.<ip>.sslip.io are BACK-COMPAT aliases for the former
+# "Riverside Stags" demo, kept so previously-shared MCP connectors and installer
+# links keep resolving to this same gateway (a direct proxy, not a redirect —
+# MCP clients POST and don't reliably follow 30x). The old analyst/installer
+# tokens are also re-added to DEMO_TOKENS on the box so those links still auth.
 
-demo.setoku.com, demo.51-81-222-176.sslip.io {
+demo.setoku.com, demo.51-81-222-176.sslip.io, stags.setoku.com, stags.51-81-222-176.sslip.io {
 	encode gzip
 	handle /mcp* {
 		reverse_proxy setoku-bulldogs-demo-server-1:8787


### PR DESCRIPTION
Follow-up to #22/#23. Keeps the old **stags.setoku.com** (and its sslip alias) serving the renamed Bulldogs demo so existing MCP connectors / installer links keep working.

**Why an alias, not a redirect:** MCP Streamable-HTTP clients `POST` with the token in the URL path. HTTP clients are unreliable about following 30x on POST (often downgrade to GET and drop the body; many MCP clients don't follow redirects at all), so a redirect would break existing connectors. A direct proxy alias keeps the transport intact.

This updates the committed `caddy-bulldogs.snippet` to list the stags hostnames alongside the demo ones, matching the live box.

**Already applied + verified on the box (out-of-band):**
- Caddyfile address list now includes `stags.setoku.com, stags.51-81-222-176.sslip.io`.
- The old analyst/installer tokens were re-added to `DEMO_TOKENS` in `.env.bulldogs` (read + propose-only over synthetic data) so old links authenticate.
- Verified: `https://stags.setoku.com/mcp/<old-token>` returns a valid MCP `initialize`; `https://stags.setoku.com/i/<old-token>` → 200; the new `demo.*` host still serves.

(Still pending your DNS action from #23: A record `demo.setoku.com → 51.81.222.176`. `stags.setoku.com` already resolves, so it has a cert now.)