### PR TITLE
deploy: publish gateway image to GHCR (pull instead of build on boxes)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the gateway image once, in CI, and publish it to GHCR — so a fresh box
+# PULLS a ready image instead of running `bun install` + baking the 130MB embed
+# model on a 2-core VPS. This is the single biggest lever on box-setup time.
+#
+# The published package is PUBLIC (repo stays private): the box pulls anonymously,
+# no token. The image holds no secrets — code is Apache-2.0 and every credential
+# arrives from .env at runtime. First publish creates a private package; flip it to
+# public once, under Packages → setoku-gateway → Package settings → Change visibility.
+name: publish-gateway
+
+on:
+  push:
+    branches: [main]
+    # only rebuild when something in the image actually changes
+    paths:
+      - "plugin/**"
+      - "deploy/Dockerfile"
+      - ".github/workflows/publish.yml"
+    tags: ["v*"]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-gateway-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image tags + labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/hedgy-labs/setoku-gateway
+          # main → `latest` + `sha-<short>`; a `v1.2.3` tag → `1.2.3`, `1.2`, `latest`.
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build + push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # persist the bun-install + model-bake layers across runs
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -75,8 +75,17 @@ fi
 set -a; source .env; set +a
 
 # 4. Bring up the stack -----------------------------------------------------
-log "building + starting the stack (first run pulls images — a few minutes)…"
-dc up -d --build --wait
+# Prefer the prebuilt gateway image (published by CI) — the box PULLS instead of
+# running bun install + baking the embed model on a small VPS. Fall back to an
+# on-box build only if the image can't be pulled (private/unpublished tag, air-gap).
+log "starting the stack (first run pulls images — a few minutes)…"
+if dc pull --quiet server 2>/dev/null; then
+  log "using prebuilt gateway image (no on-box compile)"
+  dc up -d --wait
+else
+  log "prebuilt gateway image unavailable — building on the box (slower)…"
+  dc up -d --build --wait
+fi
 log "stack healthy."
 
 # 5. Admin account for the approval surface ---------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,11 @@ services:
       retries: 5
 
   server:
+    # Prebuilt image published by CI (.github/workflows/publish.yml). A fresh box
+    # PULLS this instead of compiling on-VPS. `build:` stays as the fallback: plain
+    # `up` pulls the image, `up --build` (dev / scripts/deploy.sh) builds locally and
+    # tags it with the same name. Pin a release with SETOKU_GATEWAY_TAG in .env.
+    image: ghcr.io/hedgy-labs/setoku-gateway:${SETOKU_GATEWAY_TAG:-latest}
     build:
       context: .
       dockerfile: deploy/Dockerfile


### PR DESCRIPTION
## Why
Fresh-box setup compiled the gateway *on the VPS* — `bun install` + baking the 130MB embed model on 2 cores was the slowest, most CPU-bound step of `bootstrap.sh`. This moves that work off the customer box onto CI: boxes **pull** a ready image.

## What
- **`.github/workflows/publish.yml`** (new) — build + push `ghcr.io/hedgy-labs/setoku-gateway` on `main` (image-affecting paths), `v*` tags, and manual dispatch. GHA layer cache persists the install + model-bake layers.
- **`docker-compose.yml`** — `server` gains `image:` alongside `build:`. Plain `up` pulls; `up --build` (dev / `scripts/deploy.sh`) still builds locally and tags the same name. Pin a release with `SETOKU_GATEWAY_TAG` in `.env`.
- **`deploy/bootstrap.sh`** — pull the prebuilt image first; fall back to an on-box `--build` only if it can't be pulled.

## Access decision
Package is published **public** (repo stays private) so boxes pull anonymously — zero auth, fastest onboarding. The image holds no secrets: code is Apache-2.0 and every credential arrives from `.env` at runtime.

## One manual step after first publish
Flip the package visibility to Public once: org **Packages → `setoku-gateway` → Package settings → Change visibility**. Until then, boxes fall back to building locally (still correct, just not faster yet).

## Cost
\$0 — public GHCR package = free storage/egress; the build is a few CI minutes per image-affecting merge.