### PR TITLE
Admin sessions: sliding 14-day window instead of a hard 12h

### DIFF
--- a/plugin/gateway/http.ts
+++ b/plugin/gateway/http.ts
@@ -914,8 +914,16 @@ const httpServer = http.createServer(async (req, res) => {
       // ---- JSON API ----
       if (reqPath.startsWith("/admin/api/")) {
         const api = reqPath.slice("/admin/api/".length);
+        // When a request slides the session window forward, re-issue the cookie so
+        // the browser's copy slides too (Max-Age is relative to each Set-Cookie).
+        let renewedCookie: string | undefined;
         const json = (status: number, body: unknown): void => {
-          res.writeHead(status, { "content-type": "application/json", "referrer-policy": "no-referrer" });
+          const headers: Record<string, string> = {
+            "content-type": "application/json",
+            "referrer-policy": "no-referrer",
+          };
+          if (renewedCookie) headers["set-cookie"] = renewedCookie;
+          res.writeHead(status, headers);
           res.end(JSON.stringify(body));
         };
 
@@ -948,6 +956,11 @@ const httpServer = http.createServer(async (req, res) => {
 
         // everything below requires a session
         if (!session) return json(401, { ok: false, error: "not signed in" });
+
+        // Sliding window: an active (non-logout) session renews on use, so a
+        // working admin never gets logged out mid-use — only 14 days idle does.
+        // Throttled inside, and the re-issued cookie slides the browser's copy too.
+        if (sessions.renew(sid, session)) renewedCookie = sessionSetCookie(sid!);
 
         // who am I — drives the SPA's auth state + the CSRF token for mutations
         if (api === "session")

--- a/plugin/gateway/lib/approval.ts
+++ b/plugin/gateway/lib/approval.ts
@@ -77,6 +77,17 @@ export interface Session {
   expires: number;
 }
 
+// Session lifetime is a SLIDING 14-day window: each authenticated request slides
+// the expiry forward, so an active admin stays signed in ("once per device") and
+// only a full 14 days of inactivity forces a fresh login. The cookie's Max-Age
+// (below) mirrors this so the browser keeps the cookie just as long.
+export const SESSION_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+// Don't write a renewal on every single request (the SPA polls): only slide the
+// window once it's drifted by more than a day. Cheap, and still effectively
+// "infinite while in use" against a 14-day window.
+const RENEW_AFTER_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Session store for the approval surface, backed by the KnowledgeStore (SQLite
  * on the durable volume) — NOT process memory — so a server restart/redeploy
@@ -86,7 +97,7 @@ export interface Session {
 export class SessionStore {
   constructor(
     private readonly store: KnowledgeStore,
-    private readonly ttlMs = 12 * 60 * 60 * 1000,
+    private readonly ttlMs = SESSION_TTL_MS,
   ) {}
 
   create(identity: string, role: string): { sid: string; csrf: string } {
@@ -99,6 +110,19 @@ export class SessionStore {
   get(sid: string | undefined): Session | null {
     if (!sid) return null;
     return this.store.getSession(sid);
+  }
+
+  /**
+   * Slide a live session's expiry forward by the full TTL. Throttled — a no-op
+   * unless the window has drifted more than RENEW_AFTER_MS. Returns true when it
+   * actually renewed, so the caller knows to re-issue the cookie.
+   */
+  renew(sid: string | undefined, session: Session): boolean {
+    if (!sid) return false;
+    const freshlyIssuedAt = session.expires - this.ttlMs;
+    if (Date.now() - freshlyIssuedAt < RENEW_AFTER_MS) return false;
+    this.store.touchSession(sid, Date.now() + this.ttlMs);
+    return true;
   }
 
   destroy(sid: string | undefined): void {
@@ -126,7 +150,7 @@ const secureAttr = (): string => (process.env.SETOKU_COOKIE_INSECURE === "1" ? "
 
 /** Set-Cookie value for a new session (HttpOnly, Secure, SameSite=Strict). */
 export function sessionSetCookie(sid: string): string {
-  return `${COOKIE}=${encodeURIComponent(sid)}; HttpOnly;${secureAttr()} SameSite=Strict; Path=/admin; Max-Age=43200`;
+  return `${COOKIE}=${encodeURIComponent(sid)}; HttpOnly;${secureAttr()} SameSite=Strict; Path=/admin; Max-Age=${SESSION_TTL_MS / 1000}`;
 }
 
 /** Set-Cookie value that clears the session cookie. */

--- a/plugin/gateway/lib/store.ts
+++ b/plugin/gateway/lib/store.ts
@@ -755,6 +755,11 @@ export class KnowledgeStore {
     return row;
   }
 
+  /** Slide a session's expiry forward (sliding-window renewal on activity). */
+  touchSession(sid: string, expires: number): void {
+    this.db.run("UPDATE sessions SET expires = ? WHERE sid = ?", [expires, sid]);
+  }
+
   destroySession(sid: string): void {
     this.db.run("DELETE FROM sessions WHERE sid = ?", [sid]);
   }

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -533,6 +533,39 @@ describe("approval surface (the human accept path, Phase 5.1/5.5/5.6)", () => {
     const shell = await (await fetch(`${BASE}/admin`)).text();
     expect(shell).not.toContain("<script>alert('xss')</script>");
   });
+
+  it("an active session slides forward on use (sliding window) — without re-issuing a cookie on every response", async () => {
+    const { Database } = await import("bun:sqlite");
+    const { cookie } = await session("boss", "s3cret-pass");
+    const sid = decodeURIComponent(cookie.split("=").slice(1).join("="));
+
+    // a just-issued session is inside the renewal throttle → an authed read does
+    // NOT re-issue the cookie (we don't Set-Cookie on every response).
+    const fresh = await apiGet("session", cookie);
+    expect(fresh.status).toBe(200);
+    expect(fresh.headers.get("set-cookie")).toBeNull();
+
+    // age it past the throttle but keep it valid — the way a day of use leaves it.
+    {
+      const db = new Database(path.join(tmpRepo, "knowledge.db"));
+      db.run("UPDATE sessions SET expires = ? WHERE sid = ?", [Date.now() + 60_000, sid]);
+      db.close();
+    }
+
+    // now the same request slides the window forward and re-issues the cookie.
+    const slid = await apiGet("session", cookie);
+    expect(slid.status).toBe(200);
+    const setCookie = slid.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`setoku_session=${sid}`);
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("Max-Age=1209600"); // 14 days, mirrors the server-side TTL
+
+    // and the persisted expiry actually slid ~14 days out (not just the cookie).
+    const check = new Database(path.join(tmpRepo, "knowledge.db"), { readonly: true });
+    const row = check.query("SELECT expires FROM sessions WHERE sid = ?").get(sid) as { expires: number };
+    check.close();
+    expect(row.expires).toBeGreaterThan(Date.now() + 13 * 24 * 60 * 60 * 1000);
+  });
 });
 
 describe("installer", () => {

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { KnowledgeStore } from "../plugin/gateway/lib/store";
+import { SessionStore, SESSION_TTL_MS } from "../plugin/gateway/lib/approval";
 
 const dbPath = path.join(os.tmpdir(), `setoku-sessions-${process.pid}.db`);
 afterAll(() => {
@@ -55,5 +56,31 @@ describe("session persistence (survives a restart)", () => {
     expect(s.getSession("sid-bye")).not.toBeNull();
     s.destroySession("sid-bye");
     expect(s.getSession("sid-bye")).toBeNull();
+  });
+});
+
+describe("sliding-window renewal (stay signed in while active)", () => {
+  it("a fresh session is not renewed yet (throttle holds for the first day)", () => {
+    const store = new KnowledgeStore(dbPath);
+    const sessions = new SessionStore(store);
+    const { sid } = sessions.create("peter", "admin");
+    const before = store.getSession(sid)!.expires;
+    // just-issued → within the throttle window → no write
+    expect(sessions.renew(sid, store.getSession(sid)!)).toBe(false);
+    expect(store.getSession(sid)!.expires).toBe(before);
+  });
+
+  it("a session older than the throttle slides its expiry forward by a full TTL", () => {
+    const store = new KnowledgeStore(dbPath);
+    const sessions = new SessionStore(store);
+    const { sid } = sessions.create("peter", "admin");
+    // simulate a session issued ~29 days ago: expiry near the end of its window
+    const aged = { ...store.getSession(sid)!, expires: Date.now() + 60_000 };
+    store.touchSession(sid, aged.expires);
+
+    expect(sessions.renew(sid, aged)).toBe(true);
+    const renewed = store.getSession(sid)!.expires;
+    // slid forward to ~now + full TTL, well past the old near-expiry value
+    expect(renewed).toBeGreaterThan(Date.now() + SESSION_TTL_MS - 60_000);
   });
 });


### PR DESCRIPTION
## Problem

Web-admin sessions had a **hard 12-hour lifetime that never slid** (`approval.ts` TTL + cookie `Max-Age=43200`). `getSession` only checked `expires < now` — nothing ever extended a live session — so an actively-used admin got logged out exactly 12h after login. That's the "I have to log in pretty often" feeling.

## Change

Make the lifetime a **sliding 14-day window**. Each authenticated `/admin/api` request renews the session, so a working admin stays signed in ("once per device") and only ~14 days of genuine inactivity forces a fresh login.

- **`lib/approval.ts`** — `SESSION_TTL_MS = 14d` (was 12h), shared by the cookie `Max-Age` so the browser's copy slides too. New `SessionStore.renew()` bumps a live session forward, **throttled to at most once/day** so the SPA's polling doesn't write to SQLite on every request.
- **`lib/store.ts`** — `touchSession()`, the `UPDATE` behind renewal.
- **`http.ts`** — renew + re-issue the cookie on authenticated, non-logout API requests, placed *after* the auth/logout guards so a logout doesn't waste a write.

Unchanged and still working: sessions persist in SQLite (restarts/redeploys don't sign anyone out), and expired rows are still pruned on read.

## Tests

- `test/sessions.test.ts` — `renew` throttle holds for a fresh session; an aged session slides forward a full TTL.
- `test/http.test.ts` — over real HTTP: a fresh request issues no `Set-Cookie`, but an aged-then-used session slides forward, re-issues the cookie (`Max-Age=1209600`), and the persisted expiry actually moves ~14 days out.

Full fast suite green.

## Security note

14 days chosen as a middle ground between the old 12h and a longer 30d window — bounds how long a stolen cookie stays valid while still meaning a regular user rarely re-logs in. The cookie remains `HttpOnly; Secure; SameSite=Strict`.