### PR TITLE
ingest: pg-mirror — full-reload business-DB mirror into the lake (#47)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ A token maps to either an **analyst** (`canWrite:false`, may read the lake) or a
 
 **`provisioner/`** — patterns for wiring sources on demand (`sources/{vercel,render,slack}.ts`, schema inference). A handful of proven patterns, not one connector per vendor (see CONTRIBUTING — new connectors are a maintenance tax).
 
-**`ingest/`** — containers that fill the lake: `slack-listener`, `mercury-poller`, `render-poller`, plus the lake's SQL schemas in `ingest/schemas/`. Liveness is tracked via `ingest_heartbeats` (a "flowing" source reads from a real beat, not data recency).
+**`ingest/`** — containers that fill the lake: `slack-listener`, `mercury-poller`, `render-poller`, `github-poller`, and `pg-mirror` (scheduled full-reload mirror of allowlisted business-Postgres tables into `biz_*` — the fast venue for app panels, issue #47), plus the lake's SQL schemas in `ingest/schemas/`. Liveness is tracked via `ingest_heartbeats` (a "flowing" source reads from a real beat, not data recency).
 
 **`plugin/skills/`** — the user-facing workflows (`SKILL.md` each): `onboard`, `connect`, `generate` (read the business code → propose/commit context), `curate` (review pending), `eval` (golden-question scorecard).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
 
   clickhouse:
     logging: *default-logging
-    profiles: [lake, ingest, slack, render, mercury, github]
+    profiles: [lake, ingest, slack, render, mercury, github, pg-mirror]
     image: clickhouse/clickhouse-server:25.3@sha256:b627d7a9bc0e0c1bac26cdbe9d2fc6316faa29c5d8a174f28f5abd57d0fa6ba2
     restart: unless-stopped
     environment:
@@ -283,6 +283,34 @@ services:
       - github_state:/state
     depends_on:
       vector:
+        condition: service_healthy
+
+  # Business-DB → lake mirror (profile: pg-mirror, issue #47). Scheduled FULL
+  # reloads of allowlisted Postgres tables into `biz_*` MergeTree tables via a
+  # staging table + atomic EXCHANGE — app panels aggregate the mirror
+  # (clickhouse dialect) instead of seq-scanning prod. Reads with the SAME
+  # read-only role the gateway uses; writes ClickHouse directly (no Vector —
+  # it needs DDL for the swap). Stateless: no volume, every run is a reload.
+  pg-mirror:
+    logging: *default-logging
+    profiles: [pg-mirror]
+    build:
+      context: .
+      dockerfile: ingest/pg-mirror/Dockerfile
+    restart: unless-stopped
+    environment:
+      SETOKU_DATABASE_URL: ${SETOKU_DATABASE_URL:-}
+      # Keep in sync with .setoku/config.json allowTables — the mirror must
+      # never widen what the gateway's postgres path allows.
+      PG_MIRROR_TABLES: ${PG_MIRROR_TABLES:-public.*}
+      PG_MIRROR_DENY_TABLES: ${PG_MIRROR_DENY_TABLES:-}
+      PG_MIRROR_INTERVAL_MS: ${PG_MIRROR_INTERVAL_MS:-3600000}
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-setoku}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?set in .env}
+      CLICKHOUSE_DB: setoku
+    depends_on:
+      clickhouse:
         condition: service_healthy
 
   # ---- backup one-shots (profile: backup) — driven by deploy/backup/*.sh ----

--- a/ingest/pg-mirror/Dockerfile
+++ b/ingest/pg-mirror/Dockerfile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+FROM oven/bun:1-slim
+WORKDIR /app
+COPY ingest/pg-mirror/mirror.ts ./mirror.ts
+CMD ["bun", "mirror.ts"]

