### PR TITLE
Membrane: capability role makes the forbidden combo unrepresentable (#34)

### DIFF
--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -26,58 +26,60 @@ import { lintDashboardTemplate } from "./lib/dashboard-runtime";
 import { LAKE_SOURCES } from "./lib/sources";
 import { VERSION } from "./lib/version";
 
+/**
+ * A token's capability role — the I2/I9 membrane, made a type. A session is
+ * EXACTLY one of these; capabilities are derived (capabilitiesFor), never passed
+ * as free booleans. This is what makes the dangerous combination — commit
+ * knowledge AND read the untrusted lake on one session — *unrepresentable*:
+ *
+ *   • analyst — reads the lake (untrusted bulk text); propose-only, no write tool.
+ *   • curator — commits curated knowledge; CANNOT read the lake.
+ *   • janitor — draft + reject only (zero authority); reads untrusted pending text.
+ *
+ * An agent reading untrusted content is prompt-injectable, so it must never hold a
+ * tool that commits knowledge. With a single role there is no way to construct a
+ * session that both writes and reads the lake — the boolean soup that previously
+ * left that one careless call-site away.
+ */
+export type TokenRole = "analyst" | "curator" | "janitor";
+
+export interface Capabilities {
+  /** Expose curated-write tools (upsert_context, resolve_correction). */
+  canWrite: boolean;
+  /** Block run_query on the lake (clickhouse) — true exactly when canWrite. */
+  denyLakeRead: boolean;
+  /** Expose draft_correction (draft-only, zero authority). */
+  canDraft: boolean;
+  /** Expose reject_correction (reject-only, zero authority). */
+  canReject: boolean;
+}
+
+/** Derive a role's capabilities. The ONLY place capabilities are decided, so the
+ *  membrane is one switch, not a convention spread across call sites. By
+ *  construction no role yields `canWrite && !denyLakeRead`. */
+export function capabilitiesFor(role: TokenRole): Capabilities {
+  switch (role) {
+    case "curator":
+      return { canWrite: true, denyLakeRead: true, canDraft: false, canReject: false };
+    case "janitor":
+      return { canWrite: false, denyLakeRead: false, canDraft: true, canReject: true };
+    case "analyst":
+      return { canWrite: false, denyLakeRead: false, canDraft: false, canReject: false };
+  }
+}
+
 export interface GatewayDeps {
   projectDir: string;
   store: KnowledgeStore;
   user: string;
+  /** The session's capability role (the membrane). Capabilities are derived from
+   *  it, so the forbidden write+lake-read combination can't be constructed. */
+  role: TokenRole;
   /**
-   * Whether to expose the curated-write tools (upsert_context,
-   * resolve_correction). FALSE = propose-only: the agent surface is read
-   * tools + report_correction, whose proposals are inert (pending) until a
-   * human accepts them. This is the membrane (I2/I9): an agent reading
-   * untrusted lake/Slack content is prompt-injectable, so it must not hold a
-   * tool that COMMITS curated knowledge — injection attacks the agent's
-   * decision, not its credential. Analyst tokens are always propose-only;
-   * `canWrite` is granted only to a separate **curator token**, which is in
-   * turn forbidden from reading the lake (see `denyLakeRead`). The two
-   * capabilities — commit knowledge, read untrusted bulk text — never coexist
-   * on one session, by enforcement. The human accept path is the web approval
-   * surface; curator tokens drive /setoku:generate and /setoku:curate.
-   */
-  canWrite: boolean;
-  /**
-   * Block `run_query` on the `clickhouse` dialect (the lake). Set TRUE for
-   * curator sessions: a session that can COMMIT curated knowledge must not be
-   * able to READ the bulk, attacker-controlled free text in the lake — that
-   * removes the injection vector that could weaponize the write tools. Curator
-   * sessions read only the business Postgres (to validate metric SQL) and the
-   * agent's own codebase (outside the gateway). Analyst sessions are the
-   * inverse: they read the lake but hold no write tool.
-   */
-  denyLakeRead: boolean;
-  /**
-   * Expose `draft_correction` — a DRAFT-ONLY capability (curation-cockpit piece
-   * B). It writes a drafted doc-edit + advisory flags onto a pending correction
-   * but touches NO curated doc: a draft grants zero authority. This is the
-   * auto-draft janitor's only write. Crucially it is NOT `upsert_context`: even
-   * though the drafting agent reads untrusted pending content, the worst it can
-   * do is propose a draft a human must still bless. Granted to the janitor
-   * token, never the analyst (no write at all) or the curator (commits directly).
-   */
-  canDraft?: boolean;
-  /**
-   * Expose `reject_correction` — a REJECT-ONLY capability (curation-cockpit piece
-   * C). It resolves a pending correction to `rejected` and nothing else: removing
-   * from the queue grants no authority (unlike accept, which commits knowledge —
-   * deliberately NOT an MCP tool). Splitting reject out of the accept-or-reject
-   * space is the whole safety argument; the janitor holds this, never accept.
-   */
-  canReject?: boolean;
-  /**
-   * The process-wide semantic index (I8 opt-in local embeddings). When present
-   * and enabled, `find_context` fuses embedding similarity with keyword retrieval
-   * (hybrid). Null/absent/disabled → keyword retrieval only (graceful fallback).
-   * Shared across per-request servers, like `store`.
+   * The process-wide semantic index (local embeddings). When enabled,
+   * `find_context` fuses embedding similarity with keyword retrieval (hybrid).
+   * Null/disabled → keyword retrieval only (graceful fallback). Shared across
+   * per-request servers, like `store`.
    */
   embedIndex?: EmbedIndex | null;
 }
@@ -86,12 +88,10 @@ export function buildServer({
   projectDir,
   store,
   user,
-  canWrite,
-  denyLakeRead,
-  canDraft = false,
-  canReject = false,
+  role,
   embedIndex = null,
 }: GatewayDeps): McpServer {
+const { canWrite, denyLakeRead, canDraft, canReject } = capabilitiesFor(role);
 const server = new McpServer({ name: "setoku", version: VERSION });
 
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] });

