### PR TITLE
Require embeddings (remove the opt-in)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -19,14 +19,15 @@ COPY plugin/gateway ./gateway
 # surfaced in MCP serverInfo + /health so a deploy is verifiable from a session.
 COPY plugin/.claude-plugin/plugin.json ./plugin.json
 
-# Optionally bake the local embedding model into the image so the box never has to
-# download it at runtime (deterministic, offline startup). OFF by default to keep
-# non-embedding images lean. Enable per-build: docker build --build-arg BAKE_EMBEDDINGS=1
-ARG BAKE_EMBEDDINGS=0
+# Bake the local embedding model into the image so the box never downloads it at
+# runtime (deterministic, offline startup). Embeddings are required, so this is ON
+# by default; pass --build-arg BAKE_EMBEDDINGS=0 only for a deliberately
+# keyword-only build.
+ARG BAKE_EMBEDDINGS=1
 ENV SETOKU_EMBED_CACHE=/app/.fastembed
 RUN if [ "$BAKE_EMBEDDINGS" = "1" ]; then \
       echo "baking bge-small-en-v1.5 into the image…" && \
-      SETOKU_EMBEDDINGS=1 bun -e 'import { FlagEmbedding, EmbeddingModel } from "fastembed"; await FlagEmbedding.init({ model: EmbeddingModel.BGESmallENV15, cacheDir: "/app/.fastembed" }); console.log("baked")'; \
+      bun -e 'import { FlagEmbedding, EmbeddingModel } from "fastembed"; await FlagEmbedding.init({ model: EmbeddingModel.BGESmallENV15, cacheDir: "/app/.fastembed" }); console.log("baked")'; \
     fi
 
 # Project dir: config + (optionally) a context seed baked into the image.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -34,19 +34,21 @@ README) so the references resolve without bloating the front page.
   behavior around them.
 - **I8 — No *external* inference; zero AI keys required.** Setoku never calls an
   LLM or a hosted embedding API, and never sends business data off the box for
-  inference. `find_context` works fully on keyword + synonym retrieval with no AI
-  credentials. **Opt-in upgrade (default off): a bundled, local, CPU-only, non-LLM
-  embedding model** (`SETOKU_EMBEDDINGS=1`) that runs *in-process on the box* for
-  hybrid retrieval — data never leaves the machine, no network at query time, no
-  key. It must **degrade gracefully**: if the model can't load, the gateway falls
-  back to keyword retrieval and keeps serving. The next rung (bring-your-own-key
-  hosted embeddings) stays external and opt-in.
-  *Amended (experiment/llm-wiki): the original wording already named a "bundled
-  local CPU embedding model" as an upgrade; this makes the local-vs-external line
-  explicit, since a local model is technically on-box inference. The load-bearing
-  guarantee — no business data to an external service, no required keys — is
-  unchanged. Evidence: cross-domain recall held 88% with embeddings vs 13% for a
-  hand-tuned synonym table (docs/llm-wiki.md).*
+  inference. The load-bearing guarantee: **no business data to an external service,
+  no required credentials.** Hybrid retrieval uses a **bundled, local, CPU-only,
+  non-LLM embedding model** that runs *in-process on the box* — data never leaves
+  the machine, no network at query time, no key. It is **on by default and
+  required** (not an opt-in); `SETOKU_EMBEDDINGS=0` is a diagnostics/test
+  kill-switch only (CI uses it so the suite stays model-free). It still **degrades
+  gracefully**: if the model genuinely can't load, the gateway falls back to
+  keyword retrieval and keeps serving — that's resilience, not a config choice. A
+  future bring-your-own-key *hosted* embedding tier would be the only external,
+  opt-in rung.
+  *Amended (experiment/llm-wiki, then "require embeddings" follow-up): the original
+  wording already named a "bundled local CPU embedding model"; a local model is
+  technically on-box inference, so the local-vs-external line is now explicit, and
+  embeddings moved from opt-in to default/required. Evidence: cross-domain recall
+  held 88% with embeddings vs 13% for a hand-tuned synonym table (docs/llm-wiki.md).*
 - **I9 — Authority changes pass through a human, outside the agent loop.** No MCP
   tool may create users, change roles, grant data access, or commit curated
   knowledge — the defense is a human action the agent *cannot perform* (a click on

--- a/docs/llm-wiki.md
+++ b/docs/llm-wiki.md
@@ -240,10 +240,12 @@ Model choice (VPS-realistic, CPU, no GPU): **bge-small** (~130MB, ~120 ms/query,
 and ~2 GB). External embedding APIs would score higher but violate I8 and aren't
 box-local.
 
-**Decision: shipped as an opt-in hybrid (I8 amended).** I8 now permits a local,
-CPU, non-LLM embedding model on the box (default off, `SETOKU_EMBEDDINGS=1`) — the
+**Decision: hybrid is the product (I8 amended).** I8 permits a local, CPU, non-LLM
+embedding model on the box; embeddings are **on by default and required** — not an
+opt-in — with `SETOKU_EMBEDDINGS=0` as a diagnostics/test kill-switch only. The
 privacy guarantee is intact (data never leaves the box, no LLM, no external call,
-no key). The implementation:
+no key), and keyword fallback remains as resilience if the model can't load. The
+implementation:
 
 - **Model** `lib/embeddings.ts` — bge-small via `fastembed`, **dynamically
   imported** (a gateway with embeddings off never loads onnx) and **graceful**: any