--- a/ingest/pg-mirror/README.md
+++ b/ingest/pg-mirror/README.md
@@ -1,0 +1,52 @@
+# pg-mirror
+
+Full-reload mirror of allowlisted business-Postgres tables into the bundled
+ClickHouse lake (issue #47). App panels that aggregate big business tables
+should read the mirror (`clickhouse` dialect, tables named `biz_*`) instead of
+seq-scanning prod — ClickHouse does that workload natively, and prod stays
+untouched by dashboard load. Prod Postgres remains the source of truth and the
+right venue for ad-hoc queries and point lookups.
+
+## How it works
+
+Every `PG_MIRROR_INTERVAL_MS` (default 1h), for each allowed table:
+
+1. **Derive DDL from the Postgres catalog** — the mirror's shape always matches
+   the current table; schema drift is a non-event, not a stall. The type map is
+   explicit and an unmapped type fails that table loudly (never a silent
+   coercion). `numeric` lands as `Float64` (documented lossiness, fine for
+   analytics).
+2. **Copy into `biz_<table>__staging`** in keyset-paginated batches on the
+   primary key (bounded memory at millions of rows). Tables without a PK load
+   in one pass up to `PG_MIRROR_NO_PK_ROW_CAP` (default 200k), beyond which
+   they fail loudly — add a PK or deny them.
+3. **Verify the staged row count, then `EXCHANGE TABLES`** — the live table is
+   never empty or partial; a failed run leaves the previous copy serving.
+
+Each row carries `_mirrored_at`, the "data as of" stamp surfaced on the
+Sources page. Liveness beats into `ingest_heartbeats` as `pg-mirror`, with
+per-table failures in the beat detail.
+
+## Access + allowlist
+
+Reads Postgres with `SETOKU_DATABASE_URL` — the **same read-only role the
+gateway uses**, so the engine-enforced grants bound what can ever leave
+Postgres. On top of that, `PG_MIRROR_TABLES` / `PG_MIRROR_DENY_TABLES` are
+`schema.table` globs with the same semantics as `.setoku/config.json`
+`allowTables` — **keep them in sync with the project config**: the mirror must
+never widen what the gateway's postgres path allows.
+
+Writes ClickHouse as the full-privilege ingest user (`CLICKHOUSE_USER`), like
+every other connector; the gateway still reads only as `setoku_ro`.
+
+Mirrors are re-derivable from Postgres, so they are NOT part of the lake's
+precious-data backup story (I4) — a lost mirror is one reload away.
+
+## Enable
+
+```bash
+# .env on the box
+COMPOSE_PROFILES=...,pg-mirror
+PG_MIRROR_TABLES=public.*            # match .setoku allowTables
+docker compose up -d --build pg-mirror
+```

--- a/ingest/pg-mirror/mirror.test.ts
+++ b/ingest/pg-mirror/mirror.test.ts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * pg-mirror tests: allow/deny glob semantics, the explicit type map (unmapped
+ * types fail loudly), and a full tick against a real throwaway Postgres with a
+ * FAKE ClickHouse (loopback Bun.serve, no real lake — same pattern as the
+ * slack-listener tests). The fake records every query so the staging→verify→
+ * EXCHANGE→DROP sequence and the heartbeat are asserted, not assumed.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { SQL } from "bun";
+import pgPkg from "pg";
+import { tableAllowed, chType, encodeValue, mirrorName, tick, type ClickHouseOptions } from "./mirror";
+
+const { Client: PgClient } = pgPkg;
+const PG_HOST = process.env.SETOKU_E2E_PG_HOST ?? "/tmp";
+const DB_NAME = "setoku_pg_mirror_test";
+
+describe("tableAllowed — same glob semantics as .setoku allowTables", () => {
+  it("allows within-segment globs, deny wins, bare names default to public", () => {
+    expect(tableAllowed("public.orders", ["public.*"], [])).toBe(true);
+    expect(tableAllowed("orders", ["public.*"], [])).toBe(true);
+    expect(tableAllowed("ticketing.seat_txn", ["public.*"], [])).toBe(false);
+    expect(tableAllowed("ticketing.seat_txn", ["ticketing.*"], [])).toBe(true);
+    expect(tableAllowed("public.users", ["public.*"], ["public.users"])).toBe(false);
+    // `*` must not cross the schema.table dot
+    expect(tableAllowed("secret.thing", ["*"], [])).toBe(false);
+  });
+});
+
+describe("chType — explicit map, loud failure", () => {
+  const col = (dataType: string, nullable = false) => ({ name: "c", dataType, nullable });
+  it("maps the supported types", () => {
+    expect(chType(col("integer"), { inKey: false })).toBe("Int32");
+    expect(chType(col("bigint"), { inKey: false })).toBe("Int64");
+    expect(chType(col("numeric"), { inKey: false })).toBe("Float64");
+    expect(chType(col("timestamp with time zone"), { inKey: false })).toBe("DateTime64(3)");
+    expect(chType(col("uuid"), { inKey: false })).toBe("UUID");
+    expect(chType(col("jsonb"), { inKey: false })).toBe("String");
+  });
+  it("wraps nullable columns except in the ORDER BY key", () => {
+    expect(chType(col("text", true), { inKey: false })).toBe("Nullable(String)");
+    expect(chType(col("text", true), { inKey: true })).toBe("String");
+  });
+  it("throws on an unmapped type instead of coercing", () => {
+    expect(() => chType(col("bytea"), { inKey: false })).toThrow(/unmapped/);
+  });
+});
+
+describe("encodeValue — JSONEachRow encoding", () => {
+  it("formats timestamps as UTC DateTime64 text and dates as YYYY-MM-DD", () => {
+    const d = new Date("2026-07-03T12:34:56.789Z");
+    expect(encodeValue(d, "timestamp with time zone")).toBe("2026-07-03 12:34:56.789");
+    expect(encodeValue(d, "date")).toBe("2026-07-03");
+  });
+  it("stringifies json/array values and passes null through", () => {
+    expect(encodeValue({ a: 1 }, "jsonb")).toBe('{"a":1}');
+    expect(encodeValue([1, 2], "ARRAY")).toBe("[1,2]");
+    expect(encodeValue(null, "text")).toBeNull();
+  });
+});
+
+describe("mirrorName", () => {
+  it("prefixes biz_ and schema-qualifies outside public", () => {
+    expect(mirrorName({ schema: "public", table: "orders" })).toBe("biz_orders");
+    expect(mirrorName({ schema: "ticketing", table: "seat_txn" })).toBe("biz_ticketing_seat_txn");
+  });
+});
+
+/** Loopback fake ClickHouse: 200s everything, records queries, counts inserted
+ *  NDJSON lines per table, and answers `SELECT count()` from those counts. */
+function fakeClickHouse() {
+  const queries: string[] = [];
+  const beats: string[] = []; // heartbeat NDJSON bodies (the detail line)
+  const inserted = new Map<string, number>();
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    async fetch(req) {
+      const url = new URL(req.url);
+      const body = await req.text();
+      const query = url.searchParams.get("query") ?? body;
+      queries.push(query);
+      const ins = query.match(/^INSERT INTO \S+\.`?([\w]+)`?/);
+      if (ins && url.searchParams.get("query")) {
+        if (ins[1] === "ingest_heartbeats") beats.push(body);
+        const lines = body.split("\n").filter(Boolean).length;
+        inserted.set(ins[1], (inserted.get(ins[1]) ?? 0) + lines);
+        return new Response("");
+      }
+      const cnt = query.match(/^SELECT count\(\) AS c FROM \S+\.`?([\w]+)`?/);
+      if (cnt) return Response.json({ data: [{ c: String(inserted.get(cnt[1]) ?? 0) }] });
+      return new Response("");
+    },
+  });
+  return {
+    queries,
+    beats,
+    inserted,
+    ch: { url: `http://127.0.0.1:${server.port}`, user: "setoku", password: "x", db: "setoku" } as ClickHouseOptions,
+    stop: () => server.stop(true),
+  };
+}
+
+describe("tick — full reload against a real throwaway Postgres", () => {
+  let sql: SQL;
+
+  beforeAll(async () => {
+    const admin = new PgClient({ host: PG_HOST, database: process.env.SETOKU_E2E_PG_MAINTENANCE_DB ?? "template1" });
+    await admin.connect();
+    await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME} WITH (FORCE)`);
+    await admin.query(`CREATE DATABASE ${DB_NAME}`);
+    await admin.end();
+    const db = new PgClient({ host: PG_HOST, database: DB_NAME });
+    await db.connect();
+    await db.query(`CREATE TABLE orders (
+      id bigint PRIMARY KEY, customer text, total numeric(10,2), paid boolean,
+      placed_at timestamptz, ship_by date, meta jsonb, note text
+    )`);
+    for (let i = 1; i <= 5; i++)
+      await db.query(
+        `INSERT INTO orders VALUES ($1, $2, $3, $4, now(), current_date, '{"k":1}', $5)`,
+        [i, `cust-${i}`, i * 10.5, i % 2 === 0, i === 3 ? null : `note ${i}`],
+      );
+    await db.query("CREATE TABLE no_pk (label text)");
+    await db.query("INSERT INTO no_pk VALUES ('a'), ('b')");
+    await db.query("CREATE TABLE secrets (id int PRIMARY KEY, ssn text)");
+    await db.query("INSERT INTO secrets VALUES (1, 'nope')");
+    await db.end();
+    sql = new SQL({ path: `${PG_HOST}/.s.PGSQL.5432`, database: DB_NAME });
+  });
+
+  afterAll(async () => {
+    await sql?.end().catch(() => {});
+  });
+
+  it("mirrors allowed tables in keyset batches, swaps atomically, skips denied, beats", async () => {
+    const fake = fakeClickHouse();
+    try {
+      const r = await tick(sql, {
+        ch: fake.ch,
+        allow: ["public.*"],
+        deny: ["public.secrets"],
+        batchRows: 2, // force multiple keyset pages over the 5-row table
+      });
+      expect(r.failed).toEqual([]);
+      expect(r.mirrored).toContainEqual({ table: "biz_orders", rows: 5 });
+      expect(r.mirrored).toContainEqual({ table: "biz_no_pk", rows: 2 });
+      // The denied table never left Postgres — no query mentions it.
+      expect(fake.queries.some((q) => q.includes("secrets"))).toBe(false);
+
+      // Staging DDL derived from the pg catalog, with the freshness column.
+      const ddl = fake.queries.find((q) => q.includes("CREATE TABLE setoku.`biz_orders__staging`"))!;
+      expect(ddl).toContain("`id` Int64");
+      expect(ddl).toContain("`total` Nullable(Float64)");
+      expect(ddl).toContain("`placed_at` Nullable(DateTime64(3))");
+      expect(ddl).toContain("`meta` Nullable(String)");
+      expect(ddl).toContain("`_mirrored_at` DateTime64(3) DEFAULT now64(3)");
+      expect(ddl).toContain("ORDER BY (`id`)");
+
+      // Verify-then-swap sequence, in order: count staging, create-if-missing
+      // target, EXCHANGE, drop staging.
+      const seq = fake.queries.filter((q) => /biz_orders/.test(q)).map((q) => q.split(" ").slice(0, 2).join(" "));
+      const exchangeIdx = fake.queries.findIndex((q) => q.startsWith("EXCHANGE TABLES setoku.`biz_orders`"));
+      const countIdx = fake.queries.findIndex((q) => q.startsWith("SELECT count() AS c FROM setoku.`biz_orders__staging`"));
+      const dropIdx = fake.queries.findIndex((q, i) => i > exchangeIdx && q.startsWith("DROP TABLE IF EXISTS setoku.`biz_orders__staging`"));
+      expect(countIdx).toBeGreaterThan(-1);
+      expect(exchangeIdx).toBeGreaterThan(countIdx);
+      expect(dropIdx).toBeGreaterThan(exchangeIdx);
+      expect(seq.length).toBeGreaterThan(0);
+
+      // 5 rows over batchRows=2 → 3 insert batches, all landed in staging.
+      const orderInserts = fake.queries.filter((q) => q.startsWith("INSERT INTO setoku.`biz_orders__staging`"));
+      expect(orderInserts.length).toBe(3);
+      expect(fake.inserted.get("biz_orders__staging")).toBe(5);
+
+      // Liveness beat with the run summary.
+      expect(fake.beats.length).toBe(1);
+      expect(fake.beats[0]).toContain("mirrored 2/2 table(s), 7 row(s)");
+    } finally {
+      fake.stop();
+    }
+  });
+
+  it("fails loudly per table without wedging the run (no-PK cap)", async () => {
+    const fake = fakeClickHouse();
+    try {
+      const r = await tick(sql, { ch: fake.ch, allow: ["public.no_pk", "public.orders"], deny: [], noPkRowCap: 1 });
+      expect(r.mirrored).toContainEqual({ table: "biz_orders", rows: 5 });
+      expect(r.failed.length).toBe(1);
+      expect(r.failed[0].table).toBe("public.no_pk");
+      expect(r.failed[0].error).toContain("no primary key");
+      // The failure is visible in the heartbeat detail, not swallowed.
+      expect(fake.beats.length).toBe(1);
+      expect(fake.beats[0]).toContain("FAILED");
+      expect(fake.beats[0]).toContain("no_pk");
+    } finally {
+      fake.stop();
+    }
+  });
+});

--- a/ingest/pg-mirror/mirror.ts
+++ b/ingest/pg-mirror/mirror.ts
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * pg-mirror — full-reload mirror of allowlisted business-Postgres tables into
+ * the bundled ClickHouse lake (issue #47).
+ *
+ * Why a mirror: app panels that aggregate big business tables are ClickHouse's
+ * native workload; prod Postgres can't be indexed by us (the query role is
+ * read-only BY DESIGN) and shouldn't carry dashboard load. Why FULL reloads:
+ * no CDC machinery, no replica-identity footguns, and schema drift is a
+ * non-event — every run re-derives the table's shape from the Postgres catalog.
+ *
+ * Per table, per run:
+ *   1. derive DDL from information_schema (explicit type map — unmapped types
+ *      fail THAT table loudly, never silently coerce),
+ *   2. load into `<name>__staging` in keyset-paginated batches (read with the
+ *      SAME read-only role the gateway uses, so the engine-enforced grants and
+ *      the PG_MIRROR_TABLES allowlist both bound what can ever leave Postgres),
+ *   3. verify the staged row count, then atomically EXCHANGE TABLES — the live
+ *      table is never empty or partial; a failed run leaves the previous copy.
+ *
+ * Mirrored tables are named `biz_<table>` (`biz_<schema>_<table>` outside
+ * public) and carry `_mirrored_at` for the "data as of" freshness surfaced on
+ * the Sources page. Mirrors are re-derivable from Postgres, so they are NOT
+ * part of the lake's precious-data backup story (I4 note) — a lost mirror is
+ * one reload away. Liveness beats into `ingest_heartbeats` as "pg-mirror".
+ */
+import { SQL } from "bun";
+
+/* ------------------------------ env config ------------------------------ */
+
+const INTERVAL = Number(process.env.PG_MIRROR_INTERVAL_MS ?? 3_600_000);
+const BATCH_ROWS = Number(process.env.PG_MIRROR_BATCH_ROWS ?? 20_000);
+/** A PK-less table can't be keyset-paginated; beyond this it fails loudly. */
+const NO_PK_ROW_CAP = Number(process.env.PG_MIRROR_NO_PK_ROW_CAP ?? 200_000);
+
+export interface ClickHouseOptions {
+  url: string;
+  user: string;
+  password: string;
+  db: string;
+}
+
+export interface MirrorOptions {
+  ch: ClickHouseOptions;
+  /** Allow globs over `schema.table` (same semantics as .setoku allowTables). */
+  allow: string[];
+  deny: string[];
+  batchRows?: number;
+  noPkRowCap?: number;
+}
+
+/* --------------------------- allow/deny globs --------------------------- */
+
+// Same semantics as the gateway's config.ts: `*` matches within one segment,
+// deny wins, then the allow list must match. Duplicated here (not imported) so
+// the container stays a single self-contained file like the other pollers.
+function globToRe(pattern: string): RegExp {
+  const esc = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^.]*");
+  return new RegExp(`^${esc}$`, "i");
+}
+
+export function tableAllowed(qualified: string, allow: string[], deny: string[]): boolean {
+  const q = qualified.includes(".") ? qualified : `public.${qualified}`;
+  if (deny.some((p) => globToRe(p).test(q))) return false;
+  return allow.some((p) => globToRe(p).test(q));
+}
+
+/* ----------------------------- type mapping ----------------------------- */
+
+interface PgColumn {
+  name: string;
+  /** information_schema data_type, e.g. "integer", "timestamp with time zone". */
+  dataType: string;
+  nullable: boolean;
+}
+
+/** Explicit Postgres→ClickHouse type map. Anything not listed throws — a
+ *  silently-wrong mirror is worse than a loudly-missing one. */
+export function chType(col: PgColumn, opts: { inKey: boolean }): string {
+  const base = (() => {
+    switch (col.dataType) {
+      case "smallint": return "Int16";
+      case "integer": return "Int32";
+      case "bigint": return "Int64";
+      case "real": return "Float32";
+      case "double precision": return "Float64";
+      // Lossy for >15 significant digits — fine for analytics, documented in
+      // the table comment. Revisit as Decimal if a tenant needs exact cents.
+      case "numeric": return "Float64";
+      case "boolean": return "Bool";
+      case "text":
+      case "character varying":
+      case "character":
+      case "citext": return "String";
+      case "uuid": return "UUID";
+      case "date": return "Date32";
+      case "timestamp without time zone":
+      case "timestamp with time zone": return "DateTime64(3)";
+      // JSON/arrays land as their JSON text — queryable via CH JSON functions.
+      case "json":
+      case "jsonb":
+      case "ARRAY": return "String";
+      // Postgres enums / domains report USER-DEFINED; their values are strings.
+      case "USER-DEFINED": return "String";
+      default:
+        throw new Error(`unmapped Postgres type "${col.dataType}" (column "${col.name}") — add it to chType or deny the table`);
+    }
+  })();
+  return col.nullable && !opts.inKey ? `Nullable(${base})` : base;
+}
+
+/** Encode one Postgres value for a ClickHouse JSONEachRow line, by pg type. */
+export function encodeValue(v: unknown, dataType: string): unknown {
+  if (v == null) return null;
+  if (v instanceof Date) {
+    const iso = v.toISOString(); // UTC
+    return dataType === "date" ? iso.slice(0, 10) : iso.replace("T", " ").replace("Z", "");
+  }
+  if (typeof v === "bigint") return Number.isSafeInteger(Number(v)) ? Number(v) : String(v);
+  if (dataType === "json" || dataType === "jsonb" || dataType === "ARRAY") {
+    return typeof v === "string" ? v : JSON.stringify(v);
+  }
+  return v;
+}
+
+/* --------------------------- clickhouse client -------------------------- */
+
+async function chExec(ch: ClickHouseOptions, query: string, opts: { body?: string; settings?: Record<string, string> } = {}): Promise<string> {
+  const params = new URLSearchParams(opts.settings ?? {});
+  if (opts.body != null) params.set("query", query);
+  const res = await fetch(`${ch.url}/?${params}`, {
+    method: "POST",
+    headers: {
+      Authorization: "Basic " + btoa(`${ch.user}:${ch.password}`),
+      "content-type": opts.body != null ? "application/x-ndjson" : "text/plain",
+    },
+    body: opts.body ?? query,
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!res.ok) throw new Error(`clickhouse failed: HTTP ${res.status} ${(await res.text().catch(() => "")).slice(0, 300)}`);
+  return res.text();
+}
+
+async function chCount(ch: ClickHouseOptions, table: string): Promise<number> {
+  const out = await chExec(ch, `SELECT count() AS c FROM ${ch.db}.\`${table}\` FORMAT JSON`);
+  const parsed = JSON.parse(out) as { data?: Array<{ c?: unknown }> };
+  return Number(parsed.data?.[0]?.c ?? 0);
+}
+
+/** Beat liveness into ingest_heartbeats (same pattern as slack-listener). The
+ *  schema init dir only runs on a FRESH ClickHouse, so ensure best-effort. */
+export async function beatHeartbeat(ch: ClickHouseOptions, detail: string): Promise<void> {
+  await chExec(
+    ch,
+    `CREATE TABLE IF NOT EXISTS ${ch.db}.ingest_heartbeats (
+       connector LowCardinality(String), beat_at DateTime64(3), detail String
+     ) ENGINE = ReplacingMergeTree(beat_at) ORDER BY connector`,
+  ).catch(() => {});
+  const beat_at = new Date().toISOString().replace("T", " ").replace("Z", "");
+  await chExec(ch, `INSERT INTO ${ch.db}.ingest_heartbeats FORMAT JSONEachRow`, {
+    body: JSON.stringify({ connector: "pg-mirror", beat_at, detail }) + "\n",
+  });
+}
+
+/* ---------------------------- pg introspection --------------------------- */
+
+type PgSql = SQL;
+
+interface PgTable {
+  schema: string;
+  table: string;
+}
+
+export async function listCandidateTables(sql: PgSql): Promise<PgTable[]> {
+  const rows = (await sql`
+    SELECT table_schema AS schema, table_name AS table
+    FROM information_schema.tables
+    WHERE table_type = 'BASE TABLE'
+      AND table_schema NOT IN ('pg_catalog', 'information_schema')
+    ORDER BY table_schema, table_name`) as unknown as PgTable[];
+  return rows;
+}
+
+async function tableColumns(sql: PgSql, t: PgTable): Promise<PgColumn[]> {
+  const rows = (await sql`
+    SELECT column_name AS name, data_type AS "dataType", is_nullable = 'YES' AS nullable
+    FROM information_schema.columns
+    WHERE table_schema = ${t.schema} AND table_name = ${t.table}
+    ORDER BY ordinal_position`) as unknown as PgColumn[];
+  return rows;
+}
+
+async function tablePk(sql: PgSql, t: PgTable): Promise<string[]> {
+  const rows = (await sql`
+    SELECT a.attname AS name
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY (i.indkey)
+    WHERE i.indisprimary AND n.nspname = ${t.schema} AND c.relname = ${t.table}
+    ORDER BY array_position(i.indkey, a.attnum)`) as unknown as Array<{ name: string }>;
+  return rows.map((r) => r.name);
+}
+
+/* ------------------------------ the mirror ------------------------------ */
+
+/** ClickHouse-side name for a mirrored table: `biz_<table>`, schema-prefixed
+ *  outside public so two schemas' same-named tables can't collide. */
+export function mirrorName(t: PgTable): string {
+  return t.schema === "public" ? `biz_${t.table}` : `biz_${t.schema}_${t.table}`;
+}
+
+const pgIdent = (s: string): string => `"${s.replace(/"/g, '""')}"`;
+
+/** Mirror one table: staging DDL → keyset-paginated copy → verify → swap. */
+export async function mirrorTable(sql: PgSql, opts: MirrorOptions, t: PgTable): Promise<{ table: string; rows: number }> {
+  const ch = opts.ch;
+  const batch = opts.batchRows ?? BATCH_ROWS;
+  const cols = await tableColumns(sql, t);
+  if (!cols.length) throw new Error(`no columns for ${t.schema}.${t.table}`);
+  const pk = await tablePk(sql, t);
+  const pkSet = new Set(pk);
+  const target = mirrorName(t);
+  const staging = `${target}__staging`;
+
+  // Fresh staging table, shape derived from the CURRENT pg catalog (drift-proof).
+  const colDefs = cols.map((c) => `\`${c.name}\` ${chType(c, { inKey: pkSet.has(c.name) })}`);
+  const orderBy = pk.length ? pk.map((c) => `\`${c}\``).join(", ") : "tuple()";
+  await chExec(ch, `DROP TABLE IF EXISTS ${ch.db}.\`${staging}\``);
+  await chExec(
+    ch,
+    `CREATE TABLE ${ch.db}.\`${staging}\` (
+       ${colDefs.join(",\n       ")},
+       \`_mirrored_at\` DateTime64(3) DEFAULT now64(3)
+     ) ENGINE = MergeTree ORDER BY (${orderBy})
+     COMMENT 'Full-reload mirror of Postgres ${t.schema}.${t.table} (pg-mirror). Re-derivable — freshness in _mirrored_at. numeric→Float64.'`,
+  );
+
+  const selectList = cols.map((c) => pgIdent(c.name)).join(", ");
+  const insertQuery = `INSERT INTO ${ch.db}.\`${staging}\` (${cols.map((c) => `\`${c.name}\``).join(", ")}) FORMAT JSONEachRow`;
+  const typeByName = new Map(cols.map((c) => [c.name, c.dataType]));
+  let sent = 0;
+
+  const push = async (rows: Record<string, unknown>[]): Promise<void> => {
+    if (!rows.length) return;
+    const lines = rows
+      .map((r) => JSON.stringify(Object.fromEntries(cols.map((c) => [c.name, encodeValue(r[c.name], typeByName.get(c.name)!)]))) + "\n")
+      .join("");
+    await chExec(ch, insertQuery, { body: lines, settings: { input_format_json_read_numbers_as_strings: "1" } });
+    sent += rows.length;
+  };
+
+  if (pk.length) {
+    // Keyset pagination on the PK — one ordered pass, bounded memory, works at
+    // millions of rows. Composite keys use row-value comparison.
+    const pkList = pk.map(pgIdent).join(", ");
+    let last: unknown[] | null = null;
+    for (;;) {
+      const where = last ? `WHERE (${pkList}) > (${pk.map((_, i) => `$${i + 1}`).join(", ")})` : "";
+      const rows = (await sql.unsafe(
+        `SELECT ${selectList} FROM ${pgIdent(t.schema)}.${pgIdent(t.table)} ${where} ORDER BY ${pkList} LIMIT ${batch}`,
+        (last ?? []) as never[],
+      )) as unknown as Record<string, unknown>[];
+      await push(rows);
+      if (rows.length < batch) break;
+      last = pk.map((c) => rows[rows.length - 1][c]);
+    }
+  } else {
+    // No PK → no stable pagination order. Small tables load in one pass;
+    // beyond the cap we refuse loudly rather than buffer the world.
+    const [{ n }] = (await sql.unsafe(
+      `SELECT count(*)::int8 AS n FROM ${pgIdent(t.schema)}.${pgIdent(t.table)}`,
+    )) as unknown as Array<{ n: number | string }>;
+    const count = Number(n);
+    const cap = opts.noPkRowCap ?? NO_PK_ROW_CAP;
+    if (count > cap)
+      throw new Error(`${t.schema}.${t.table} has no primary key and ${count} rows (> ${cap}) — add a PK or deny it from the mirror`);
+    const rows = (await sql.unsafe(
+      `SELECT ${selectList} FROM ${pgIdent(t.schema)}.${pgIdent(t.table)}`,
+    )) as unknown as Record<string, unknown>[];
+    await push(rows);
+  }
+
+  // Sanity: everything we sent is queryable in staging before it goes live.
+  const staged = await chCount(ch, staging);
+  if (staged !== sent) throw new Error(`staged ${staged} rows but sent ${sent} for ${t.schema}.${t.table} — not swapping`);
+
+  // Atomic swap — viewers see the old copy until the instant the new one is
+  // complete. First run: the target doesn't exist yet, so create it empty
+  // (same shape) and exchange into it.
+  await chExec(ch, `CREATE TABLE IF NOT EXISTS ${ch.db}.\`${target}\` AS ${ch.db}.\`${staging}\``);
+  await chExec(ch, `EXCHANGE TABLES ${ch.db}.\`${target}\` AND ${ch.db}.\`${staging}\``);
+  await chExec(ch, `DROP TABLE IF EXISTS ${ch.db}.\`${staging}\``);
+  return { table: target, rows: sent };
+}
+
+/** One full mirror pass. Per-table failures are isolated (one broken table
+ *  can't wedge the rest) and reported in the heartbeat detail. */
+export async function tick(sql: PgSql, opts: MirrorOptions): Promise<{ mirrored: Array<{ table: string; rows: number }>; failed: Array<{ table: string; error: string }> }> {
+  const candidates = await listCandidateTables(sql);
+  const selected = candidates.filter((t) => tableAllowed(`${t.schema}.${t.table}`, opts.allow, opts.deny));
+  const mirrored: Array<{ table: string; rows: number }> = [];
+  const failed: Array<{ table: string; error: string }> = [];
+  for (const t of selected) {
+    try {
+      mirrored.push(await mirrorTable(sql, opts, t));
+    } catch (e) {
+      failed.push({ table: `${t.schema}.${t.table}`, error: String((e as Error).message ?? e).slice(0, 300) });
+    }
+  }
+  const rows = mirrored.reduce((a, m) => a + m.rows, 0);
+  const detail =
+    `mirrored ${mirrored.length}/${selected.length} table(s), ${rows} row(s)` +
+    (failed.length ? `; FAILED: ${failed.map((f) => `${f.table} (${f.error.slice(0, 80)})`).join("; ")}` : "");
+  await beatHeartbeat(opts.ch, detail).catch((e) => console.error(`pg-mirror: heartbeat failed: ${e}`));
+  return { mirrored, failed };
+}
+
+/* --------------------------------- main ---------------------------------- */
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`pg-mirror: ${name} is required`);
+  return v;
+}
+
+async function main(): Promise<void> {
+  const dbUrl = required("SETOKU_DATABASE_URL");
+  const opts: MirrorOptions = {
+    ch: {
+      url: process.env.CLICKHOUSE_URL ?? "http://clickhouse:8123",
+      user: process.env.CLICKHOUSE_USER ?? "setoku",
+      password: process.env.CLICKHOUSE_PASSWORD ?? "",
+      db: process.env.CLICKHOUSE_DB ?? "setoku",
+    },
+    // Keep in sync with .setoku/config.json allowTables — the mirror must never
+    // widen what the gateway's postgres path allows (issue #47).
+    allow: (process.env.PG_MIRROR_TABLES ?? "public.*").split(",").map((s) => s.trim()).filter(Boolean),
+    deny: (process.env.PG_MIRROR_DENY_TABLES ?? "").split(",").map((s) => s.trim()).filter(Boolean),
+  };
+  console.error(`pg-mirror: mirroring [${opts.allow.join(", ")}] every ${INTERVAL}ms`);
+  for (;;) {
+    const sql = new SQL(dbUrl);
+    try {
+      const r = await tick(sql, opts);
+      console.error(`pg-mirror: ${r.mirrored.length} table(s) mirrored${r.failed.length ? `, ${r.failed.length} FAILED: ${JSON.stringify(r.failed)}` : ""}`);
+    } catch (e) {
+      console.error(`pg-mirror: tick failed: ${e}`);
+    } finally {
+      await sql.end().catch(() => {});
+    }
+    await Bun.sleep(INTERVAL);
+  }
+}
+
+if (import.meta.main) void main();

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -27,7 +27,7 @@ import { resolveParams, paramsVariant, type AppParam } from "./lib/params";
 import { lintAppTemplate } from "./lib/app-runtime";
 import { extractSql } from "./lib/lint";
 import { queryCaptureNudge, panelCaptureNote } from "./lib/nudge";