--- a/plugin/gateway/http.ts
+++ b/plugin/gateway/http.ts
@@ -27,7 +27,7 @@ import http from "node:http";
 import path from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 
-import { buildServer } from "./app";
+import { buildServer, type TokenRole } from "./app";
 import { EmbedIndex } from "./lib/embed-index";
 import { loadConfig, resolveProjectDir } from "./lib/config";
 import {
@@ -112,39 +112,36 @@ function storePath(): string {
 
 interface TokenInfo {
   identity: string;
-  /** curator tokens may commit curated knowledge but cannot read the lake. */
-  curator: boolean;
   /**
-   * Janitor tokens (the auto-draft/auto-reject job, curation-cockpit B/C). They
-   * hold ONLY draft + reject capabilities — both of which grant zero knowledge
-   * authority — never `upsert_context` or any accept path. So even though the
-   * janitor reads untrusted pending content, it cannot commit; the human /admin
-   * click remains the only door into curated context (the membrane, I2/I9).
+   * The token's capability role (the membrane, I2/I9). EXACTLY one value, so a
+   * token can never be both curator and janitor: analyst (reads lake, propose-
+   * only), curator (commits knowledge, no lake), janitor (draft+reject only).
+   * Each source env maps to a single role.
    */
-  janitor?: boolean;
+  role: TokenRole;
 }
 
 function loadTokens(): Map<string, TokenInfo> {
   const tokens = new Map<string, TokenInfo>();
-  const add = (spec: string | undefined, info: Omit<TokenInfo, "identity">): void => {
+  const add = (spec: string | undefined, role: TokenRole): void => {
     for (const pair of (spec ?? "").split(",")) {
       const i = pair.indexOf("=");
       if (i > 0)
         tokens.set(pair.slice(0, i).trim(), {
           identity: pair.slice(i + 1).trim(),
-          ...info,
+          role,
         });
     }
   };
-  add(process.env.SETOKU_TOKENS, { curator: false });
-  add(process.env.SETOKU_CURATOR_TOKENS, { curator: true });
-  add(process.env.SETOKU_JANITOR_TOKENS, { curator: false, janitor: true });
+  add(process.env.SETOKU_TOKENS, "analyst");
+  add(process.env.SETOKU_CURATOR_TOKENS, "curator");
+  add(process.env.SETOKU_JANITOR_TOKENS, "janitor");
   const file = process.env.SETOKU_TOKENS_FILE;
   if (file && fs.existsSync(file)) {
     for (const [token, identity] of Object.entries(
       JSON.parse(fs.readFileSync(file, "utf8")),
     )) {
-      tokens.set(token, { identity: String(identity), curator: false });
+      tokens.set(token, { identity: String(identity), role: "analyst" });
     }
   }
   return tokens;
@@ -172,7 +169,7 @@ function mintToken(): string {
  * surface never mints curator/write capability (that stays an operator action).
  */
 function addAnalystToken(token: string, identity: string): { persisted: boolean } {
-  tokens.set(token, { identity, curator: false });
+  tokens.set(token, { identity, role: "analyst" });
   const file = process.env.SETOKU_TOKENS_FILE;
   if (!file) return { persisted: false };
   let map: Record<string, string> = {};
@@ -205,7 +202,8 @@ function removeAnalystTokens(identity: string): { removed: number; envBacked: bo
   let removed = 0;
   let envBacked = false;
   for (const [tok, info] of [...tokens]) {
-    if (info.curator || info.identity !== identity) continue;
+    // only revoke analyst tokens for this identity (never curator/janitor)
+    if (info.role !== "analyst" || info.identity !== identity) continue;
     tokens.delete(tok);
     removed++;
     if (tok in fileMap) delete fileMap[tok];
@@ -215,9 +213,10 @@ function removeAnalystTokens(identity: string): { removed: number; envBacked: bo
   return { removed, envBacked };
 }
 
-/** Analyst (non-curator) identities currently provisioned — for the Team page. */
+/** Analyst identities currently provisioned — for the Team page (curator/janitor
+ *  are operator-held, not team members). */
 function analystIdentities(): string[] {
-  return [...new Set([...tokens.values()].filter((t) => !t.curator).map((t) => t.identity))].sort();
+  return [...new Set([...tokens.values()].filter((t) => t.role === "analyst").map((t) => t.identity))].sort();
 }
 
 const store = new KnowledgeStore(process.env.SETOKU_DB_PATH ?? storePath());
@@ -1296,19 +1295,13 @@ const httpServer = http.createServer(async (req, res) => {
     }
     // Stateless: a fresh McpServer per request, identity bound from the token.
     // Shared state lives in the SQLite store (WAL), not the server instance.
-    // Analyst tokens are propose-only (canWrite:false) and may read the lake.
-    // Curator tokens may commit curated knowledge (canWrite) but are blocked
-    // from reading the lake (denyLakeRead) — the two never coexist (I2/I9).
+    // The token's role IS the membrane (I2/I9): capabilities are derived from it,
+    // so commit-knowledge and read-the-lake can never coexist on one session.
     const server = buildServer({
       projectDir,
       store,
       user: auth.identity,
-      canWrite: auth.curator,
-      denyLakeRead: auth.curator,
-      // the janitor holds draft + reject only — both grant zero authority — so it
-      // can read untrusted pending content without ever committing knowledge.
-      canDraft: auth.janitor === true,
-      canReject: auth.janitor === true,
+      role: auth.role,
       embedIndex,
     });
     const transport = new StreamableHTTPServerTransport({

--- a/test/roles.test.ts
+++ b/test/roles.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * The I2/I9 membrane as a type: capabilities are DERIVED from a single role, so
+ * the forbidden combination — commit curated knowledge AND read the untrusted
+ * lake on one session — is unrepresentable. These tests assert no role can ever
+ * yield it (previously four free booleans left that one careless call-site away).
+ */
+import { describe, expect, it } from "bun:test";
+import { capabilitiesFor, type TokenRole } from "../plugin/gateway/app";
+
+const ROLES: TokenRole[] = ["analyst", "curator", "janitor"];
+
+describe("capability membrane (capabilitiesFor)", () => {
+  it("NO role can both commit knowledge and read the lake", () => {
+    for (const role of ROLES) {
+      const c = capabilitiesFor(role);
+      expect(c.canWrite && !c.denyLakeRead).toBe(false); // the forbidden combo
+    }
+  });
+
+  it("curator commits knowledge but is barred from the lake", () => {
+    const c = capabilitiesFor("curator");
+    expect(c).toEqual({ canWrite: true, denyLakeRead: true, canDraft: false, canReject: false });
+  });
+
+  it("analyst reads the lake, holds no write/draft/reject", () => {
+    const c = capabilitiesFor("analyst");
+    expect(c).toEqual({ canWrite: false, denyLakeRead: false, canDraft: false, canReject: false });
+  });
+
+  it("janitor holds draft+reject only (zero authority), may read pending text", () => {
+    const c = capabilitiesFor("janitor");
+    expect(c).toEqual({ canWrite: false, denyLakeRead: false, canDraft: true, canReject: true });
+  });
+});


### PR DESCRIPTION
Part of #34 (make illegal states unrepresentable).

The I2/I9 membrane was four free booleans (`canWrite`, `denyLakeRead`, `canDraft`, `canReject`) on `GatewayDeps`, kept consistent by a single call site. `canWrite:true + denyLakeRead:false` — commit knowledge **and** read the untrusted lake — was representable and one careless `buildServer({...})` from breaking, with green tests.

Now a single **`TokenRole`** (`analyst | curator | janitor`) is the membrane:
- `GatewayDeps` takes `role`; capabilities are **derived** (`capabilitiesFor`), never passed. The forbidden combination has no representation.
- `TokenInfo` carries one role (a token can't be both curator and janitor); each source env maps to exactly one.
- `buildServer` is unchanged internally — it destructures the derived caps.
- Test asserts no role yields `canWrite && !denyLakeRead`.

Net −/+ is roughly flat (removed boolean plumbing, added the role + one switch). #3 (account role) is already guarded at the boundary by `isRole`; #4 (relates_to vs links) is a real ownership-vs-reference distinction, not a duplication — both intentionally left. Next: #2 (Correction status union).