### PR TITLE
deploy: gate the unused local Postgres off by default (profile: pgstore)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           POSTGRES_PASSWORD: ci
           CLICKHOUSE_PASSWORD: ci
           CLICKHOUSE_RO_PASSWORD: ci
-          COMPOSE_PROFILES: lake,ingest,backup,slack,render,mercury
+          COMPOSE_PROFILES: lake,ingest,backup,slack,render,mercury,pgstore
         run: docker compose -f docker-compose.yml config -q
 
   dco:

--- a/deploy/backup/backup.sh
+++ b/deploy/backup/backup.sh
@@ -28,8 +28,14 @@ dc exec -T server bun -e "
 docker cp "$(dc ps -q server)":/data/knowledge-snapshot.db "backups/context/knowledge-${STAMP}.db"
 dc exec -T server rm -f /data/knowledge-snapshot.db
 
-echo "[backup] pg_dump context store…"
-dc exec -T postgres pg_dump -U postgres setoku | gzip > "backups/context/pg-setoku-${STAMP}.sql.gz"
+# The Postgres context store is the reserved migration target (profile: pgstore)
+# and is unused/off by default — dump it only when it's actually running, mirroring
+# the clickhouse guard below. The irreplaceable asset is the SQLite snapshot above,
+# which is always taken.
+if dc ps --status running postgres 2>/dev/null | grep -q postgres; then
+  echo "[backup] pg_dump context store…"
+  dc exec -T postgres pg_dump -U postgres setoku | gzip > "backups/context/pg-setoku-${STAMP}.sql.gz"
+fi
 
 if [[ -n "${SETOKU_BACKUP_S3_BUCKET:-}" ]]; then
   echo "[backup] upload to bucket + prune (14 d)…"

--- a/deploy/backup/restore-drill.sh
+++ b/deploy/backup/restore-drill.sh
@@ -13,20 +13,25 @@ source deploy/dc.sh
 set -a; source .env; set +a
 : "${SETOKU_BACKUP_S3_BUCKET:?restore needs the backup bucket configured}"
 
-echo "[drill] 1/5 start databases…"
-dc up -d --wait postgres clickhouse
+echo "[drill] 1/5 start the lake…"
+dc up -d --wait clickhouse
 
 echo "[drill] 2/5 fetch latest context backups…"
 dc run --rm rclone copy "remote:${SETOKU_BACKUP_S3_BUCKET}/context" /backups/context
 latest_kdb="$(ls -1 backups/context/knowledge-*.db | sort | tail -1)"
-latest_pg="$(ls -1 backups/context/pg-setoku-*.sql.gz | sort | tail -1)"
-echo "        knowledge: ${latest_kdb}   pg: ${latest_pg}"
+latest_pg="$(ls -1 backups/context/pg-setoku-*.sql.gz 2>/dev/null | sort | tail -1)"
+echo "        knowledge: ${latest_kdb}   pg: ${latest_pg:-<none — postgres store off by default>}"
 
 echo "[drill] 3/5 restore context stores…"
 # knowledge.db goes onto the data volume BEFORE the server starts
 docker run --rm -v setoku_setoku_data:/data -v "$PWD/backups/context:/restore:ro" \
   alpine sh -c "cp /restore/$(basename "$latest_kdb") /data/knowledge.db"
-gunzip -c "$latest_pg" | dc exec -T postgres psql -q -U postgres setoku
+# Restore the Postgres store only when a dump exists (profile: pgstore); bring the
+# container up on demand since it's off by default.
+if [[ -n "$latest_pg" ]]; then
+  dc up -d --wait postgres
+  gunzip -c "$latest_pg" | dc exec -T postgres psql -q -U postgres setoku
+fi
 
 echo "[drill] 4/5 restore the lake…"
 latest_ch="$(dc run --rm clickhouse-backup list remote | awk '/nightly-/{name=$1} END{print name}')"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,12 @@
 #
 # Setoku — the whole system on one box (README Figure 1).
 #