-import { LAKE_SOURCES } from "./lib/sources";
+import { LAKE_SOURCES, MIRROR_TABLE_PREFIX, isMirrorTable, mirrorLakeSource } from "./lib/sources";
 import { VERSION } from "./lib/version";
 
 /**
@@ -740,11 +740,22 @@ server.registerTool(
           });
           const present = new Set(res.rows.map((r) => String(Object.values(r)[0] ?? "")));
           const known = LAKE_SOURCES.filter((s) => present.has(s.table));
-          const extra = [...present].filter((t) => !LAKE_SOURCES.some((s) => s.table === t));
-          if (known.length || extra.length) {
+          // Business-DB mirrors (pg-mirror, #47) are per-tenant, so they're
+          // recognized by prefix, not the static list — and their in-flight
+          // `__staging` work tables are noise, never a query target.
+          const mirrors = [...present].filter(isMirrorTable).sort().map(mirrorLakeSource);
+          const extra = [...present].filter(
+            (t) => !LAKE_SOURCES.some((s) => s.table === t) && !t.startsWith(MIRROR_TABLE_PREFIX),
+          );
+          if (known.length || mirrors.length || extra.length) {
             lines.push("", 'DATA LAKE (ClickHouse) — run_query with dialect:"clickhouse" — tables:');
             for (const s of known) lines.push(`  - setoku.${s.table} — ${s.blurb}`);
+            for (const s of mirrors) lines.push(`  - setoku.${s.table} — ${s.blurb}`);
             for (const t of extra) lines.push(`  - setoku.${t}`);
+            if (mirrors.length)
+              lines.push(
+                "  (biz_* mirrors reload on a schedule — prefer them over Postgres for big scans/aggregations; use Postgres for point lookups and to-the-second freshness.)",
+              );
           } else {
             lines.push("", "DATA LAKE: configured but empty.");
           }

--- a/plugin/gateway/http.ts
+++ b/plugin/gateway/http.ts
@@ -478,7 +478,7 @@ echo "    how many companies are paying us right now?"
 
 // Lake source tables we know how to surface (shared with the list_sources MCP
 // tool) — query only the ones that actually exist; see gatherSources().
-import { LAKE_SOURCES } from "./lib/sources";
+import { LAKE_SOURCES, isMirrorTable, mirrorLakeSource, type LakeSource } from "./lib/sources";
 
 /**
  * Gather the /admin Sources view live: is Postgres configured + reachable (+
@@ -486,6 +486,26 @@ import { LAKE_SOURCES } from "./lib/sources";
  * All read-only; every probe is independently try/caught so one failure
  * degrades to "—" rather than blanking the page.
  */
