### PR TITLE
Corrections: discriminated union on status (#34)

### DIFF
--- a/plugin/gateway/lib/approval.ts
+++ b/plugin/gateway/lib/approval.ts
@@ -51,7 +51,7 @@ function gotchaDocName(relatesTo: string | null | undefined, fact: string): stri
  * RENDERING the pending queue (the cockpit shows this as the editable draft).
  */
 export function defaultDraft(corr: Correction): CorrectionDraft | null {
-  if (corr.draft) return corr.draft;
+  if (corr.status === "pending" && corr.draft) return corr.draft;
   if (corr.kind === "gotcha") {
     // store only the concise FACT as knowledge (#10, avenue 1); the supporting
     // context stays in the corrections record, not the gotcha doc.

--- a/plugin/gateway/lib/store.ts
+++ b/plugin/gateway/lib/store.ts
@@ -43,7 +43,10 @@ export interface CorrectionDraft {
   meta: Record<string, string | string[]>;
 }
 
-export interface Correction {
+export type CorrectionStatus = "pending" | "accepted" | "rejected";
+
+/** Fields every correction has, regardless of lifecycle stage. */
+interface CorrectionBase {
   id: number;
   ts: string;
   user: string;
@@ -55,21 +58,38 @@ export interface Correction {
    *  proposals, where `content` is used as the savable text instead. */
   fact: string | null;
   relatesTo: string | null;
-  status: "pending" | "accepted" | "rejected";
-  /** The drafted doc-edit approving this would commit (cockpit). Null = undrafted.
-   *  Optional on the in-memory shape (test fixtures omit it); rowToCorrection
-   *  always populates it from the DB. */
+}
+
+/**
+ * A correction is a discriminated union on `status`, so the status-dependent
+ * fields can't disagree with the lifecycle stage (#34): a *pending* item may
+ * carry a draft + advisory flags; a *rejected* item ALWAYS has a reason; an
+ * *accepted* item carries neither. "Rejected with no reason" / "pending with a
+ * reject reason" / "accepted still carrying a draft" are unrepresentable. The
+ * sole constructor is `rowToCorrection`; the JSON served to the admin UI is
+ * flattened back to one shape at the wire boundary, so this is gateway-internal.
+ */
+export interface PendingCorrection extends CorrectionBase {
+  status: "pending";
+  /** The drafted doc-edit approving this would commit (cockpit). Null = undrafted. */
   draft?: CorrectionDraft | null;
   /** Advisory flags from the auto-draft/lint pass: dupe, contradiction, lint, provenance. */
   flags?: string[];
   /** Who drafted (the draft-only janitor identity), and when. Null = undrafted. */
   draftedBy?: string | null;
   draftedTs?: string | null;
-  /** True when the auto-reject janitor (not a human) rejected it — soft + reversible. */
-  rejectedByBot?: boolean;
-  /** Why it was rejected (janitor reason or human reason). */
-  rejectReason?: string | null;
 }
+export interface AcceptedCorrection extends CorrectionBase {
+  status: "accepted";
+}
+export interface RejectedCorrection extends CorrectionBase {
+  status: "rejected";
+  /** Why it was rejected — REQUIRED (a rejected correction always has a reason). */
+  rejectReason: string;
+  /** True when the auto-reject janitor (not a human) rejected it — soft + reversible. */
+  rejectedByBot: boolean;
+}
+export type Correction = PendingCorrection | AcceptedCorrection | RejectedCorrection;
 
 /** A local account for the web admin surface (Phase 5.1). */
 export interface Account {
@@ -548,6 +568,12 @@ export class KnowledgeStore {
     );
   }
 
+  // Overloads narrow the result to the variant matching the requested status, so
+  // callers get e.g. PendingCorrection[] (with `draft`) without re-narrowing.
+  listCorrections(status: "pending"): PendingCorrection[];
+  listCorrections(status: "accepted"): AcceptedCorrection[];
+  listCorrections(status: "rejected"): RejectedCorrection[];
+  listCorrections(status?: string): Correction[];
   listCorrections(status: string = "pending"): Correction[] {
     const rows = this.db
       .query(
@@ -1208,6 +1234,25 @@ function rowToCorrection(row: Record<string, unknown>): Correction {
       return fallback;
     }
   };
+  const base: CorrectionBase = {
+    id: Number(row.id),
+    ts: String(row.ts),
+    user: String(row.user),
+    kind: String(row.kind),
+    content: String(row.content ?? ""),
+    fact: (row.fact as string) ?? null,
+    relatesTo: (row.relates_to as string) ?? null,
+  };
+  const status = row.status as CorrectionStatus;
+  if (status === "rejected")
+    return {
+      ...base,
+      status,
+      // rejectCorrection always sets a reason; default keeps the type honest.
+      rejectReason: (row.reject_reason as string) ?? "",
+      rejectedByBot: !!row.rejected_by_bot,
+    };
+  if (status === "accepted") return { ...base, status };
   const draftName = row.draft_name as string | null;
   const draft: CorrectionDraft | null =
     row.draft_type && draftName
@@ -1219,20 +1264,12 @@ function rowToCorrection(row: Record<string, unknown>): Correction {
         }
       : null;
   return {
-    id: Number(row.id),
-    ts: String(row.ts),
-    user: String(row.user),
-    kind: String(row.kind),
-    content: String(row.content ?? ""),
-    fact: (row.fact as string) ?? null,
-    relatesTo: (row.relates_to as string) ?? null,
-    status: row.status as Correction["status"],
+    ...base,
+    status: "pending",
     draft,
     flags: parse<string[]>(row.flags, []),
     draftedBy: (row.drafted_by as string) ?? null,
     draftedTs: (row.drafted_ts as string) ?? null,
-    rejectedByBot: !!row.rejected_by_bot,
-    rejectReason: (row.reject_reason as string) ?? null,
   };
 }
 

--- a/test/cockpit.test.ts
+++ b/test/cockpit.test.ts
@@ -93,8 +93,8 @@ describe("cockpit: draft + flags persistence (piece B)", () => {
     );
     expect(ok).toBe(true);
     expect(store.docCount).toBe(0); // a draft commits nothing
-    const corr = store.getCorrection(id)!;
-    expect(corr.status).toBe("pending");
+    const corr = store.getCorrection(id);
+    if (corr?.status !== "pending") throw new Error("expected a pending correction");
     expect(corr.draft?.body).toBe("SELECT 1");
     expect(corr.flags).toEqual(["lint", "dupe"]);
     expect(corr.draftedBy).toBe("janitor@bot");
@@ -108,8 +108,8 @@ describe("cockpit: reject is soft, audited, reversible (piece C)", () => {
     const store = freshStore();
     const id = store.addCorrection({ user: "a", kind: "gotcha", fact: "noise" });
     applyApprovalAction(store, "boss", { id, action: "rejected", reason: "duplicate of existing" });
-    const corr = store.getCorrection(id)!;
-    expect(corr.status).toBe("rejected");
+    const corr = store.getCorrection(id);
+    if (corr?.status !== "rejected") throw new Error("expected a rejected correction");
     expect(corr.rejectReason).toBe("duplicate of existing");
     expect(corr.rejectedByBot).toBe(false);
   });
@@ -118,14 +118,13 @@ describe("cockpit: reject is soft, audited, reversible (piece C)", () => {
     const store = freshStore();
     const id = store.addCorrection({ user: "a", kind: "gotcha", fact: "maybe good" });
     expect(store.rejectCorrection(id, "drafted SQL errors", "janitor@bot", true)).toBe(true);
-    let corr = store.getCorrection(id)!;
-    expect(corr.status).toBe("rejected");
-    expect(corr.rejectedByBot).toBe(true);
+    const rejected = store.getCorrection(id);
+    if (rejected?.status !== "rejected") throw new Error("expected a rejected correction");
+    expect(rejected.rejectedByBot).toBe(true);
 
     expect(store.unrejectCorrection(id, "boss")).toBe(true);
-    corr = store.getCorrection(id)!;
-    expect(corr.status).toBe("pending");
-    expect(corr.rejectedByBot).toBe(false);
-    expect(corr.rejectReason).toBeNull();
+    // back to pending — a pending correction simply has no reject info (the union
+    // makes "pending with a reject reason" unrepresentable).
+    expect(store.getCorrection(id)?.status).toBe("pending");
   });
 });

--- a/test/facts.test.ts
+++ b/test/facts.test.ts
@@ -4,7 +4,7 @@ import { Database } from "bun:sqlite";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { KnowledgeStore, type Correction, type KnowledgeDoc } from "../plugin/gateway/lib/store";
+import { KnowledgeStore, type PendingCorrection, type KnowledgeDoc } from "../plugin/gateway/lib/store";
 import {
   buildKnowledgeView,
   compact,
@@ -33,7 +33,7 @@ function doc(over: Partial<KnowledgeDoc> & { name: string; type: KnowledgeDoc["t
   };
 }
 
-function correction(over: Partial<Correction> & { id: number; content: string }): Correction {
+function correction(over: Partial<PendingCorrection> & { id: number; content: string }): PendingCorrection {
   return {
     ts: "2026-01-02T00:00:00Z",
     user: "analyst@example.com",


### PR DESCRIPTION
Part of #34 — the bounded (gateway-internal) version you chose.

`Correction` becomes `Pending | Accepted | Rejected`:
- pending may carry a draft + advisory flags; **rejected ALWAYS has a reason**; accepted carries neither.
- 'rejected with no reason', 'pending with a reject reason', 'accepted still holding a draft' no longer typecheck.

Implementation is contained: `rowToCorrection` (the sole constructor) builds the right variant; `listCorrections` gets per-status overloads so callers receive the precise variant. The persisted state machine was already enforced atomically at the store (rejectCorrection sets status+reason together, etc.), so this is **defense-in-depth against future gateway code** — and it does **not** change the wire/UI: each variant serializes with exactly the fields the admin UI reads per section (pending→draft/flags, rejected→reject info), confirmed by the HTTP e2e and a UI read audit.

4 files, +68/−32; typecheck clean; 216 tests pass (cockpit/facts narrowed to variants). No web rebuild (UI untouched).