### PR TITLE
pg-mirror: nullable pg enums map to LowCardinality(Nullable(String))

### DIFF
--- a/ingest/pg-mirror/mirror.test.ts
+++ b/ingest/pg-mirror/mirror.test.ts
@@ -104,6 +104,10 @@ describe("type mapping", () => {
   it("pg enums become LowCardinality(String)", () => {
     expect(mapColumn(col({ udt_name: "order_status", typtype: "e", not_null: true })).chType).toBe("LowCardinality(String)");
   });
+  it("NULLABLE enums nest Nullable inside LowCardinality (ClickHouse rejects the inverse)", () => {
+    // hit on the hedgy pilot: Prisma optional enums → Nullable(LowCardinality(…)) is ILLEGAL_TYPE_OF_ARGUMENT
+    expect(mapColumn(col({ udt_name: "order_status", typtype: "e" })).chType).toBe("LowCardinality(Nullable(String))");
+  });
   it("arrays wrap the element and are never Nullable", () => {
     const a = mapColumn(col({ udt_name: "_int4", elem_udt: "int4", elem_typtype: "b" }));
     expect(a.chType).toBe("Array(Int32)");
@@ -323,6 +327,7 @@ const SCHEMA_STATEMENTS = [
      tags text[],
      nums int4[],
      status order_status NOT NULL DEFAULT 'pending',
+     status_note order_status,
      active boolean NOT NULL DEFAULT true,
      uid uuid,
      note text,
@@ -340,9 +345,9 @@ const SCHEMA_STATEMENTS = [
   `CREATE TABLE public.internal_notes (id int PRIMARY KEY, secret text)`,
   `CREATE TABLE public.has_interval (id int PRIMARY KEY, span interval)`,
   `CREATE TABLE public.evil__staging (id int PRIMARY KEY)`, // reserved-suffix guard
-  `INSERT INTO public.orders (id, amount, loose, placed_at, day, naive, meta, tags, nums, status, active, uid, note, blob, ratio) VALUES
-     (1, 12.34, 0.000000001, '2026-05-01T10:00:00Z', '2026-05-01', '2026-05-01 10:00:00', '{"a":1}', ARRAY['x','y''z'], ARRAY[1,2], 'paid', true, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'héllo — ''quoted''', '\\xdead', 'NaN'),
-     (2, 0.05, NULL, '2026-05-02T00:00:00Z', NULL, NULL, NULL, NULL, NULL, 'pending', false, NULL, NULL, NULL, '-Infinity')`,
+  `INSERT INTO public.orders (id, amount, loose, placed_at, day, naive, meta, tags, nums, status, status_note, active, uid, note, blob, ratio) VALUES
+     (1, 12.34, 0.000000001, '2026-05-01T10:00:00Z', '2026-05-01', '2026-05-01 10:00:00', '{"a":1}', ARRAY['x','y''z'], ARRAY[1,2], 'paid', 'refunded', true, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'héllo — ''quoted''', '\\xdead', 'NaN'),
+     (2, 0.05, NULL, '2026-05-02T00:00:00Z', NULL, NULL, NULL, NULL, NULL, 'pending', NULL, false, NULL, NULL, NULL, '-Infinity')`,
   `INSERT INTO ticketing.seat_txn SELECT g, 1, g * 100, 'fan' || g || '@example.com' FROM generate_series(1, 25000) g`,
   `INSERT INTO public.no_pk VALUES ('a'), ('b')`,
   `INSERT INTO public.internal_notes VALUES (1, 'do not mirror')`,
@@ -523,11 +528,12 @@ describe.skipIf(!CH_URL)("mirror e2e (real ClickHouse)", () => {
 
     // arrays, enums, uuid, bool, nullables
     const row = await adminRows(
-      `SELECT tags, nums, status, active, toString(uid) AS uid, note, day, meta FROM ${rch.mirrorDb}.orders WHERE id = 1`,
+      `SELECT tags, nums, status, status_note, active, toString(uid) AS uid, note, day, meta FROM ${rch.mirrorDb}.orders WHERE id = 1`,
     );
     expect(row[0].tags).toEqual(["x", "y'z"]);
     expect(row[0].nums).toEqual([1, 2]);
     expect(row[0].status).toBe("paid");
+    expect(row[0].status_note).toBe("refunded"); // nullable enum → LowCardinality(Nullable(String))
     expect(row[0].active).toBe(true);
     expect(row[0].uid).toBe("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11");
     expect(row[0].note).toBe("héllo — 'quoted'");

--- a/ingest/pg-mirror/mirror.ts
+++ b/ingest/pg-mirror/mirror.ts
@@ -188,9 +188,14 @@ export function mapColumn(c: PgColumnRow): MirrorColumn {
     const elem = base.ch === "Bool" ? "UInt8" : base.ch; // Array(Bool) quirks avoided
     return { name: c.column_name, chType: `Array(${elem})`, kind: "plain", elemKind: base.kind, nullable, udt, isArray, isEnum: typtype === "e" };
   }
+  // Nullable nests INSIDE LowCardinality — ClickHouse rejects
+  // Nullable(LowCardinality(String)) but accepts LowCardinality(Nullable(String)).
+  // Hit in the wild by nullable pg enum columns (Prisma optional enums).
+  const nullify = (t: string): string =>
+    t.startsWith("LowCardinality(") ? `LowCardinality(Nullable(${t.slice("LowCardinality(".length, -1)}))` : `Nullable(${t})`;
   return {
     name: c.column_name,
-    chType: nullable ? `Nullable(${base.ch})` : base.ch,
+    chType: nullable ? nullify(base.ch) : base.ch,
     kind: base.kind,
     nullable,
     udt,


### PR DESCRIPTION
First real-world catch from the hedgy pilot rollout (issue #47, rollout step 3): 15 of 55 tables failed every reload with `ILLEGAL_TYPE_OF_ARGUMENT` — nullable enum columns (Prisma optional enums, ubiquitous in that schema) mapped to `Nullable(LowCardinality(String))`, which ClickHouse rejects. The legal nesting is `LowCardinality(Nullable(String))`.

The synthetic fixture only carried a NOT NULL enum; it now has a nullable one, exercised end-to-end against the real engine (gated e2e). 362 tests green.

https://claude.ai/code/session_0124iFKWKU6nHVc2fUrUPCoX