-# Core services (caddy, server, postgres) have no profile: they always run.
+# Core services (caddy, server) have no profile: they always run.
 # Optional profiles:
 #   lake    → clickhouse                 (the bundled lake)
 #   ingest  → vector (+ lake implied)    (log/event receiver; slack-listener lands in Phase 3)
 #   backup  → clickhouse-backup, rclone  (one-shots driven by deploy/backup/*.sh)
+#   pgstore → postgres                   (reserved for the future SQLite→Postgres store migration; unused today, OFF by default)
 # Enable in .env:  COMPOSE_PROFILES=lake,ingest
 #
 # Images are pinned by multi-arch manifest-list digest (arm64 prototype box,
@@ -91,9 +92,6 @@ services:
       SETOKU_LAKE_URL: "http://setoku_ro:${CLICKHOUSE_RO_PASSWORD}@clickhouse:8123/setoku"
     volumes:
       - setoku_data:/data
-    depends_on:
-      postgres:
-        condition: service_healthy
     healthcheck:
       test:
         - CMD
@@ -105,10 +103,15 @@ services:
       retries: 5
       start_period: 15s
 
-  # Context store + auth (target architecture). The v0.9 gateway still keeps
-  # knowledge in SQLite on the setoku_data volume; the store migrates here
-  # during the Phase 3/5 build-out. pgvector is installed but unused (I8).
+  # Context store + auth (target architecture). The gateway still keeps knowledge
+  # in SQLite on the setoku_data volume; the store migrates here during the
+  # Phase 3/5 build-out. pgvector is installed but unused today (I8), so this is
+  # OFF by default (profile: pgstore) — nothing connects to it, and a fresh box
+  # neither pulls the 600MB+ image nor waits on its healthcheck. It stays in the
+  # file as the reserved slot for that migration; enable with
+  # COMPOSE_PROFILES=...,pgstore.
   postgres:
+    profiles: [pgstore]
     image: pgvector/pgvector:pg16@sha256:00ba258a66dac104fd5171074a0084462a64a1369d8513f3d0a634e2f24d15bc
     restart: unless-stopped
     logging: *default-logging


### PR DESCRIPTION
## Why
A fresh box pulls `pgvector/pgvector:pg16` (**~621MB on disk / ~300MB compressed**) and blocks the `--wait` on its healthcheck — for a database **nothing queries**:
- the gateway persists to **SQLite** (`store.ts`),
- business data is read from an **external** Postgres via `SETOKU_DATABASE_URL` (set by `connect-postgres.sh` to a remote read-only role),
- `run_query`'s default read path is the ClickHouse lake.

The local `postgres` service is the reserved slot for the future SQLite→Postgres store migration — *installed but unused today* (the existing comment says as much, per I8). I grepped the whole repo: only `server`'s `depends_on` referenced it, and it never opens a connection to it.

## What
- **`docker-compose.yml`** — `postgres` gains `profiles: [pgstore]`; drop `server`'s vestigial `depends_on: postgres`. Default boot is now **caddy + server** (+ whatever lake/ingest profiles are enabled). The service stays in the file as the reserved migration slot.
- **`backup.sh` / `restore-drill.sh`** — skip the `pg_dump`/restore when Postgres isn't running, mirroring the existing ClickHouse guard. The irreplaceable asset (the SQLite `VACUUM INTO` snapshot) is untouched, so **I4 coverage is unchanged** — the removed step was dumping an empty DB.
- **`ci.yml`** — add `pgstore` to the compose-validation profiles so the gated service is still linted.

## Effect
Removes ~621MB (~300MB compressed) + one healthcheck wait from every fresh box. The lake stays in (it's the `run_query` read path). Re-enable Postgres with `COMPOSE_PROFILES=...,pgstore` when the store migration lands.

## Validation
- `docker compose config -q` passes with all profiles incl. `pgstore`.
- Default `lake,ingest` boot renders **caddy, clickhouse, server, vector** — no postgres, no dangling dependency.
- Both backup scripts pass `bash -n`.