### PR TITLE
gateway: success-path capture nudges — prompt report_correction when it matters (v0.20.0)

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "setoku",
   "displayName": "Setoku",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Governed agentic BI on your Claude subscription. Setoku gives Claude a verified business-context layer (derived from your codebase) plus read-only, audited access to your database \u2014 so it answers business questions accurately instead of guessing from column names.",
   "author": {
     "name": "Hedgy Labs"

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -130,10 +130,16 @@ function requireDb(config: SetokuConfig): string {
   return res.url;
 }
 
-/** Every ```sql fence in the curated store — what "already covered" means for
- *  the success-path capture nudges (lib/nudge). Cheap at curated-store scale. */
+/** The ```sql fences of METRIC/QUERY docs — what "already covered" means for
+ *  the success-path capture nudges (lib/nudge). Scoped to the doc types that
+ *  define numbers: an illustrative fence in an entity/gotcha doc is context,
+ *  not a metric, and must not suppress the capture hint. Passed as a thunk so
+ *  the nudge helpers only scan the store once their cheap gates pass. */
 function curatedSqls(): string[] {
-  return store.listDocs().flatMap((d) => extractSql(d.body));
+  return store
+    .listDocs()
+    .filter((d) => d.type === "metric" || d.type === "query")
+    .flatMap((d) => extractSql(d.body));
 }
 
 const NO_KNOWLEDGE_HINT =
@@ -946,7 +952,7 @@ server.registerTool(
       // validated. (The empty-store warning below owns docCount === 0; nudging
       // on failed or zero-row queries would just coach retries.)
       if (store.docCount > 0 && result.rowCount > 0) {
-        const nudge = queryCaptureNudge(sql, curatedSqls());
+        const nudge = queryCaptureNudge(sql, curatedSqls);
         if (nudge) lines.push("", nudge);
       }
       // No curated context yet → the agent is querying from raw schema, which is
@@ -1108,7 +1114,7 @@ function publishNotes(html: string, panels: AppPanel[]): string {
   const noDesc = panels.filter((p) => !p.description?.trim()).map((p) => p.key);
   if (noDesc.length)
     notes.push(`panel(s) ${noDesc.map((k) => `"${k}"`).join(", ")} have no \`description\` — the drawer can't explain what they compute. Add a one-line description.`);
-  const capture = panelCaptureNote(panels, curatedSqls());
+  const capture = panelCaptureNote(panels, curatedSqls);
   if (capture) notes.push(capture);
   notes.push(...lintAppTemplate(html, panels.map((p) => p.key)));
   return notes.length ? `\n\n⚠ Heads up (publishes anyway):\n- ${notes.join("\n- ")}` : "";

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -25,6 +25,8 @@ import { KnowledgeStore, type AppPanel, type DocType } from "./lib/store";
 import { MAX_PANELS, MIN_REFRESH_SECONDS, MAX_REFRESH_SECONDS, DEFAULT_REFRESH_SECONDS, runPanel, compilePanel, isFullDoc } from "./lib/apps";
 import { resolveParams, paramsVariant, type AppParam } from "./lib/params";
 import { lintAppTemplate } from "./lib/app-runtime";
+import { extractSql } from "./lib/lint";
+import { queryCaptureNudge, panelCaptureNote } from "./lib/nudge";
 import { LAKE_SOURCES } from "./lib/sources";
 import { VERSION } from "./lib/version";
 
@@ -126,6 +128,12 @@ function requireDb(config: SetokuConfig): string {
   const res = resolveDatabaseUrl(projectDir, config);
   if (!res.ok) throw new Error(res.error);
   return res.url;
+}
+
+/** Every ```sql fence in the curated store — what "already covered" means for
+ *  the success-path capture nudges (lib/nudge). Cheap at curated-store scale. */
+function curatedSqls(): string[] {
+  return store.listDocs().flatMap((d) => extractSql(d.body));
 }
 
 const NO_KNOWLEDGE_HINT =
@@ -933,6 +941,14 @@ server.registerTool(
         "",
         `${result.rowCount} row(s) in ${result.ms}ms${result.truncated ? ` — TRUNCATED at row cap (${config.rowCap}); add aggregation or LIMIT` : ""}`,
       );
+      // Success-path capture nudge: the query worked AND computed an aggregate
+      // no curated metric covers — the one moment the definition is fresh and
+      // validated. (The empty-store warning below owns docCount === 0; nudging
+      // on failed or zero-row queries would just coach retries.)
+      if (store.docCount > 0 && result.rowCount > 0) {
+        const nudge = queryCaptureNudge(sql, curatedSqls());
+        if (nudge) lines.push("", nudge);
+      }
       // No curated context yet → the agent is querying from raw schema, which is
       // exactly when it confidently returns a wrong number (test accounts not
       // excluded, refunds not netted, status-vs-event-log confusion). Make that
@@ -1092,6 +1108,8 @@ function publishNotes(html: string, panels: AppPanel[]): string {
   const noDesc = panels.filter((p) => !p.description?.trim()).map((p) => p.key);
   if (noDesc.length)
     notes.push(`panel(s) ${noDesc.map((k) => `"${k}"`).join(", ")} have no \`description\` — the drawer can't explain what they compute. Add a one-line description.`);
+  const capture = panelCaptureNote(panels, curatedSqls());
+  if (capture) notes.push(capture);
   notes.push(...lintAppTemplate(html, panels.map((p) => p.key)));
   return notes.length ? `\n\n⚠ Heads up (publishes anyway):\n- ${notes.join("\n- ")}` : "";
 }

--- a/plugin/gateway/lib/nudge.ts
+++ b/plugin/gateway/lib/nudge.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Success-path knowledge-capture nudges — pure, so they unit-test without a box.
+ *
+ * The empty-store warnings (run_query, find_context) prompt hardest when the
+ * store knows least and go silent the moment retrieval starts hitting — which
+ * is exactly when real usage produces the most learnable material. Measured on
+ * the pilot: correction intake died the week the store stopped being empty,
+ * while query volume kept growing. These helpers put a hint in the SUCCESS
+ * path instead: when a query (or a published app panel) just computed a
+ * business aggregate that no curated metric covers, the tool result carries a
+ * one-line report_correction suggestion at the moment the SQL is fresh and
+ * validated. Propose-only (lands as pending, human approves) — the membrane
+ * (I2/I9) is untouched.
+ */
+
+/** Collapse whitespace/comments/case so cosmetically different SQL compares equal. */
+export function normalizeSql(sql: string): string {
+  return sql
+    .replace(/--[^\n]*/g, " ")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/;+$/, "")
+    .trim()
+    .toLowerCase();
+}
+
+/** Schema/metadata exploration — never worth capturing as a metric. */
+export function isExploratorySql(sql: string): boolean {
+  const n = normalizeSql(sql);
+  return (
+    /^(show|describe|desc|explain)\b/.test(n) ||
+    /\b(information_schema|pg_catalog|pg_tables|pg_class|pg_namespace|sqlite_master|system)\./.test(n)
+  );
+}
+
+/** A query that computes a business fact rather than fetching rows to read. */
+export function isAggregateShaped(sql: string): boolean {
+  const n = normalizeSql(sql);
+  return (
+    /\bgroup by\b/.test(n) ||
+    /\b(count|sum|avg|min|max|median|percentile_cont|percentile_disc|countif|sumif|avgif|uniq|uniqexact|quantile\w*)\s*\(/.test(n)
+  );
+}
+
+/**
+ * Whether a curated doc's SQL already covers this query. Containment (either
+ * direction, normalized) rather than equality: agents routinely take canonical
+ * metric SQL and add a date filter or wrap it in a WITH — that's still covered.
+ */
+export function coveredByCurated(sql: string, curatedSqls: string[]): boolean {
+  const n = normalizeSql(sql);
+  if (!n) return false;
+  return curatedSqls.some((c) => {
+    const cn = normalizeSql(c);
+    return cn.length > 0 && (n.includes(cn) || cn.includes(n));
+  });
+}
+
+/**
+ * The run_query success-path hint, or null when the query isn't capture-worthy
+ * (exploration, non-aggregate, or a curated metric already covers it).
+ */
+export function queryCaptureNudge(sql: string, curatedSqls: string[]): string | null {
+  if (isExploratorySql(sql) || !isAggregateShaped(sql)) return null;
+  if (coveredByCurated(sql, curatedSqls)) return null;
+  return (
+    "💡 No curated metric covers this query. If it answered a real business question " +
+    "(not one-off exploration), capture the definition now with report_correction " +
+    '(kind:"metric" — include this SQL and what it means in business terms). It lands as ' +
+    "pending for a human to approve, and the whole team gets it next time."
+  );
+}
+
+/**
+ * publish/update_app note listing panels whose aggregate SQL no curated metric
+ * covers (and that declare no metricId provenance). Null when every panel is
+ * covered, linked, or non-aggregate.
+ */
+export function panelCaptureNote(
+  panels: { key: string; sql: string; metricId?: string | null }[],
+  curatedSqls: string[],
+): string | null {
+  const uncovered = panels
+    .filter((p) => !p.metricId)
+    .filter((p) => !isExploratorySql(p.sql) && isAggregateShaped(p.sql))
+    .filter((p) => !coveredByCurated(p.sql, curatedSqls))
+    .map((p) => `"${p.key}"`);
+  if (!uncovered.length) return null;
+  return (
+    `panel(s) ${uncovered.join(", ")} compute aggregates no curated metric covers — you just ` +
+    "validated these definitions, so capture the reusable ones with report_correction " +
+    '(kind:"metric", one per panel, include the SQL); once approved, link them via `metricId`.'
+  );
+}

--- a/plugin/gateway/lib/nudge.ts
+++ b/plugin/gateway/lib/nudge.ts
@@ -12,59 +12,138 @@
  * one-line report_correction suggestion at the moment the SQL is fresh and
  * validated. Propose-only (lands as pending, human approves) — the membrane
  * (I2/I9) is untouched.
+ *
+ * Everything here is a heuristic feeding one advisory line; a wrong verdict
+ * costs a spurious or missing hint, never data. The predicates still lex
+ * literals properly (a one-pass scanner, same technique as lib/params.ts)
+ * because naive comment-stripping corrupts SQL like `slug = 'my--post'`.
  */
 
-/** Collapse whitespace/comments/case so cosmetically different SQL compares equal. */
+/** One pass over `sql`: drop comments (literal-aware), collapse whitespace,
+ *  lowercase, strip trailing semicolons. Returns two views of the same scan:
+ *  `normalized` keeps string-literal contents (for containment comparison);
+ *  `skeleton` blanks them to `'?'` so shape predicates never match text the
+ *  query merely filters on (`label = 'sum(total)'`). */
+function lex(sql: string): { normalized: string; skeleton: string } {
+  let norm = "";
+  let skel = "";
+  const n = sql.length;
+  let i = 0;
+  while (i < n) {
+    const c = sql[i];
+    // line comment: -- … to end of line
+    if (c === "-" && sql[i + 1] === "-") {
+      const nl = sql.indexOf("\n", i);
+      i = nl === -1 ? n : nl;
+      norm += " ";
+      skel += " ";
+      continue;
+    }
+    // block comment: /* … */ (non-nesting — fine for a heuristic on both dialects)
+    if (c === "/" && sql[i + 1] === "*") {
+      const close = sql.indexOf("*/", i + 2);
+      i = close === -1 ? n : close + 2;
+      norm += " ";
+      skel += " ";
+      continue;
+    }
+    // string literal / quoted identifier: '…' or "…" (a doubled quote escapes)
+    if (c === "'" || c === '"') {
+      let j = i + 1;
+      while (j < n) {
+        if (sql[j] === c) {
+          if (sql[j + 1] === c) {
+            j += 2;
+            continue;
+          }
+          j += 1;
+          break;
+        }
+        j += 1;
+      }
+      norm += sql.slice(i, j).toLowerCase();
+      skel += `${c}?${c}`;
+      i = j;
+      continue;
+    }
+    norm += c.toLowerCase();
+    skel += c.toLowerCase();
+    i += 1;
+  }
+  const squash = (s: string): string =>
+    s.replace(/\s+/g, " ").trim().replace(/[\s;]+$/, "").trim();
+  return { normalized: squash(norm), skeleton: squash(skel) };
+}
+
+/** Comment-stripped, whitespace/case-collapsed SQL for comparison. Literal
+ *  contents survive intact (comment markers inside them included). */
 export function normalizeSql(sql: string): string {
-  return sql
-    .replace(/--[^\n]*/g, " ")
-    .replace(/\/\*[\s\S]*?\*\//g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .replace(/;+$/, "")
-    .trim()
-    .toLowerCase();
+  return lex(sql).normalized;
 }
 
 /** Schema/metadata exploration — never worth capturing as a metric. */
 export function isExploratorySql(sql: string): boolean {
-  const n = normalizeSql(sql);
+  const s = lex(sql).skeleton;
   return (
-    /^(show|describe|desc|explain)\b/.test(n) ||
-    /\b(information_schema|pg_catalog|pg_tables|pg_class|pg_namespace|sqlite_master|system)\./.test(n)
+    /^(show|describe|desc|explain)\b/.test(s) ||
+    /\b(information_schema|pg_catalog|pg_tables|pg_class|pg_namespace|sqlite_master|system)\./.test(s)
   );
 }
 
-/** A query that computes a business fact rather than fetching rows to read. */
+const AGG_FNS =
+  "count|sum|avg|min|max|median|percentile_cont|percentile_disc|countif|sumif|avgif|uniq|uniqexact|quantile\\w*";
+/** `fn( args ) over (` — a window call: per-row math, not a business fact.
+ *  One nesting level of parens in the args is enough for a heuristic. */
+const WINDOW_CALL = new RegExp(
+  `\\b(?:${AGG_FNS})\\s*\\((?:[^()]|\\([^()]*\\))*\\)\\s+over\\s*\\(`,
+  "g",
+);
+const AGG_CALL = new RegExp(`\\b(?:${AGG_FNS})\\s*\\(`);
+
+/** A query that computes a business fact rather than fetching rows to read.
+ *  Judged on the literal-blanked skeleton, with window calls removed first —
+ *  `sum(x) OVER (…)` fetches rows, it doesn't define a metric. */
 export function isAggregateShaped(sql: string): boolean {
-  const n = normalizeSql(sql);
-  return (
-    /\bgroup by\b/.test(n) ||
-    /\b(count|sum|avg|min|max|median|percentile_cont|percentile_disc|countif|sumif|avgif|uniq|uniqexact|quantile\w*)\s*\(/.test(n)
-  );
+  const s = lex(sql).skeleton.replace(WINDOW_CALL, " over (");
+  return /\bgroup by\b/.test(s) || AGG_CALL.test(s);
+}
+
+/** `needle` occurs in `hay` at word boundaries on both ends — so curated
+ *  `… from orders` never claims `… from orders_archive`. */
+function containsAtBoundary(hay: string, needle: string): boolean {
+  const isWord = (ch: string | undefined): boolean => ch !== undefined && /[\w$]/.test(ch);
+  for (let idx = hay.indexOf(needle); idx !== -1; idx = hay.indexOf(needle, idx + 1)) {
+    if (!isWord(hay[idx - 1]) && !isWord(hay[idx + needle.length])) return true;
+  }
+  return false;
 }
 
 /**
- * Whether a curated doc's SQL already covers this query. Containment (either
- * direction, normalized) rather than equality: agents routinely take canonical
- * metric SQL and add a date filter or wrap it in a WITH — that's still covered.
+ * Whether a curated doc's SQL already covers this query: the query CONTAINS
+ * the curated SQL at token boundaries. Containment rather than equality
+ * because agents routinely take canonical metric SQL and add a date filter or
+ * wrap it in a WITH — that's still covered. One direction only: a broad query
+ * that merely appears as a fragment inside a narrower curated metric computes
+ * a number no metric defines, so it should still nudge.
  */
 export function coveredByCurated(sql: string, curatedSqls: string[]): boolean {
   const n = normalizeSql(sql);
   if (!n) return false;
   return curatedSqls.some((c) => {
     const cn = normalizeSql(c);
-    return cn.length > 0 && (n.includes(cn) || cn.includes(n));
+    return cn.length > 0 && containsAtBoundary(n, cn);
   });
 }
 
 /**
  * The run_query success-path hint, or null when the query isn't capture-worthy
  * (exploration, non-aggregate, or a curated metric already covers it).
+ * `curatedSqls` is a thunk so callers on the hot query path only pay the
+ * store scan once the cheap shape gates have passed.
  */
-export function queryCaptureNudge(sql: string, curatedSqls: string[]): string | null {
+export function queryCaptureNudge(sql: string, curatedSqls: () => string[]): string | null {
   if (isExploratorySql(sql) || !isAggregateShaped(sql)) return null;
-  if (coveredByCurated(sql, curatedSqls)) return null;
+  if (coveredByCurated(sql, curatedSqls())) return null;
   return (
     "💡 No curated metric covers this query. If it answered a real business question " +
     "(not one-off exploration), capture the definition now with report_correction " +
@@ -76,16 +155,20 @@ export function queryCaptureNudge(sql: string, curatedSqls: string[]): string | 
 /**
  * publish/update_app note listing panels whose aggregate SQL no curated metric
  * covers (and that declare no metricId provenance). Null when every panel is
- * covered, linked, or non-aggregate.
+ * covered, linked, or non-aggregate — decided before the `curatedSqls` thunk
+ * runs, so a zero-panel or non-aggregate publish never scans the store.
  */
 export function panelCaptureNote(
   panels: { key: string; sql: string; metricId?: string | null }[],
-  curatedSqls: string[],
+  curatedSqls: () => string[],
 ): string | null {
-  const uncovered = panels
+  const candidates = panels
     .filter((p) => !p.metricId)
-    .filter((p) => !isExploratorySql(p.sql) && isAggregateShaped(p.sql))
-    .filter((p) => !coveredByCurated(p.sql, curatedSqls))
+    .filter((p) => !isExploratorySql(p.sql) && isAggregateShaped(p.sql));
+  if (!candidates.length) return null;
+  const curated = curatedSqls();
+  const uncovered = candidates
+    .filter((p) => !coveredByCurated(p.sql, curated))
     .map((p) => `"${p.key}"`);
   if (!uncovered.length) return null;
   return (

--- a/test/nudge.test.ts
+++ b/test/nudge.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Success-path capture nudges: fire exactly when a working query computed a
+// business aggregate no curated metric covers — never on exploration, never on
+// SQL the store already knows (else the nudge is noise and gets ignored).
+import { describe, it, expect } from "bun:test";
+import {
+  normalizeSql,
+  isExploratorySql,
+  isAggregateShaped,
+  coveredByCurated,
+  queryCaptureNudge,
+  panelCaptureNote,
+} from "../plugin/gateway/lib/nudge";
+
+const HIRES_SQL = `SELECT COUNT(*) AS hires\nFROM "UserCompanyPairing"\nWHERE status = 'HIRED';`;
+
+describe("normalizeSql", () => {
+  it("collapses whitespace, comments, case, trailing semicolons", () => {
+    expect(normalizeSql("SELECT  1;\n-- note\n")).toBe("select 1");
+    expect(normalizeSql("/* why */ SELECT\n\tcount(*) FROM t ;")).toBe(
+      "select count(*) from t",
+    );
+  });
+});
+
+describe("isExploratorySql", () => {
+  it("metadata and schema peeks are exploratory", () => {
+    expect(isExploratorySql("SHOW TABLES")).toBe(true);
+    expect(isExploratorySql("DESCRIBE slack_messages")).toBe(true);
+    expect(isExploratorySql("EXPLAIN SELECT count(*) FROM t")).toBe(true);
+    expect(
+      isExploratorySql(
+        "SELECT table_name FROM information_schema.tables LIMIT 50",
+      ),
+    ).toBe(true);
+  });
+  it("business queries are not", () => {
+    expect(isExploratorySql(HIRES_SQL)).toBe(false);
+  });
+});
+
+describe("isAggregateShaped", () => {
+  it("aggregates and GROUP BY count; row fetches don't", () => {
+    expect(isAggregateShaped(HIRES_SQL)).toBe(true);
+    expect(isAggregateShaped("SELECT plan, sum(amt) FROM x GROUP BY plan")).toBe(true);
+    expect(isAggregateShaped('SELECT * FROM "Company" LIMIT 10')).toBe(false);
+    expect(isAggregateShaped("SELECT id, name FROM users WHERE id = 3")).toBe(false);
+  });
+});
+
+describe("coveredByCurated", () => {
+  const curated = [HIRES_SQL];
+  it("exact and cosmetically-different SQL is covered", () => {
+    expect(coveredByCurated(HIRES_SQL, curated)).toBe(true);
+    expect(
+      coveredByCurated(
+        'select count(*) as hires from "usercompanypairing" where status = \'hired\'',
+        curated,
+      ),
+    ).toBe(true);
+  });
+  it("a wrapped/extended variant of curated SQL is covered (containment)", () => {
+    const wrapped = `WITH h AS (${HIRES_SQL.replace(/;$/, "")}) SELECT * FROM h`;
+    expect(coveredByCurated(wrapped, curated)).toBe(true);
+  });
+  it("a genuinely new aggregate is not", () => {
+    expect(
+      coveredByCurated('SELECT count(*) FROM "JobPost" WHERE live', curated),
+    ).toBe(false);
+  });
+  it("empty store covers nothing, blank fences cover nothing", () => {
+    expect(coveredByCurated(HIRES_SQL, [])).toBe(false);
+    expect(coveredByCurated(HIRES_SQL, ["  "])).toBe(false);
+  });
+});
+
+describe("queryCaptureNudge", () => {
+  const curated = [HIRES_SQL];
+  it("fires on an uncovered business aggregate", () => {
+    const nudge = queryCaptureNudge(
+      'SELECT count(*) FROM "JobPost" WHERE status = \'LIVE\'',
+      curated,
+    );
+    expect(nudge).toContain("report_correction");
+  });
+  it("silent on exploration, row fetches, and covered SQL", () => {
+    expect(queryCaptureNudge("SHOW TABLES", curated)).toBeNull();
+    expect(queryCaptureNudge('SELECT * FROM "Company" LIMIT 5', curated)).toBeNull();
+    expect(queryCaptureNudge(HIRES_SQL, curated)).toBeNull();
+  });
+});
+
+describe("panelCaptureNote", () => {
+  const curated = [HIRES_SQL];
+  it("names only the uncovered, unlinked aggregate panels", () => {
+    const note = panelCaptureNote(
+      [
+        { key: "hires", sql: HIRES_SQL }, // covered
+        { key: "live_posts", sql: 'SELECT count(*) FROM "JobPost" WHERE live' }, // nudge
+        { key: "linked", sql: "SELECT sum(amt) FROM spend", metricId: "spend_last_30d" }, // provenance already linked
+        { key: "detail", sql: "SELECT id, name FROM users LIMIT 20" }, // not an aggregate
+      ],
+      curated,
+    );
+    expect(note).toContain('"live_posts"');
+    expect(note).not.toContain('"hires"');
+    expect(note).not.toContain('"linked"');
+    expect(note).not.toContain('"detail"');
+  });
+  it("null when everything is covered or linked", () => {
+    expect(panelCaptureNote([{ key: "hires", sql: HIRES_SQL }], curated)).toBeNull();
+  });
+});

--- a/test/nudge.test.ts
+++ b/test/nudge.test.ts
@@ -12,7 +12,7 @@ import {
   panelCaptureNote,
 } from "../plugin/gateway/lib/nudge";
 
-const HIRES_SQL = `SELECT COUNT(*) AS hires\nFROM "UserCompanyPairing"\nWHERE status = 'HIRED';`;
+const WINS_SQL = `SELECT COUNT(*) AS won_deals\nFROM "DealPipeline"\nWHERE status = 'WON';`;
 
 describe("normalizeSql", () => {
   it("collapses whitespace, comments, case, trailing semicolons", () => {
@@ -35,79 +35,79 @@ describe("isExploratorySql", () => {
     ).toBe(true);
   });
   it("business queries are not", () => {
-    expect(isExploratorySql(HIRES_SQL)).toBe(false);
+    expect(isExploratorySql(WINS_SQL)).toBe(false);
   });
 });
 
 describe("isAggregateShaped", () => {
   it("aggregates and GROUP BY count; row fetches don't", () => {
-    expect(isAggregateShaped(HIRES_SQL)).toBe(true);
+    expect(isAggregateShaped(WINS_SQL)).toBe(true);
     expect(isAggregateShaped("SELECT plan, sum(amt) FROM x GROUP BY plan")).toBe(true);
-    expect(isAggregateShaped('SELECT * FROM "Company" LIMIT 10')).toBe(false);
+    expect(isAggregateShaped('SELECT * FROM "Vendor" LIMIT 10')).toBe(false);
     expect(isAggregateShaped("SELECT id, name FROM users WHERE id = 3")).toBe(false);
   });
 });
 
 describe("coveredByCurated", () => {
-  const curated = [HIRES_SQL];
+  const curated = [WINS_SQL];
   it("exact and cosmetically-different SQL is covered", () => {
-    expect(coveredByCurated(HIRES_SQL, curated)).toBe(true);
+    expect(coveredByCurated(WINS_SQL, curated)).toBe(true);
     expect(
       coveredByCurated(
-        'select count(*) as hires from "usercompanypairing" where status = \'hired\'',
+        'select count(*) as won_deals from "dealpipeline" where status = \'won\'',
         curated,
       ),
     ).toBe(true);
   });
   it("a wrapped/extended variant of curated SQL is covered (containment)", () => {
-    const wrapped = `WITH h AS (${HIRES_SQL.replace(/;$/, "")}) SELECT * FROM h`;
+    const wrapped = `WITH h AS (${WINS_SQL.replace(/;$/, "")}) SELECT * FROM h`;
     expect(coveredByCurated(wrapped, curated)).toBe(true);
   });
   it("a genuinely new aggregate is not", () => {
     expect(
-      coveredByCurated('SELECT count(*) FROM "JobPost" WHERE live', curated),
+      coveredByCurated('SELECT count(*) FROM "Listing" WHERE active', curated),
     ).toBe(false);
   });
   it("empty store covers nothing, blank fences cover nothing", () => {
-    expect(coveredByCurated(HIRES_SQL, [])).toBe(false);
-    expect(coveredByCurated(HIRES_SQL, ["  "])).toBe(false);
+    expect(coveredByCurated(WINS_SQL, [])).toBe(false);
+    expect(coveredByCurated(WINS_SQL, ["  "])).toBe(false);
   });
 });
 
 describe("queryCaptureNudge", () => {
-  const curated = [HIRES_SQL];
+  const curated = [WINS_SQL];
   it("fires on an uncovered business aggregate", () => {
     const nudge = queryCaptureNudge(
-      'SELECT count(*) FROM "JobPost" WHERE status = \'LIVE\'',
+      'SELECT count(*) FROM "Listing" WHERE status = \'LIVE\'',
       curated,
     );
     expect(nudge).toContain("report_correction");
   });
   it("silent on exploration, row fetches, and covered SQL", () => {
     expect(queryCaptureNudge("SHOW TABLES", curated)).toBeNull();
-    expect(queryCaptureNudge('SELECT * FROM "Company" LIMIT 5', curated)).toBeNull();
-    expect(queryCaptureNudge(HIRES_SQL, curated)).toBeNull();
+    expect(queryCaptureNudge('SELECT * FROM "Vendor" LIMIT 5', curated)).toBeNull();
+    expect(queryCaptureNudge(WINS_SQL, curated)).toBeNull();
   });
 });
 
 describe("panelCaptureNote", () => {
-  const curated = [HIRES_SQL];
+  const curated = [WINS_SQL];
   it("names only the uncovered, unlinked aggregate panels", () => {
     const note = panelCaptureNote(
       [
-        { key: "hires", sql: HIRES_SQL }, // covered
-        { key: "live_posts", sql: 'SELECT count(*) FROM "JobPost" WHERE live' }, // nudge
-        { key: "linked", sql: "SELECT sum(amt) FROM spend", metricId: "spend_last_30d" }, // provenance already linked
+        { key: "won_deals", sql: WINS_SQL }, // covered
+        { key: "active_listings", sql: 'SELECT count(*) FROM "Listing" WHERE active' }, // nudge
+        { key: "linked", sql: "SELECT sum(amt) FROM spend", metricId: "gross_margin" }, // provenance already linked
         { key: "detail", sql: "SELECT id, name FROM users LIMIT 20" }, // not an aggregate
       ],
       curated,
     );
-    expect(note).toContain('"live_posts"');
-    expect(note).not.toContain('"hires"');
+    expect(note).toContain('"active_listings"');
+    expect(note).not.toContain('"won_deals"');
     expect(note).not.toContain('"linked"');
     expect(note).not.toContain('"detail"');
   });
   it("null when everything is covered or linked", () => {
-    expect(panelCaptureNote([{ key: "hires", sql: HIRES_SQL }], curated)).toBeNull();
+    expect(panelCaptureNote([{ key: "won_deals", sql: WINS_SQL }], curated)).toBeNull();
   });
 });

--- a/test/nudge.test.ts
+++ b/test/nudge.test.ts
@@ -21,6 +21,18 @@ describe("normalizeSql", () => {
       "select count(*) from t",
     );
   });
+  it("comment markers inside string literals survive (literal-aware lexing)", () => {
+    expect(normalizeSql("SELECT id FROM t WHERE slug = 'my--post'")).toBe(
+      "select id from t where slug = 'my--post'",
+    );
+    expect(normalizeSql("SELECT id FROM t WHERE note LIKE '%/*%'")).toBe(
+      "select id from t where note like '%/*%'",
+    );
+    // distinct literals must stay distinct after normalization
+    expect(normalizeSql("SELECT 1 FROM t WHERE s='a--x'")).not.toBe(
+      normalizeSql("SELECT 1 FROM t WHERE s='a--y'"),
+    );
+  });
 });
 
 describe("isExploratorySql", () => {
@@ -46,6 +58,24 @@ describe("isAggregateShaped", () => {
     expect(isAggregateShaped('SELECT * FROM "Vendor" LIMIT 10')).toBe(false);
     expect(isAggregateShaped("SELECT id, name FROM users WHERE id = 3")).toBe(false);
   });
+  it("aggregate-looking text inside a string literal is not an aggregate", () => {
+    expect(
+      isAggregateShaped("SELECT id, note FROM t WHERE label = 'sum(total)'"),
+    ).toBe(false);
+  });
+  it("window functions are per-row fetches, not metrics", () => {
+    expect(
+      isAggregateShaped(
+        "SELECT id, amount, sum(amount) OVER (PARTITION BY user_id) FROM ledger",
+      ),
+    ).toBe(false);
+    // a real aggregate alongside a window call still counts
+    expect(
+      isAggregateShaped(
+        "SELECT plan, count(*), sum(amt) OVER (PARTITION BY plan) FROM x GROUP BY plan",
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("coveredByCurated", () => {
@@ -68,6 +98,16 @@ describe("coveredByCurated", () => {
       coveredByCurated('SELECT count(*) FROM "Listing" WHERE active', curated),
     ).toBe(false);
   });
+  it("token boundaries: a curated prefix must not claim a different table", () => {
+    const c = ["SELECT count(*) FROM orders"];
+    expect(coveredByCurated("SELECT count(*) FROM orders_archive", c)).toBe(false);
+    expect(coveredByCurated("SELECT count(*) FROM orders WHERE paid", c)).toBe(true);
+  });
+  it("a broad query inside a narrower curated metric is NOT covered", () => {
+    const narrow = ["SELECT count(*) FROM orders WHERE status = 'paid' AND total > 0"];
+    // the broad number is defined by no metric — it should still nudge
+    expect(coveredByCurated("SELECT count(*) FROM orders", narrow)).toBe(false);
+  });
   it("empty store covers nothing, blank fences cover nothing", () => {
     expect(coveredByCurated(WINS_SQL, [])).toBe(false);
     expect(coveredByCurated(WINS_SQL, ["  "])).toBe(false);
@@ -75,7 +115,7 @@ describe("coveredByCurated", () => {
 });
 
 describe("queryCaptureNudge", () => {
-  const curated = [WINS_SQL];
+  const curated = () => [WINS_SQL];
   it("fires on an uncovered business aggregate", () => {
     const nudge = queryCaptureNudge(
       'SELECT count(*) FROM "Listing" WHERE status = \'LIVE\'',
@@ -88,10 +128,22 @@ describe("queryCaptureNudge", () => {
     expect(queryCaptureNudge('SELECT * FROM "Vendor" LIMIT 5', curated)).toBeNull();
     expect(queryCaptureNudge(WINS_SQL, curated)).toBeNull();
   });
+  it("does not pay for the curated scan unless the shape gates pass", () => {
+    let scans = 0;
+    const counting = (): string[] => {
+      scans += 1;
+      return [WINS_SQL];
+    };
+    queryCaptureNudge("SELECT id, name FROM users LIMIT 20", counting);
+    queryCaptureNudge("SHOW TABLES", counting);
+    expect(scans).toBe(0);
+    queryCaptureNudge('SELECT count(*) FROM "Listing"', counting);
+    expect(scans).toBe(1);
+  });
 });
 
 describe("panelCaptureNote", () => {
-  const curated = [WINS_SQL];
+  const curated = () => [WINS_SQL];
   it("names only the uncovered, unlinked aggregate panels", () => {
     const note = panelCaptureNote(
       [
@@ -109,5 +161,15 @@ describe("panelCaptureNote", () => {
   });
   it("null when everything is covered or linked", () => {
     expect(panelCaptureNote([{ key: "won_deals", sql: WINS_SQL }], curated)).toBeNull();
+  });
+  it("never scans the store for zero-panel or non-aggregate publishes", () => {
+    let scans = 0;
+    const counting = (): string[] => {
+      scans += 1;
+      return [];
+    };
+    panelCaptureNote([], counting);
+    panelCaptureNote([{ key: "d", sql: "SELECT id FROM t LIMIT 5" }], counting);
+    expect(scans).toBe(0);
   });
 });


### PR DESCRIPTION
## Why

Knowledge intake on the pilot stalled the week the store stopped being empty. The only `report_correction` prompts lived in the empty-store warning (`NO_KNOWLEDGE_HINT`) and the zero-retrieval branch of `find_context` — so the system prompted hardest when it knew least, and went silent exactly when sessions produced the most learnable material. Measured on the Hedgy box: last organic correction June 18; 250+ successful queries since, zero proposals.

## What

- **`lib/nudge.ts` (new, pure):** `queryCaptureNudge` fires when a query is non-exploratory (no `SHOW`/`DESCRIBE`/`EXPLAIN`/metadata catalogs), aggregate-shaped (`GROUP BY` or aggregate functions), and not covered by any curated doc's ```sql fence (normalized containment, either direction — so canonical SQL plus a date filter still counts as covered). `panelCaptureNote` does the same per app panel, skipping panels already linked via `metricId`.
- **`run_query`:** on success with rows, when the store is non-empty, appends the one-line hint. (Empty store keeps its existing louder warning; failed/zero-row queries never nudge — that would coach retries.)
- **`publish_app` / `update_app`:** via `publishNotes`, uncovered aggregate panels get named in the existing "Heads up" list with a capture suggestion.

Propose-only: everything lands as a pending correction for a human to bless on /admin. The membrane (I2/I9) is untouched.

## Tests

`test/nudge.test.ts` (12 cases) — covered/uncovered/wrapped SQL, exploration, panel filtering. Full fast suite: 291 pass / 0 fail. Typecheck clean.