+/** The known lake sources plus any dynamically-discovered business-DB mirror
+ *  tables (pg-mirror, issue #47) — mirrors are per-tenant so they can't live in
+ *  the static LAKE_SOURCES list. Failure to list (lake down, SHOW not granted)
+ *  just yields the static set. */
+async function discoverLakeSources(lakeUrl: string): Promise<LakeSource[]> {
+  try {
+    const res = await runLakeQuery(lakeUrl, "SHOW TABLES FROM setoku LIKE 'biz\\\\_%'", {
+      rowCap: 500,
+      statementTimeoutMs: 8_000,
+    });
+    const mirrors = res.rows
+      .map((r) => String(Object.values(r)[0] ?? ""))
+      .filter(isMirrorTable)
+      .map(mirrorLakeSource);
+    return [...LAKE_SOURCES, ...mirrors];
+  } catch {
+    return LAKE_SOURCES;
+  }
+}
+
 async function gatherSources(): Promise<SourcesData> {
   const cfg = loadConfig(projectDir);
   const config = cfg.ok ? cfg.config : null;
@@ -540,7 +560,7 @@ async function gatherSources(): Promise<SourcesData> {
           /* ingest_heartbeats absent — sources fall back to data-recency freshness */
         }
         const probes = await Promise.all(
-          LAKE_SOURCES.map(async (s): Promise<SourceTable | null> => {
+          (await discoverLakeSources(lakeUrl.url)).map(async (s): Promise<SourceTable | null> => {
             try {
               const res = await runLakeQuery(
                 lakeUrl.url,
@@ -587,7 +607,7 @@ async function gatherSourceSeries(): Promise<SourceSeriesData> {
     if (lakeUrl.ok) {
       const qopts = { rowCap: 100, statementTimeoutMs: 8_000 };
       const results = await Promise.all(
-        LAKE_SOURCES.map(async (s): Promise<SourceSeries | null> => {
+        (await discoverLakeSources(lakeUrl.url)).map(async (s): Promise<SourceSeries | null> => {
           try {
             const res = await runLakeQuery(
               lakeUrl.url,

--- a/plugin/gateway/lib/sources.ts
+++ b/plugin/gateway/lib/sources.ts
@@ -31,3 +31,27 @@ export const LAKE_SOURCES: LakeSource[] = [
   { table: "github_comments", source: "GitHub · comments", ts: "ingested_at", blurb: "Issue/PR discussion + code-review comments (query with FINAL)" },
   { table: "ingest_raw", source: "Unrouted (raw)", ts: "ingested_at", blurb: "Raw ingest that didn't match a known schema (rarely queried directly)" },
 ];
+
+/** Business-DB mirror tables (the pg-mirror connector, issue #47) can't be a
+ *  static list — one `biz_*` table appears per mirrored Postgres table, per
+ *  tenant. Callers discover them (SHOW TABLES LIKE 'biz\_%'), drop the
+ *  `__staging` work tables, and synthesize a LakeSource per table here so the
+ *  Sources page / list_sources treat mirrors like any other connector. */
+export const MIRROR_TABLE_PREFIX = "biz_";
+export const MIRROR_STAGING_SUFFIX = "__staging";
+export const MIRROR_CONNECTOR = "pg-mirror";
+
+export function isMirrorTable(name: string): boolean {
+  return name.startsWith(MIRROR_TABLE_PREFIX) && !name.endsWith(MIRROR_STAGING_SUFFIX);
+}
+
+export function mirrorLakeSource(table: string): LakeSource {
+  const pgName = table.slice(MIRROR_TABLE_PREFIX.length);
+  return {
+    table,
+    source: `Business DB · ${pgName}`,
+    ts: "_mirrored_at",
+    blurb: `Scheduled full-reload mirror of the business-Postgres table "${pgName}" — the fast venue for big aggregations; freshness in _mirrored_at`,
+    connector: MIRROR_CONNECTOR,
+  };
+}


### PR DESCRIPTION
The container half of #47 — the decision record has the full reasoning. **Stacked on #49** (base branch = `perf/swr-panel-telemetry`; retarget to `main` after #49 merges).

## What it does
A new zero-dep ingest container (`ingest/pg-mirror/`) that mirrors allowlisted business-Postgres tables into `biz_*` MergeTree tables in the lake on a schedule (default 1h), via **full reloads with a staged atomic swap**:

1. DDL derived from the pg catalog each run — schema drift is a non-event, and the type map is explicit (an unmapped type fails that table loudly, never a silent coercion; `numeric`→`Float64` documented).
2. Keyset-paginated copy on the PK into `biz_<t>__staging` (bounded memory at millions of rows; PK-less tables load whole up to a 200k cap, then fail loudly).
3. Staged row count verified, then `EXCHANGE TABLES` — the live table is never empty or partial; a failed run leaves the previous copy serving.

Rows carry `_mirrored_at` (the honest "data as of"); liveness beats as `pg-mirror` with per-table failures in the beat detail. Reads with the **same read-only pg role the gateway uses** + `PG_MIRROR_TABLES`/`PG_MIRROR_DENY_TABLES` globs (`.setoku` allowTables semantics) so the mirror can never widen the postgres path. Writes CH directly (the swap needs DDL, so no Vector). Mirrors are re-derivable → outside the I4 precious-backup scope.

## Gateway surfaces
- `biz_*` tables discovered dynamically (`SHOW TABLES LIKE 'biz\_%'") and shown on the /admin Sources page — freshness from `_mirrored_at`, "flowing" from the heartbeat — and in `list_sources` with steer-to-the-mirror guidance for big scans. `__staging` work tables hidden everywhere.
- Compose: new `pg-mirror` profile (added to the clickhouse profile list); stateless, `depends_on` clickhouse healthy; not built by `deploy.sh` (manual `up --build` like the other pollers).

## Tests
9 tests: allow/deny glob semantics, the type map (incl. loud unmapped failure), JSONEachRow encoding, and a full `tick` against a real throwaway Postgres with a loopback fake ClickHouse asserting the DDL → batched inserts → count-verify → EXCHANGE → DROP → heartbeat sequence, denied-table isolation, and the no-PK cap. Fast suite 312 pass / 0 fail; typecheck clean.

## Not in this PR (follow-ups within #47)
- publish-time lint nudge ("this table is mirrored — use the clickhouse dialect")
- demo-box rollout + rewriting the Fan LTV app against the mirror (the acceptance test)