### PR TITLE
Teach the knowledge write path about meta.links

### DIFF
--- a/docs/knowledge-conventions.md
+++ b/docs/knowledge-conventions.md
@@ -58,7 +58,10 @@ Link generously; the graph is what makes retrieval and navigation work:
 - **entity → entities it joins to** (`Order` → `Customer`) and its gotchas.
 - **overview → the top entities and metrics** (it's the hub).
 - A new doc should link to its obvious neighbors *as it's written* — that's the
-  "ingest reconciles neighbors" discipline.
+  "ingest reconciles neighbors" discipline. Note the curated-write path
+  (`upsert_context`) rejects a save whose links don't resolve to an existing
+  doc, so save link *targets* before the docs that point at them (overview
+  last), or add the link when the target lands.
 
 Lint will flag the failures of this convention:
 - **orphan** — a canonical doc with no link in or out (connect it to the graph).

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -17,7 +17,7 @@ import {
 } from "./lib/config";
 import { diagnoseNoTables, introspectSchema } from "./lib/db";
 import { runLakeQuery } from "./lib/lake";
-import { buildLinkGraph, matchByTokens, retrieve, selectGotchas } from "./lib/search";
+import { buildLinkGraph, docRef, matchByTokens, retrieve, selectGotchas } from "./lib/search";
 import { synonymsOf } from "./lib/synonyms";
 import type { EmbedIndex } from "./lib/embed-index";
 import { KnowledgeStore, type AppPanel, type DocType } from "./lib/store";
@@ -503,7 +503,9 @@ server.registerTool(
       "Used by the /setoku:generate and /setoku:curate workflows — do NOT use it mid-analysis to record " +
       "unreviewed beliefs (use report_correction for that). Attribution and a revision history are kept automatically. " +
       "For entities pass meta.table (e.g. public.orders), meta.summary, meta.keywords. For metrics include the " +
-      "canonical SQL in the body. For gotchas put the one-liner in body (name can be a short slug).",
+      "canonical SQL in the body. For gotchas put the one-liner in body (name can be a short slug). " +
+      "Set meta.links (array of exact doc names) to interlink related docs — join targets, the metrics an " +
+      "entity feeds, the entities a metric reads. Links must resolve to existing docs or the save is rejected.",
     inputSchema: {
       type: z.enum(["entity", "metric", "query", "overview", "gotcha"]),
       name: z
@@ -514,7 +516,7 @@ server.registerTool(
         .record(z.union([z.string(), z.array(z.string())]))
         .optional()
         .describe(
-          "Frontmatter-style fields: table, summary, keywords, question, sources",
+          "Frontmatter-style fields: table, summary, keywords, question, sources, links (array of doc names this doc references)",
         ),
     },
   },
@@ -537,7 +539,9 @@ server.registerTool(
       ...store.listDocs().filter((d) => !(d.type === type && d.name === name)),
       incoming,
     ];
-    const bad = buildLinkGraph(prospective).unresolved.filter((u) => u.from === name);
+    const bad = buildLinkGraph(prospective).unresolved.filter(
+      (u) => u.fromRef === docRef(incoming),
+    );
     if (bad.length)
       return errorText(
         `Won't save: ${bad.length} link(s) don't resolve to a doc — ${bad.map((b) => `"${b.ref}"`).join(", ")}. ` +
@@ -580,7 +584,9 @@ server.registerTool(
       meta: z
         .record(z.union([z.string(), z.array(z.string())]))
         .optional()
-        .describe("Frontmatter fields: table, summary, keywords, relates_to, expect, unit"),
+        .describe(
+          "Frontmatter fields: table, summary, keywords, relates_to, expect, unit, links (array of existing doc names the drafted doc references)",
+        ),
       flags: z
         .array(z.string())
         .optional()

--- a/plugin/gateway/lib/search.ts
+++ b/plugin/gateway/lib/search.ts
@@ -168,8 +168,10 @@ export interface LinkGraph {
   out: Map<string, Set<string>>;
   /** DocRef → DocRefs that link TO it (inbound / backlinks). */
   back: Map<string, Set<string>>;
-  /** Declared refs that resolved to no doc OR were ambiguous — broken links. */
-  unresolved: { from: string; ref: string }[];
+  /** Declared refs that resolved to no doc OR were ambiguous — broken links.
+   *  `from` is the declaring doc's name (display); `fromRef` its DocRef, so
+   *  same-named docs across types don't blur together. */
+  unresolved: { from: string; fromRef: string; ref: string }[];
   /** DocRef → original-case doc name, for display. */
   nameOf: Map<string, string>;
 }
@@ -217,7 +219,7 @@ export function buildLinkGraph(docs: ScorableDoc[]): LinkGraph {
 
   const out = new Map<string, Set<string>>();
   const back = new Map<string, Set<string>>();
-  const unresolved: { from: string; ref: string }[] = [];
+  const unresolved: { from: string; fromRef: string; ref: string }[] = [];
   for (const d of docs) {
     out.set(docRef(d), new Set());
     back.set(docRef(d), new Set());
@@ -227,7 +229,7 @@ export function buildLinkGraph(docs: ScorableDoc[]): LinkGraph {
     for (const ref of rawLinks(d)) {
       const target = resolveLinkRef(ref, byName, byTable, refs);
       if (!target || target === from) {
-        if (!target) unresolved.push({ from: d.name, ref });
+        if (!target) unresolved.push({ from: d.name, fromRef: from, ref });
         continue;
       }
       out.get(from)!.add(target);

--- a/plugin/skills/curate/SKILL.md
+++ b/plugin/skills/curate/SKILL.md
@@ -23,6 +23,7 @@ You are helping a **curator** — typically a business user, not a developer —
    - `entity` → update the relevant entity doc (fetch current body with `describe_entity`, edit, re-save)
    - `query` → new query doc
    - Preserve attribution in the body when it matters ("per ops team, 2026-06").
+   - Keep the wiki connected: when saving, set/extend `meta.links` (array of exact doc names — join targets, the entities a metric reads). Links must resolve to existing docs or the save is rejected. Fetching-then-resaving a doc? Carry its existing meta (including links) forward — `upsert_context` replaces meta wholesale.
 4. **Resolve each candidate:** `resolve_correction` with accepted or rejected. (Accept without the matching `upsert_context` loses the knowledge — always do both.)
 5. **Summarize:** accepted / edited / rejected, and what got better.
 

--- a/plugin/skills/generate/SKILL.md
+++ b/plugin/skills/generate/SKILL.md
@@ -27,7 +27,7 @@ Save each via `upsert_context` (curator) **or** `report_correction` (analyst —
 supporting detail, and `relates_to` to the entity/metric name).
 The structure below is the *content* to produce either way.
 
-**entity** — one per business-relevant table (skip pure join/system tables). `meta`: `table` (qualified, e.g. `public.orders`), `summary` (one line), `keywords` (synonyms users say). Body sections:
+**entity** — one per business-relevant table (skip pure join/system tables). `meta`: `table` (qualified, e.g. `public.orders`), `summary` (one line), `keywords` (synonyms users say), `links` (see **Interlinking** below). Body sections:
 
 ```markdown
 ## Semantics
@@ -47,13 +47,17 @@ customer_id → public.customers.id (the buyer). One order : many order_items.
 - prisma/schema.prisma:120 (model definition)
 ```
 
-**metric** — canonical business numbers. `meta`: `summary`, `keywords`. Body: `## Definition` (prose), `## Canonical SQL` (fenced sql block — the exact production logic), `## Caveats`, `## Sources` (file:line).
+**metric** — canonical business numbers. `meta`: `summary`, `keywords`, `links` (the entities its SQL reads). Body: `## Definition` (prose), `## Canonical SQL` (fenced sql block — the exact production logic), `## Caveats`, `## Sources` (file:line).
 
-**query** — known-good SQL for a recurring question. `meta`: `question`, `keywords`. Body: fenced sql.
+**query** — known-good SQL for a recurring question. `meta`: `question`, `keywords`, `links` (the entities/metrics it touches). Body: fenced sql.
 
 **gotcha** — one-liner traps, each self-contained with its source. `name` = short slug, `body` = the line, e.g. `Customers with deleted_at set are soft-deleted — exclude from all counts (src/models/customer.ts:12)`.
 
-**overview** — 10–20 lines: what the business does, core objects, money flow.
+**overview** — 10–20 lines: what the business does, core objects, money flow. `meta.links`: the core entities and headline metrics — the overview is the hub of the wiki.
+
+## Interlinking (`meta.links`)
+
+The store is a wiki: `meta.links` is an array of **exact doc names** this doc references, and it's what makes docs retrievable by association (`/admin/knowledge` graphs it; entity/metric/query docs with no links in or out are flagged as orphans — overviews and gotchas are exempt). Link an entity to its join targets and the metrics computed from it; link a metric to the entities its SQL reads; link the overview to the core entities/metrics. Every entity/metric/query doc should have at least one link. On a curator connector, links are validated at save time — a ref that resolves to no doc (or is ambiguous) rejects the save, so save link *targets* before the docs that point at them (overview last). Use `type:name` when a name is shared across types. On the analyst connector, `report_correction` has no links field — `relates_to` is its one link mechanism (a gotcha's `relates_to` counts as a link automatically); full `meta.links` get added when a curator pass shapes the accepted proposals into docs.
 
 ## Process
 

--- a/test/wiki-retrieval.test.ts
+++ b/test/wiki-retrieval.test.ts
@@ -46,7 +46,7 @@ describe("buildLinkGraph (keyed by DocRef)", () => {
 
   it("records a declared link that resolves to no doc as broken", () => {
     const g = buildLinkGraph(DOCS);
-    expect(g.unresolved).toContainEqual({ from: "Order", ref: "Coupon" });
+    expect(g.unresolved).toContainEqual({ from: "Order", fromRef: "entity:order", ref: "Coupon" });
   });
 
   it("neighbors() is the undirected 1-hop set", () => {
@@ -76,7 +76,7 @@ describe("DocRef identity — same name across types can't merge", () => {
       ...collide,
       { type: "query", name: "q", meta: { links: ["revenue"] }, body: "" },
     ];
-    expect(buildLinkGraph(ambiguous).unresolved).toContainEqual({ from: "q", ref: "revenue" });
+    expect(buildLinkGraph(ambiguous).unresolved).toContainEqual({ from: "q", fromRef: "query:q", ref: "revenue" });
     const explicit: ScorableDoc[] = [
       ...collide,
       { type: "query", name: "q", meta: { links: ["metric:revenue"] }, body: "" },


### PR DESCRIPTION
## Why

The wiki-links feature (d580b57, #32) added link storage, the `/admin/knowledge` graph, and orphan/broken-link lints — but nothing in the **write path** ever mentioned links. `upsert_context`'s meta description listed only `table, summary, keywords, question, sources`, and the generate/curate skills never instructed linking. Result: every generated doc was born an orphan, and the live boxes render all-orphan graphs with zero edges.

## What

**Docs/instructions (the main fix):**
- `upsert_context` and `draft_correction` meta descriptions now document `meta.links` (exact doc names, validated at save time).
- `generate` skill: `links` added to each doc type's meta list + a new **Interlinking** section — entities link to join targets and the metrics computed from them, metrics to the entities their SQL reads, overview is the hub; save link targets before linkers; analyst-path caveat (`report_correction` has no links field — `relates_to` is its one link mechanism).
- `curate` skill: set/extend `meta.links` when applying candidates, and carry existing meta forward — `upsertDoc` replaces meta wholesale.
- `docs/knowledge-conventions.md`: note that the curated-write path rejects unresolved links, so link targets must exist first.

## Review findings fixed along the way

`upsert_context`'s link validation filtered `buildLinkGraph(...).unresolved` by **bare doc name**, so a same-named doc of another type carrying a pre-existing broken link would falsely reject an unrelated save (and the suggested `type:name` fix couldn't clear it, since the filter never used type). `unresolved` entries now carry `fromRef` (a DocRef) and the filter keys on it. Tests updated.

## Testing

- `bun run typecheck` clean
- `bun test` — 266 pass, 0 fail