--- a/plugin/gateway/lib/embeddings.ts
+++ b/plugin/gateway/lib/embeddings.ts
@@ -24,9 +24,15 @@ export interface Embedder {
   embedQuery(text: string): Promise<number[]>;
 }
 
-/** Embeddings are an explicit opt-in (default off) so existing deploys are inert. */
+/**
+ * Embeddings are REQUIRED — hybrid retrieval is the product, not an opt-in.
+ * On by default; `SETOKU_EMBEDDINGS=0` is a diagnostics/test kill-switch only
+ * (e.g. CI keeps it off so the suite never loads the native model). Graceful
+ * fallback to keyword retrieval still applies if the model genuinely can't load —
+ * that's resilience, not a configuration choice.
+ */
 export function embeddingsEnabled(): boolean {
-  return process.env.SETOKU_EMBEDDINGS === "1";
+  return process.env.SETOKU_EMBEDDINGS !== "0";
 }
 
 let cached: Promise<Embedder | null> | null = null;

--- a/test/embeddings.test.ts
+++ b/test/embeddings.test.ts
@@ -5,6 +5,9 @@
  * (no model loaded), proving the gateway never depends on the embedder being
  * present: disabled → null embedder, inert index, keyword retrieval unchanged.
  */
+// Embeddings are on by default in prod; the suite forces the kill-switch so it
+// never loads the native model (set here too, so the file is safe run directly).
+process.env.SETOKU_EMBEDDINGS = "0";
 import { describe, expect, it } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
@@ -19,9 +22,9 @@ const DOCS: ScorableDoc[] = [
   { type: "metric", name: "fan_count", meta: { keywords: ["fans"] }, body: "distinct fans" },
 ];
 
-describe("graceful degradation (embeddings off by default)", () => {
-  it("is disabled unless SETOKU_EMBEDDINGS=1", () => {
-    expect(embeddingsEnabled()).toBe(false); // not set in the test env
+describe("graceful degradation (kill-switch + fallback)", () => {
+  it("the SETOKU_EMBEDDINGS=0 kill-switch disables (default is ON in prod)", () => {
+    expect(embeddingsEnabled()).toBe(false); // forced off at the top of this file
   });
 
   it("getEmbedder() returns null when disabled (no native load)", async () => {

--- a/test/lib/gateway.ts
+++ b/test/lib/gateway.ts
@@ -13,11 +13,14 @@ export const ROOT = path.resolve(import.meta.dir, "..", "..");
 export const HTTP_SERVER = path.join(ROOT, "plugin", "gateway", "http.ts");
 export const FIXTURES = path.join(ROOT, "test", "fixtures");
 
-/** Spawn http.ts with the given env merged over the current process env. */
+/** Spawn http.ts with the given env merged over the current process env.
+ *  Embeddings default OFF for tests (kill-switch) so the suite never loads the
+ *  native model — fast + deterministic however it's invoked; a test can still opt
+ *  in via `env`. Precedence: this default < process env < caller's `env`. */
 export function spawnGateway(env: Record<string, string>): Subprocess {
   return spawn({
     cmd: ["bun", HTTP_SERVER],
-    env: { ...(process.env as Record<string, string>), ...env },
+    env: { SETOKU_EMBEDDINGS: "0", ...(process.env as Record<string, string>), ...env },
     stdout: "ignore",
     stderr: "pipe",
   });


### PR DESCRIPTION
Follow-up to #32. Hybrid retrieval is the product, not an opt-in.

- **Embeddings on by default / required.** `embeddingsEnabled()` is true unless `SETOKU_EMBEDDINGS=0`, which is now a diagnostics/test kill-switch — not a feature toggle. Graceful keyword fallback stays as *resilience* (if the model can't load), not a config choice.
- **Dockerfile bakes the model by default** (`BAKE_EMBEDDINGS=1`) so every image is embedding-ready offline; `=0` for a deliberately keyword-only build.
- **Tests stay fast + model-free:** `spawnGateway` defaults the kill-switch on (a test can opt in), plus the npm test script / pre-push hook / CI set `SETOKU_EMBEDDINGS=0`. Full suite ~5s, zero model loads, 0 fail.
- **Docs:** I8 + llm-wiki updated — the local CPU embedder is required/default; still no external inference, no keys, data never leaves the box.

Closes the 'embeddings as an option' design smell. Next: deploy to hedgy from main with embeddings on by default.