### PR TITLE
Add Monarch Money connector (profile: monarch)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,19 @@ RENDER_OWNER_ID=         # tea-… workspace id (GET https://api.render.com/v1/o
 RENDER_SERVICE_IDS=      # srv-…,srv-… (GET https://api.render.com/v1/services)
 RENDER_POLL_INTERVAL_MS=60000
 
+# ── monarch money (profile: monarch — see ingest/monarch-poller/README.md) ───
+# Personal finance: accounts, transactions, net worth, budgets, holdings.
+# No API key — Monarch blocks automated password logins, so auth is a browser
+# session (session_id + csrftoken cookies). Grab them from DevTools → Network →
+# an api.monarch.com/graphql request → Cookie header, or run:
+#   deploy/set-monarch-cookie.sh --env-file /opt/setoku/.env
+# Add `monarch` to COMPOSE_PROFILES.
+SETOKU_MONARCH_SESSION_ID=
+SETOKU_MONARCH_CSRFTOKEN=
+#SETOKU_MONARCH_TOKEN=          # best-effort fallback if you have a Token instead
+#MONARCH_API_BASE=https://api.monarch.com   # set if your session is on the newer host
+#MONARCH_REFRESH_HOUR=13        # daily institution force-refresh hour, Pacific (1pm = market close)
+
 # ── business-DB mirror (profile: mirror — see ingest/pg-mirror/README.md) ────
 # Full-reloads allowlisted SETOKU_DATABASE_URL tables into ClickHouse `biz.*`
 # so heavy app panels read the mirror instead of seq-scanning prod. Uses the

--- a/deploy/set-monarch-cookie.sh
+++ b/deploy/set-monarch-cookie.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Store a Monarch browser session (session_id + csrftoken cookies) into a Setoku
+# .env for cookie-auth polling. Monarch blocks automated password logins, so the
+# working auth is a session lifted from a logged-in browser. Values are read
+# hidden and only the two cookies are persisted — nothing else.
+#
+# Usage:  set-monarch-cookie.sh [--env-file /opt/setoku/.env]
+set -euo pipefail
+
+ENV_FILE="/opt/setoku/.env"
+case "${1:-}" in
+  --env-file) ENV_FILE="${2:?}" ;;
+  "" ) : ;;
+  * ) ENV_FILE="$1" ;;
+esac
+
+printf 'Paste Monarch session_id cookie value (hidden): ' >&2; read -rs SID < /dev/tty; echo >&2
+printf 'Paste Monarch csrftoken cookie value (hidden): ' >&2; read -rs CSRF < /dev/tty; echo >&2
+SID="${SID// /}"; CSRF="${CSRF// /}"
+[ -n "$SID" ] && [ -n "$CSRF" ] || { echo "set-monarch-cookie: both values are required" >&2; exit 1; }
+
+touch "$ENV_FILE"; chmod 600 "$ENV_FILE"
+tmp="$(mktemp)"
+grep -vE '^(SETOKU_MONARCH_SESSION_ID|SETOKU_MONARCH_CSRFTOKEN)=' "$ENV_FILE" > "$tmp" 2>/dev/null || true
+cat "$tmp" > "$ENV_FILE"; rm -f "$tmp"
+printf 'SETOKU_MONARCH_SESSION_ID=%s\n' "$SID" >> "$ENV_FILE"
+printf 'SETOKU_MONARCH_CSRFTOKEN=%s\n' "$CSRF" >> "$ENV_FILE"
+echo "set-monarch-cookie: stored session_id + csrftoken in $ENV_FILE" >&2

--- a/deploy/vector/vector.yaml
+++ b/deploy/vector/vector.yaml
@@ -13,6 +13,11 @@
 #   /ingest/github/pulls         → github_pulls    (poller; PR merge/branch detail)
 #   /ingest/github/commits       → github_commits  (poller; default-branch commits)
 #   /ingest/github/comments      → github_comments (poller; issue + review comments)
+#   /ingest/monarch/accounts     → monarch_accounts     (poller balance snapshots)
+#   /ingest/monarch/networth     → monarch_net_worth    (poller; daily net worth, ReplacingMergeTree)
+#   /ingest/monarch/transactions → monarch_transactions (poller, ReplacingMergeTree)
+#   /ingest/monarch/budgets      → monarch_budgets      (poller; monthly budget vs actual)
+#   /ingest/monarch/holdings     → monarch_holdings     (poller; investment portfolio breakdown)
 #   anything else                → ingest_raw    (catch-all; nothing is silently dropped)
 #
 # Buffer policy (I4): app events block when the disk buffer fills (never shed
@@ -49,6 +54,11 @@ transforms:
       github_pull: '._path == "/ingest/github/pulls"'
       github_commit: '._path == "/ingest/github/commits"'
       github_comment: '._path == "/ingest/github/comments"'
+      monarch_acct: '._path == "/ingest/monarch/accounts"'
+      monarch_networth: '._path == "/ingest/monarch/networth"'
+      monarch_txn: '._path == "/ingest/monarch/transactions"'
+      monarch_budget: '._path == "/ingest/monarch/budgets"'
+      monarch_holding: '._path == "/ingest/monarch/holdings"'
 
   vercel_parse:
     type: remap
@@ -311,6 +321,83 @@ transforms:
       if e3 != null { ts_in = now() }
       .ingested_at = format_timestamp!(ts_in, "%F %T%.3f")
 
+  monarch_accounts_parse:
+    type: remap
+    inputs: [router.monarch_acct]
+    source: |
+      # Poller sends pre-normalized fields; normalize timestamps to the
+      # ClickHouse-friendly format (no full account number exists in the source).
+      del(.source_type)
+      del(._path)
+      ts_snap, e1 = parse_timestamp(to_string(.snapshot_ts) ?? "", "%+")
+      if e1 != null { ts_snap = now() }
+      .snapshot_ts = format_timestamp!(ts_snap, "%F %T%.3f")
+      ts_cr, e2 = parse_timestamp(to_string(.created_at) ?? "", "%+")
+      if e2 != null { ts_cr = ts_snap }
+      .created_at = format_timestamp!(ts_cr, "%F %T%.3f")
+      ts_up, e3 = parse_timestamp(to_string(.updated_at) ?? "", "%+")
+      if e3 != null { ts_up = ts_snap }
+      .updated_at = format_timestamp!(ts_up, "%F %T%.3f")
+
+  monarch_networth_parse:
+    type: remap
+    inputs: [router.monarch_networth]
+    source: |
+      del(.source_type)
+      del(._path)
+      # Monarch sometimes returns a bare YYYY-MM; pad to first-of-month for Date
+      dt = to_string(.date) ?? ""
+      if match(dt, r'^\d{4}-\d{2}$') { dt = dt + "-01" }
+      if !match(dt, r'^\d{4}-\d{2}-\d{2}') { dt = "1970-01-01" }
+      .date = slice!(dt, 0, 10)
+      ts_in, e1 = parse_timestamp(to_string(.ingested_at) ?? "", "%+")
+      if e1 != null { ts_in = now() }
+      .ingested_at = format_timestamp!(ts_in, "%F %T%.3f")
+
+  monarch_transactions_parse:
+    type: remap
+    inputs: [router.monarch_txn]
+    source: |
+      del(.source_type)
+      del(._path)
+      dt = to_string(.date) ?? ""
+      if match(dt, r'^\d{4}-\d{2}$') { dt = dt + "-01" }
+      if !match(dt, r'^\d{4}-\d{2}-\d{2}') { dt = "1970-01-01" }
+      .date = slice!(dt, 0, 10)
+      ts_cr, e1 = parse_timestamp(to_string(.created_at) ?? "", "%+")
+      if e1 != null { ts_cr = now() }
+      .created_at = format_timestamp!(ts_cr, "%F %T%.3f")
+      ts_up, e2 = parse_timestamp(to_string(.updated_at) ?? "", "%+")
+      if e2 != null { ts_up = ts_cr }
+      .updated_at = format_timestamp!(ts_up, "%F %T%.3f")
+      ts_in, e3 = parse_timestamp(to_string(.ingested_at) ?? "", "%+")
+      if e3 != null { ts_in = now() }
+      .ingested_at = format_timestamp!(ts_in, "%F %T%.3f")
+
+  monarch_budgets_parse:
+    type: remap
+    inputs: [router.monarch_budget]
+    source: |
+      del(.source_type)
+      del(._path)
+      m = to_string(.month) ?? ""
+      if match(m, r'^\d{4}-\d{2}$') { m = m + "-01" }
+      if !match(m, r'^\d{4}-\d{2}-\d{2}') { m = "1970-01-01" }
+      .month = slice!(m, 0, 10)
+      ts_in, e1 = parse_timestamp(to_string(.ingested_at) ?? "", "%+")
+      if e1 != null { ts_in = now() }
+      .ingested_at = format_timestamp!(ts_in, "%F %T%.3f")
+
+  monarch_holdings_parse:
+    type: remap
+    inputs: [router.monarch_holding]
+    source: |
+      del(.source_type)
+      del(._path)
+      ts_snap, e1 = parse_timestamp(to_string(.snapshot_ts) ?? "", "%+")
+      if e1 != null { ts_snap = now() }
+      .snapshot_ts = format_timestamp!(ts_snap, "%F %T%.3f")
+
   to_raw:
     type: remap
     inputs: [router._unmatched]
@@ -437,6 +524,61 @@ sinks:
     compression: gzip
     batch: { timeout_secs: 10, max_events: 10000 }
     buffer: { type: disk, max_size: 536870912, when_full: drop_newest } # re-pollable — see lake_github_issues
+
+  lake_monarch_accounts:
+    type: clickhouse
+    inputs: [monarch_accounts_parse]
+    endpoint: http://clickhouse:8123
+    database: setoku
+    table: monarch_accounts
+    auth: { strategy: basic, user: "${CLICKHOUSE_USER}", password: "${CLICKHOUSE_PASSWORD}" }
+    compression: gzip
+    batch: { timeout_secs: 10, max_events: 10000 }
+    buffer: { type: disk, max_size: 536870912, when_full: block } # financial data: never shed
+
+  lake_monarch_net_worth:
+    type: clickhouse
+    inputs: [monarch_networth_parse]
+    endpoint: http://clickhouse:8123
+    database: setoku
+    table: monarch_net_worth
+    auth: { strategy: basic, user: "${CLICKHOUSE_USER}", password: "${CLICKHOUSE_PASSWORD}" }
+    compression: gzip
+    batch: { timeout_secs: 10, max_events: 10000 }
+    buffer: { type: disk, max_size: 536870912, when_full: block }
+
+  lake_monarch_transactions:
+    type: clickhouse
+    inputs: [monarch_transactions_parse]
+    endpoint: http://clickhouse:8123
+    database: setoku
+    table: monarch_transactions
+    auth: { strategy: basic, user: "${CLICKHOUSE_USER}", password: "${CLICKHOUSE_PASSWORD}" }
+    compression: gzip
+    batch: { timeout_secs: 10, max_events: 10000 }
+    buffer: { type: disk, max_size: 1073741824, when_full: block }
+
+  lake_monarch_budgets:
+    type: clickhouse
+    inputs: [monarch_budgets_parse]
+    endpoint: http://clickhouse:8123
+    database: setoku
+    table: monarch_budgets
+    auth: { strategy: basic, user: "${CLICKHOUSE_USER}", password: "${CLICKHOUSE_PASSWORD}" }
+    compression: gzip
+    batch: { timeout_secs: 10, max_events: 10000 }
+    buffer: { type: disk, max_size: 536870912, when_full: block }
+
+  lake_monarch_holdings:
+    type: clickhouse
+    inputs: [monarch_holdings_parse]
+    endpoint: http://clickhouse:8123
+    database: setoku
+    table: monarch_holdings
+    auth: { strategy: basic, user: "${CLICKHOUSE_USER}", password: "${CLICKHOUSE_PASSWORD}" }
+    compression: gzip
+    batch: { timeout_secs: 10, max_events: 10000 }
+    buffer: { type: disk, max_size: 536870912, when_full: block }
 
   lake_raw:
     type: clickhouse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
 
   clickhouse:
     logging: *default-logging
-    profiles: [lake, ingest, slack, render, mercury, github, mirror]
+    profiles: [lake, ingest, slack, render, mercury, github, monarch, mirror]
     image: clickhouse/clickhouse-server:25.3@sha256:b627d7a9bc0e0c1bac26cdbe9d2fc6316faa29c5d8a174f28f5abd57d0fa6ba2
     restart: unless-stopped
     environment:
@@ -164,7 +164,7 @@ services:
 
   vector:
     logging: *default-logging
-    profiles: [ingest, render, mercury, github]
+    profiles: [ingest, render, mercury, github, monarch]
     image: timberio/vector:0.49.0-alpine@sha256:2a31648e67280953aaf6b219c1b04729ac5ed12820ec2bfb698630b2d989d135
     restart: unless-stopped
     environment:
@@ -264,6 +264,39 @@ services:
       MERCURY_BACKFILL_DAYS: ${MERCURY_BACKFILL_DAYS:-730}
     volumes:
       - mercury_state:/state
+    depends_on:
+      vector:
+        condition: service_healthy
+
+  # Monarch Money → ingest bridge (profile: monarch). No official API and no push
+  # stream, so we poll its private GraphQL endpoint: account balance snapshots,
+  # daily net-worth history, a rolling window of transactions, monthly budgets, and
+  # the investment portfolio breakdown. Auth is a browser session (session_id +
+  # csrftoken) — Monarch blocks automated password logins; see the README + the
+  # deploy/set-monarch-cookie.sh helper. Mutable objects land in ReplacingMergeTree
+  # tables; state on a volume so restarts don't re-backfill.
+  monarch-poller:
+    logging: *default-logging
+    profiles: [monarch]
+    build:
+      context: .
+      dockerfile: ingest/monarch-poller/Dockerfile
+    restart: unless-stopped
+    environment:
+      # Auth: cookie mode (preferred — Monarch blocks automated password logins)
+      # uses a browser session; MONARCH_TOKEN is a best-effort fallback. poll.ts
+      # requires one of the two; :- defaults keep `docker compose config` valid for
+      # non-monarch deploys (matches render/mercury/github).
+      MONARCH_SESSION_ID: ${SETOKU_MONARCH_SESSION_ID:-}
+      MONARCH_CSRFTOKEN: ${SETOKU_MONARCH_CSRFTOKEN:-}
+      MONARCH_TOKEN: ${SETOKU_MONARCH_TOKEN:-}
+      # optional host override — Monarch moved monarchmoney.com → monarch.com in
+      # 2026; set to whichever host your session was minted against.
+      MONARCH_API_BASE: ${MONARCH_API_BASE:-https://api.monarchmoney.com}
+      # daily institution force-refresh hour, Pacific (default 1pm = market close)
+      MONARCH_REFRESH_HOUR: ${MONARCH_REFRESH_HOUR:-13}
+    volumes:
+      - monarch_state:/state
     depends_on:
       vector:
         condition: service_healthy
@@ -370,3 +403,4 @@ volumes:
   render_state:
   mercury_state:
   github_state:
+  monarch_state:

--- a/ingest/monarch-poller/Dockerfile
+++ b/ingest/monarch-poller/Dockerfile
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# Monarch Money → ingest bridge. Zero deps (Bun built-ins only).
+FROM oven/bun:1-slim
+WORKDIR /app
+COPY ingest/monarch-poller/poll.ts ./poll.ts
+VOLUME /state
+CMD ["bun", "poll.ts"]

--- a/ingest/monarch-poller/README.md
+++ b/ingest/monarch-poller/README.md
@@ -1,0 +1,77 @@
+# Monarch Money → Setoku ingest bridge
+
+Pull-based poller (profile `monarch`). Monarch has **no official data API** and no
+push stream; access is its private GraphQL endpoint (`/graphql`). So we poll on a
+loop, like the Mercury and Render bridges.
+
+## What it ingests
+
+| tick step | endpoint (Vector) | lake table | engine |
+|---|---|---|---|
+| account + balance snapshot | `/ingest/monarch/accounts` | `monarch_accounts` | MergeTree (append-only time series) |
+| daily net-worth history | `/ingest/monarch/networth` | `monarch_net_worth` | ReplacingMergeTree(ingested_at) |
+| rolling window of transactions | `/ingest/monarch/transactions` | `monarch_transactions` | ReplacingMergeTree(ingested_at) |
+| monthly budget vs. actual | `/ingest/monarch/budgets` | `monarch_budgets` | ReplacingMergeTree(ingested_at) |
+| investment portfolio breakdown | `/ingest/monarch/holdings` | `monarch_holdings` | MergeTree (append-only time series) |
+
+Monarch objects are **mutable** (a transaction is recategorized, a pending charge
+posts, a day's net worth is revised on institution back-fill), so we re-emit rolling
+windows and the newest observation wins via `ingested_at`. Accounts and holdings are
+append-only per-tick snapshots (latest snapshot = current state).
+
+`monarch_net_worth.balance` is Monarch's own aggregate — assets minus liabilities,
+signs already resolved. `monarch_accounts.current_balance` is **signed** (liabilities
+negative); net worth = `SUM(current_balance)`, never assets−liabilities and never
+`SUM(display_balance)` (the UI flips liability signs). `monarch_transactions.amount`
+is signed (negative = money out); exclude `hide_from_reports=1` from spend/income.
+
+## Auth — browser session cookies (there is no API key)
+
+Monarch has no read-only API token, and its `/auth/login/` endpoint **blocks
+automated password logins** (returns a CAPTCHA challenge, an app-version gate, or a
+Cloudflare block from datacenter IPs). The working method — the same one the
+maintained community libraries moved to — is to lift a **session from a logged-in
+browser**: the `session_id` and `csrftoken` cookies, sent with an `X-Csrftoken`
+header.
+
+Grab them from your browser (DevTools → Network → any `api.monarch.com/graphql`
+request → **Cookie** request header), then on the box:
+
+```
+deploy/set-monarch-cookie.sh --env-file /opt/setoku/.env
+```
+
+It writes `SETOKU_MONARCH_SESSION_ID` + `SETOKU_MONARCH_CSRFTOKEN` (hidden prompt;
+nothing else persisted). The session lasts days-to-weeks; when it expires the poller
+logs a `401` and stops updating — re-run the helper with fresh cookies and
+`docker compose restart monarch-poller`. (Set `MONARCH_API_BASE=https://api.monarch.com`
+if your session was minted against the newer host.)
+
+> Monitoring tip: `max(monarch_accounts.snapshot_ts)` should stay under ~90 min.
+> If it goes stale, the cookie expired.
+
+## Schedule
+
+Reads run every tick (hourly, aligned to the top of the hour). A **force-refresh**
+(the UI's "refresh" button — an institution sync) fires at most **once/day** at
+`MONARCH_REFRESH_HOUR` Pacific (default 13:00 = US market close), waits ~5 min for
+the sync, then reads. This keeps balances fresh without hammering the banks. Set
+`MONARCH_FORCE_REFRESH=0` to disable, or `MONARCH_RUN_ONCE=1` for a single cron-style run.
+
+## Run
+
+```
+# .env: add `monarch` to COMPOSE_PROFILES, set the two SETOKU_MONARCH_* cookies
+docker compose --profile monarch up -d --build monarch-poller
+docker compose logs -f monarch-poller
+```
+
+First tick backfills deep (txns 3y, net worth 5y, budgets 18mo); later ticks scan
+recent windows. State on the `monarch_state` volume gates this.
+
+## ⚠ Fragility
+
+Unofficial. Monarch moved the API host (`monarchmoney.com` → `monarch.com`) in 2026
+and can change the GraphQL schema without notice. `MONARCH_API_BASE` repoints the
+host without a code change. If a query starts erroring, diff the fragments against
+the current community `monarchmoney` Python library, which tracks the live schema.

--- a/ingest/monarch-poller/poll.ts
+++ b/ingest/monarch-poller/poll.ts
@@ -1,0 +1,645 @@
+#!/usr/bin/env bun
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Monarch Money → Setoku ingest bridge (pull-based).
+ *
+ * Monarch has NO official data API and no push stream. Access is the same
+ * private GraphQL endpoint the web app uses (api.monarchmoney.com/graphql),
+ * authenticated with a session token minted by an interactive login. So, like
+ * the Mercury and Render bridges, we poll. Each tick we fetch:
+ *   1. every account + balance snapshot   → POST /ingest/monarch/accounts
+ *   2. daily net-worth history (aggregate) → POST /ingest/monarch/networth
+ *   3. a rolling window of transactions    → POST /ingest/monarch/transactions
+ *   4. monthly budget vs. actual by category → POST /ingest/monarch/budgets
+ *
+ * Why re-fetch windows instead of only-new: Monarch objects are MUTABLE. A
+ * transaction is recategorized, a merchant renamed, a pending charge posts, a
+ * day's net worth is revised when an institution back-fills. Append-only would
+ * freeze the first observation. So transactions/networth/budgets land in
+ * ReplacingMergeTree tables keyed by their natural id with `ingested_at` as the
+ * version (newest observation wins). Accounts are an append-only balance
+ * time-series (one row per account per tick), same as mercury_accounts.
+ *
+ * ⚠ Data minimization: `mask` (last-4 of the account) is kept; no full account
+ * number is exposed by this API. Free-text (merchant, notes, category) is
+ * untrusted user input — treat as such downstream.
+ *
+ * ⚠ Unofficial & fragile: Monarch moved the API host (monarchmoney.com →
+ * monarch.com) in 2026 and can change the schema without notice. MONARCH_API_BASE
+ * is overridable so we can repoint without a code change.
+ *
+ * Auth (one of):
+ *   MONARCH_SESSION_ID + MONARCH_CSRFTOKEN   browser session cookies    [preferred]
+ *   MONARCH_TOKEN                            "Token <t>" (best-effort fallback)
+ * Monarch walls off automated password logins (CAPTCHA / version gate), so the
+ * working path is to lift session_id + csrftoken from a logged-in browser — see
+ * deploy/set-monarch-cookie.sh and the README.
+ *
+ * Env:
+ *   MONARCH_API_BASE          default https://api.monarchmoney.com
+ *   MONARCH_VECTOR_URL        default http://vector:8080  (base; paths appended)
+ *   MONARCH_POLL_INTERVAL_MS  default 3600000 (1h — personal finance is daily)
+ *   MONARCH_TXN_WINDOW_DAYS   steady-state txn lookback, default 45
+ *   MONARCH_TXN_BACKFILL_DAYS first-run txn lookback, default 1095 (3y)
+ *   MONARCH_NW_WINDOW_DAYS    steady-state net-worth lookback, default 60
+ *   MONARCH_NW_BACKFILL_DAYS  first-run net-worth lookback, default 1825 (5y)
+ *   MONARCH_BUDGET_WINDOW_MONTHS   steady-state budget lookback, default 2
+ *   MONARCH_BUDGET_BACKFILL_MONTHS first-run budget lookback, default 18
+ *   MONARCH_STATE_DIR         default /state
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const BASE = (process.env.MONARCH_API_BASE ?? "https://api.monarchmoney.com").replace(/\/+$/, "");
+const GQL = `${BASE}/graphql`;
+// Auth: prefer browser-cookie auth (session_id + csrftoken) — Monarch's login
+// endpoint blocks automated password logins (CAPTCHA / "please update"), so the
+// working path is to lift a session from a logged-in browser. Token auth is kept
+// as a fallback for environments where a Token can still be minted.
+const SESSION_ID = process.env.MONARCH_SESSION_ID ?? "";
+const CSRFTOKEN = process.env.MONARCH_CSRFTOKEN ?? "";
+const TOKEN = process.env.MONARCH_TOKEN ?? "";
+const COOKIE_MODE = Boolean(SESSION_ID && CSRFTOKEN);
+if (!COOKIE_MODE && !TOKEN) {
+  console.error("monarch-poller: set MONARCH_SESSION_ID + MONARCH_CSRFTOKEN (cookie auth) or MONARCH_TOKEN");
+  process.exit(1);
+}
+const VECTOR_BASE = (process.env.MONARCH_VECTOR_URL ?? "http://vector:8080").replace(/\/+$/, "");
+const INTERVAL = Number(process.env.MONARCH_POLL_INTERVAL_MS ?? 3_600_000);
+const TXN_WINDOW_DAYS = Number(process.env.MONARCH_TXN_WINDOW_DAYS ?? 45);
+const TXN_BACKFILL_DAYS = Number(process.env.MONARCH_TXN_BACKFILL_DAYS ?? 1095);
+const NW_WINDOW_DAYS = Number(process.env.MONARCH_NW_WINDOW_DAYS ?? 60);
+const NW_BACKFILL_DAYS = Number(process.env.MONARCH_NW_BACKFILL_DAYS ?? 1825);
+const BUDGET_WINDOW_MONTHS = Number(process.env.MONARCH_BUDGET_WINDOW_MONTHS ?? 2);
+const BUDGET_BACKFILL_MONTHS = Number(process.env.MONARCH_BUDGET_BACKFILL_MONTHS ?? 18);
+const STATE_DIR = process.env.MONARCH_STATE_DIR ?? "/state";
+const STATE_FILE = path.join(STATE_DIR, "monarch-poller.json");
+const TXN_PAGE = 100;
+// Force an institution sync (the UI's "refresh" button) at the start of each tick,
+// then wait for it to finish, so we read fresh balances/transactions rather than
+// whatever Monarch last synced on its own. Toggle with MONARCH_FORCE_REFRESH=0.
+// Reads are cheap and run every tick; the force-refresh (an institution sync —
+// the thing banks rate-limit) fires at most ONCE per day, at REFRESH_HOUR in
+// Pacific time. So the loop keeps data current from Monarch's own syncs and
+// guarantees one fresh pull a day without hammering the banks.
+const FORCE_REFRESH = (process.env.MONARCH_FORCE_REFRESH ?? "1") !== "0";
+const REFRESH_HOUR = Number(process.env.MONARCH_REFRESH_HOUR ?? 13); // 1pm, America/Los_Angeles
+const REFRESH_TIMEOUT_MS = Number(process.env.MONARCH_REFRESH_TIMEOUT_MS ?? 240_000);
+const REFRESH_POLL_MS = Number(process.env.MONARCH_REFRESH_POLL_MS ?? 15_000);
+// Loop forever (default) vs. run one tick and exit (MONARCH_RUN_ONCE=1). A
+// one-shot always force-refreshes; the loop gates it to REFRESH_HOUR Pacific.
+const RUN_ONCE = process.env.MONARCH_RUN_ONCE === "1";
+// Align ticks to the top of each hour (vs. a drifting fixed-interval sleep) so
+// the daily refresh lands at REFRESH_HOUR:00 (~1pm PT) instead of a phase that
+// depends on when the poller last started. Set MONARCH_ALIGN_TO_HOUR=0 for a
+// plain INTERVAL loop.
+const ALIGN_TO_HOUR = (process.env.MONARCH_ALIGN_TO_HOUR ?? "1") !== "0";
+// Minimal client identity matching the confirmed-working monarchmoney-cli.
+// NB: do NOT send monarch-client-version — an (old) version header trips
+// Monarch's "please update to the latest version" gate. Just a browser UA.
+const USER_AGENT =
+  process.env.MONARCH_USER_AGENT ??
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`monarch-poller: ${name} is required`);
+    process.exit(1);
+  }
+  return v;
+}
+
+interface State {
+  backfilled?: boolean; // once true, we've done the deep first-run pull; use steady windows
+  lastRefreshDate?: string; // YYYY-MM-DD (Pacific) of the last forced institution refresh
+}
+
+// Current hour (0-23) and date (YYYY-MM-DD) in America/Los_Angeles — used to fire
+// the daily force-refresh at market close (1pm PT = 4pm ET) regardless of DST.
+function pacificNow(): { hour: number; date: string } {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Los_Angeles",
+    year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", hour12: false,
+  }).formatToParts(new Date());
+  const g = (t: string): string => parts.find((p) => p.type === t)?.value ?? "";
+  let hh = Number(g("hour"));
+  if (hh === 24) hh = 0; // some ICU builds emit "24" at midnight
+  return { hour: hh, date: `${g("year")}-${g("month")}-${g("day")}` };
+}
+
+// ms until the next HH:00:05 — top of the hour, +5s to dodge boundary races — so
+// hourly ticks land on the clock and the daily refresh fires right at 1:00pm PT.
+function msToNextHourTick(): number {
+  const now = Date.now();
+  const d = new Date(now);
+  d.setMinutes(0, 5, 0);
+  let next = d.getTime();
+  if (next <= now) next += 3_600_000;
+  return next - now;
+}
+function loadState(): State {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+function saveState(s: State): void {
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.writeFileSync(STATE_FILE, JSON.stringify(s));
+}
+
+const isoDate = (d: Date): string => d.toISOString().slice(0, 10);
+const daysAgo = (n: number): string => isoDate(new Date(Date.now() - n * 86_400_000));
+// first day of the month N months before today (UTC), YYYY-MM-DD
+function monthStart(monthsBack: number): string {
+  const now = new Date();
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - monthsBack, 1));
+  return isoDate(d);
+}
+// last day of the month N months ahead of today (UTC)
+function monthEnd(monthsAhead: number): string {
+  const now = new Date();
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + monthsAhead + 1, 0));
+  return isoDate(d);
+}
+
+function authHeaders(): Record<string, string> {
+  const base: Record<string, string> = {
+    "Client-Platform": "web",
+    "Content-Type": "application/json",
+    "User-Agent": USER_AGENT,
+  };
+  if (COOKIE_MODE) {
+    // Match the browser/web client the community libraries use for cookie auth.
+    return {
+      ...base,
+      Cookie: `session_id=${SESSION_ID}; csrftoken=${CSRFTOKEN}`,
+      "X-Csrftoken": CSRFTOKEN,
+      "monarch-client": "web",
+      "monarch-client-version": process.env.MONARCH_CLIENT_VERSION ?? "2025.05",
+      Origin: "https://app.monarch.com",
+      Referer: "https://app.monarch.com/",
+    };
+  }
+  return { ...base, Authorization: `Token ${TOKEN}` };
+}
+
+async function gql<T>(operationName: string, query: string, variables: Record<string, unknown> = {}): Promise<T | null> {
+  for (let attempt = 0; attempt < 6; attempt++) {
+    let r: Response;
+    try {
+      r = await fetch(GQL, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ operationName, query, variables }),
+        signal: AbortSignal.timeout(45_000),
+      });
+    } catch (e) {
+      await Bun.sleep(2 ** attempt * 1000);
+      continue;
+    }
+    if (r.status === 429 || r.status >= 500) {
+      await Bun.sleep(Number(r.headers.get("retry-after") ?? 2 ** attempt) * 1000);
+      continue;
+    }
+    if (r.status === 401 || r.status === 403) {
+      console.error(`monarch-poller: ${operationName} → ${r.status} (session expired/rejected? re-run deploy/set-monarch-cookie.sh with fresh cookies)`);
+      return null;
+    }
+    if (!r.ok) {
+      console.error(`monarch-poller: ${operationName} → ${r.status} ${(await r.text().catch(() => "")).slice(0, 300)}`);
+      return null;
+    }
+    const body = (await r.json()) as { data?: T; errors?: unknown };
+    if (body.errors) {
+      console.error(`monarch-poller: ${operationName} GraphQL errors: ${JSON.stringify(body.errors).slice(0, 400)}`);
+      return null;
+    }
+    return body.data ?? null;
+  }
+  console.error(`monarch-poller: ${operationName} gave up after retries`);
+  return null;
+}
+
+async function pushToVector(suffix: string, lines: string[]): Promise<void> {
+  if (!lines.length) return;
+  const r = await fetch(`${VECTOR_BASE}/ingest/monarch/${suffix}`, {
+    method: "POST",
+    headers: { "content-type": "application/x-ndjson" },
+    body: lines.join("\n") + "\n",
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!r.ok) throw new Error(`vector ${r.status} ${(await r.text().catch(() => "")).slice(0, 200)}`);
+}
+
+// ---------------------------------------------------------------- accounts
+const Q_ACCOUNTS = `query GetAccounts {
+  accounts { ...AccountFields __typename }
+}
+fragment AccountFields on Account {
+  id displayName syncDisabled deactivatedAt isHidden isAsset mask
+  createdAt updatedAt displayLastUpdatedAt currentBalance displayBalance
+  includeInNetWorth includeBalanceInNetWorth isManual transactionsCount holdingsCount
+  type { name display __typename }
+  subtype { name display __typename }
+  institution { id name __typename }
+  __typename
+}`;
+
+interface MonarchAccount {
+  id: string;
+  displayName?: string;
+  isAsset?: boolean;
+  isHidden?: boolean;
+  isManual?: boolean;
+  mask?: string;
+  currentBalance?: number;
+  displayBalance?: number;
+  includeInNetWorth?: boolean;
+  includeBalanceInNetWorth?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+  transactionsCount?: number;
+  holdingsCount?: number;
+  type?: { name?: string; display?: string };
+  subtype?: { name?: string; display?: string };
+  institution?: { id?: string; name?: string };
+  [k: string]: unknown;
+}
+
+async function snapshotAccounts(snapshotTs: string): Promise<MonarchAccount[]> {
+  const d = await gql<{ accounts: MonarchAccount[] }>("GetAccounts", Q_ACCOUNTS);
+  const accounts = d?.accounts ?? [];
+  const lines = accounts.map((a) =>
+    JSON.stringify({
+      snapshot_ts: snapshotTs,
+      id: a.id,
+      display_name: a.displayName ?? "",
+      type: a.type?.name ?? "",
+      type_display: a.type?.display ?? "",
+      subtype: a.subtype?.name ?? "",
+      institution: a.institution?.name ?? "",
+      mask: a.mask ?? "",
+      is_asset: a.isAsset ? 1 : 0,
+      is_manual: a.isManual ? 1 : 0,
+      is_hidden: a.isHidden ? 1 : 0,
+      include_in_net_worth: a.includeInNetWorth ?? a.includeBalanceInNetWorth ? 1 : 0,
+      current_balance: a.currentBalance ?? 0,
+      display_balance: a.displayBalance ?? 0,
+      transactions_count: a.transactionsCount ?? 0,
+      created_at: a.createdAt ?? "",
+      updated_at: a.updatedAt ?? "",
+      raw: JSON.stringify(a),
+    }),
+  );
+  await pushToVector("accounts", lines);
+  console.error(`monarch-poller: snapshotted ${lines.length} account(s)`);
+  return accounts;
+}
+
+// ---------------------------------------------------------------- holdings
+const Q_HOLDINGS = `query Web_GetHoldings($input: PortfolioInput) {
+  portfolio(input: $input) {
+    aggregateHoldings {
+      edges {
+        node {
+          id quantity basis totalValue securityPriceChangeDollars securityPriceChangePercent lastSyncedAt
+          holdings { id isManual __typename }
+          security { id name ticker type typeDisplay currentPrice closingPrice __typename }
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+}`;
+
+interface HoldingNode {
+  quantity?: number;
+  basis?: number;
+  totalValue?: number;
+  securityPriceChangeDollars?: number;
+  securityPriceChangePercent?: number;
+  holdings?: { isManual?: boolean }[];
+  security?: { id?: string; name?: string; ticker?: string; type?: string; typeDisplay?: string; currentPrice?: number; closingPrice?: number };
+}
+
+// Snapshot the portfolio breakdown (per security) for every investment account.
+// Append-only time series, like accounts: latest snapshot = current portfolio.
+async function snapshotHoldings(accounts: MonarchAccount[], snapshotTs: string): Promise<void> {
+  const brokerage = accounts.filter((a) => (a.holdingsCount ?? 0) > 0);
+  if (!brokerage.length) return;
+  const today = isoDate(new Date());
+  let total = 0;
+  for (const acct of brokerage) {
+    const d = await gql<{ portfolio: { aggregateHoldings: { edges: { node: HoldingNode }[] } } }>(
+      "Web_GetHoldings",
+      Q_HOLDINGS,
+      { input: { accountIds: [acct.id], startDate: today, endDate: today, includeHiddenHoldings: true } },
+    );
+    const edges = d?.portfolio?.aggregateHoldings?.edges ?? [];
+    const lines = edges.map((e) => {
+      const n = e.node;
+      const s = n.security ?? {};
+      const basis = n.basis ?? 0;
+      const value = n.totalValue ?? 0;
+      return JSON.stringify({
+        snapshot_ts: snapshotTs,
+        account_id: acct.id,
+        account_name: acct.displayName ?? "",
+        security_id: s.id ?? "",
+        ticker: s.ticker ?? "",
+        name: s.name ?? "",
+        type: s.type ?? "",
+        type_display: s.typeDisplay ?? "",
+        quantity: n.quantity ?? 0,
+        value,
+        basis,
+        gain: value - basis,
+        price: s.closingPrice ?? s.currentPrice ?? 0,
+        day_change_dollars: n.securityPriceChangeDollars ?? 0,
+        day_change_pct: n.securityPriceChangePercent ?? 0,
+        is_manual: n.holdings?.[0]?.isManual ? 1 : 0,
+        raw: JSON.stringify(n),
+      });
+    });
+    await pushToVector("holdings", lines);
+    total += lines.length;
+  }
+  console.error(`monarch-poller: snapshotted ${total} holding(s) across ${brokerage.length} investment account(s)`);
+}
+
+// ---------------------------------------------------------------- net worth
+const Q_NETWORTH = `query GetAggregateSnapshots($filters: AggregateSnapshotFilters) {
+  aggregateSnapshots(filters: $filters) { date balance __typename }
+}`;
+
+async function pollNetWorth(days: number, ingestedAt: string): Promise<void> {
+  const start = daysAgo(days);
+  const d = await gql<{ aggregateSnapshots: { date: string; balance: number }[] }>("GetAggregateSnapshots", Q_NETWORTH, {
+    filters: { startDate: start, endDate: null, accountType: null },
+  });
+  const snaps = d?.aggregateSnapshots ?? [];
+  const lines = snaps.map((s) =>
+    JSON.stringify({ date: s.date, balance: s.balance ?? 0, ingested_at: ingestedAt }),
+  );
+  await pushToVector("networth", lines);
+  console.error(`monarch-poller: forwarded ${lines.length} daily net-worth point(s) from ${start}`);
+}
+
+// ---------------------------------------------------------------- transactions
+const Q_TXNS = `query GetTransactionsList($offset: Int, $limit: Int, $filters: TransactionFilterInput, $orderBy: TransactionOrdering) {
+  allTransactions(filters: $filters) {
+    totalCount
+    results(offset: $offset, limit: $limit, orderBy: $orderBy) { id ...TransactionOverviewFields __typename }
+    __typename
+  }
+}
+fragment TransactionOverviewFields on Transaction {
+  id amount pending date hideFromReports plaidName notes isRecurring reviewStatus needsReview
+  isSplitTransaction createdAt updatedAt
+  category { id name __typename }
+  merchant { name id __typename }
+  account { id displayName __typename }
+  tags { id name __typename }
+  __typename
+}`;
+
+interface MonarchTxn {
+  id: string;
+  amount?: number;
+  pending?: boolean;
+  date?: string;
+  hideFromReports?: boolean;
+  plaidName?: string;
+  notes?: string;
+  isRecurring?: boolean;
+  isSplitTransaction?: boolean;
+  needsReview?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+  category?: { id?: string; name?: string };
+  merchant?: { id?: string; name?: string };
+  account?: { id?: string; displayName?: string };
+  tags?: { name?: string }[];
+  [k: string]: unknown;
+}
+
+async function pollTransactions(startDate: string, mode: string, ingestedAt: string): Promise<void> {
+  const endDate = isoDate(new Date());
+  let offset = 0;
+  let total = 0;
+  for (;;) {
+    const d = await gql<{ allTransactions: { totalCount: number; results: MonarchTxn[] } }>("GetTransactionsList", Q_TXNS, {
+      offset,
+      limit: TXN_PAGE,
+      orderBy: "date",
+      filters: { search: "", categories: [], accounts: [], tags: [], startDate, endDate },
+    });
+    const page = d?.allTransactions?.results ?? [];
+    if (!page.length) break;
+    const lines = page.map((t) =>
+      JSON.stringify({
+        id: t.id,
+        account_id: t.account?.id ?? "",
+        account_name: t.account?.displayName ?? "",
+        amount: t.amount ?? 0,
+        date: t.date ?? "",
+        pending: t.pending ? 1 : 0,
+        category_id: t.category?.id ?? "",
+        category: t.category?.name ?? "",
+        merchant: t.merchant?.name ?? "",
+        merchant_id: t.merchant?.id ?? "",
+        plaid_name: t.plaidName ?? "",
+        notes: t.notes ?? "",
+        tags: (t.tags ?? []).map((x) => x.name ?? "").filter(Boolean).join(","),
+        is_recurring: t.isRecurring ? 1 : 0,
+        is_split: t.isSplitTransaction ? 1 : 0,
+        needs_review: t.needsReview ? 1 : 0,
+        hide_from_reports: t.hideFromReports ? 1 : 0,
+        created_at: t.createdAt ?? "",
+        updated_at: t.updatedAt ?? "",
+        raw: JSON.stringify(t),
+        ingested_at: ingestedAt,
+      }),
+    );
+    await pushToVector("transactions", lines);
+    total += lines.length;
+    offset += page.length;
+    const totalCount = d?.allTransactions?.totalCount ?? 0;
+    if (offset >= totalCount || page.length < TXN_PAGE) break;
+  }
+  console.error(`monarch-poller: forwarded ${total} transaction row(s) from ${startDate} (${mode})`);
+}
+
+// ---------------------------------------------------------------- budgets
+const Q_BUDGETS = `query Common_GetJointPlanningData($startDate: Date!, $endDate: Date!) {
+  budgetData(startMonth: $startDate, endMonth: $endDate) {
+    monthlyAmountsByCategory {
+      category { id __typename }
+      monthlyAmounts { month plannedCashFlowAmount actualAmount remainingAmount __typename }
+      __typename
+    }
+    __typename
+  }
+  categoryGroups {
+    id name type
+    categories { id name __typename }
+    __typename
+  }
+}`;
+
+interface BudgetData {
+  budgetData?: {
+    monthlyAmountsByCategory?: {
+      category?: { id?: string };
+      monthlyAmounts?: { month?: string; plannedCashFlowAmount?: number; actualAmount?: number; remainingAmount?: number }[];
+    }[];
+  };
+  categoryGroups?: { id?: string; name?: string; type?: string; categories?: { id?: string; name?: string }[] }[];
+}
+
+async function pollBudgets(monthsBack: number, mode: string, ingestedAt: string): Promise<void> {
+  const startDate = monthStart(monthsBack);
+  const endDate = monthEnd(1);
+  const d = await gql<BudgetData>("Common_GetJointPlanningData", Q_BUDGETS, { startDate, endDate });
+  if (!d) return;
+  // catId -> {name, group, groupType}
+  const cat = new Map<string, { name: string; group: string; groupType: string }>();
+  for (const g of d.categoryGroups ?? []) {
+    for (const c of g.categories ?? []) {
+      if (c.id) cat.set(c.id, { name: c.name ?? "", group: g.name ?? "", groupType: g.type ?? "" });
+    }
+  }
+  const lines: string[] = [];
+  for (const mc of d.budgetData?.monthlyAmountsByCategory ?? []) {
+    const cid = mc.category?.id ?? "";
+    const meta = cat.get(cid);
+    for (const m of mc.monthlyAmounts ?? []) {
+      // skip empty forward-looking months with no plan and no actual
+      const planned = m.plannedCashFlowAmount ?? 0;
+      const actual = m.actualAmount ?? 0;
+      if (planned === 0 && actual === 0) continue;
+      lines.push(
+        JSON.stringify({
+          month: m.month ?? "",
+          category_id: cid,
+          category: meta?.name ?? "",
+          category_group: meta?.group ?? "",
+          group_type: meta?.groupType ?? "",
+          planned_amount: planned,
+          actual_amount: actual,
+          remaining_amount: m.remainingAmount ?? 0,
+          ingested_at: ingestedAt,
+        }),
+      );
+    }
+  }
+  await pushToVector("budgets", lines);
+  console.error(`monarch-poller: forwarded ${lines.length} budget row(s) from ${startDate} (${mode})`);
+}
+
+// ---------------------------------------------------------------- force refresh
+const Q_ACCOUNT_IDS = `query GetAccountIds { accounts { id __typename } }`;
+const Q_FORCE_REFRESH = `mutation Common_ForceRefreshAccountsMutation($input: ForceRefreshAccountsInput!) {
+  forceRefreshAccounts(input: $input) { success __typename }
+}`;
+const Q_SYNC_STATUS = `query ForceRefreshAccountsQuery { accounts { id hasSyncInProgress __typename } }`;
+
+// Kick an institution sync for all accounts and wait until none report
+// hasSyncInProgress (or we hit the timeout). Best-effort: never throws.
+async function forceRefresh(): Promise<void> {
+  const d = await gql<{ accounts: { id: string }[] }>("GetAccountIds", Q_ACCOUNT_IDS);
+  const ids = (d?.accounts ?? []).map((a) => a.id);
+  if (!ids.length) return;
+  const r = await gql<{ forceRefreshAccounts: { success: boolean } }>(
+    "Common_ForceRefreshAccountsMutation",
+    Q_FORCE_REFRESH,
+    { input: { accountIds: ids } },
+  );
+  if (!r?.forceRefreshAccounts?.success) {
+    console.error("monarch-poller: force-refresh not accepted; reading last-synced data");
+    return;
+  }
+  console.error(`monarch-poller: requested refresh of ${ids.length} account(s), waiting for sync…`);
+  const deadline = Date.now() + REFRESH_TIMEOUT_MS;
+  for (;;) {
+    await Bun.sleep(REFRESH_POLL_MS);
+    const s = await gql<{ accounts: { id: string; hasSyncInProgress: boolean }[] }>("ForceRefreshAccountsQuery", Q_SYNC_STATUS);
+    const accts = s?.accounts ?? [];
+    const pending = accts.filter((a) => a.hasSyncInProgress).length;
+    if (!pending) {
+      console.error("monarch-poller: sync complete");
+      return;
+    }
+    if (Date.now() >= deadline) {
+      console.error(`monarch-poller: refresh wait timed out with ${pending} account(s) still syncing; reading anyway`);
+      return;
+    }
+  }
+}
+
+// ---------------------------------------------------------------- loop
+async function tick(): Promise<void> {
+  const now = new Date().toISOString();
+  const st = loadState();
+  const first = !st.backfilled;
+
+  // Force-refresh at most once/day: on a one-shot run always; in the loop, on the
+  // first tick at or after REFRESH_HOUR Pacific each day (robust to a missed tick).
+  if (FORCE_REFRESH) {
+    if (RUN_ONCE) {
+      await forceRefresh();
+    } else {
+      const { hour, date } = pacificNow();
+      if (hour >= REFRESH_HOUR && st.lastRefreshDate !== date) {
+        await forceRefresh();
+        st.lastRefreshDate = date;
+        saveState(st);
+      }
+    }
+  }
+
+  const accounts = await snapshotAccounts(now);
+  await snapshotHoldings(accounts, now);
+  await pollNetWorth(first ? NW_BACKFILL_DAYS : NW_WINDOW_DAYS, now);
+  await pollTransactions(first ? daysAgo(TXN_BACKFILL_DAYS) : daysAgo(TXN_WINDOW_DAYS), first ? "backfill" : "window", now);
+  await pollBudgets(first ? BUDGET_BACKFILL_MONTHS : BUDGET_WINDOW_MONTHS, first ? "backfill" : "window", now);
+
+  if (first) {
+    st.backfilled = true;
+    saveState(st);
+  }
+}
+
+async function main(): Promise<void> {
+  if (RUN_ONCE) {
+    console.error(`monarch-poller: single run → ${VECTOR_BASE}/ingest/monarch/* (${GQL})`);
+    try {
+      await tick();
+    } catch (e) {
+      console.error(`monarch-poller: tick failed: ${e}`);
+      process.exit(1);
+    }
+    console.error("monarch-poller: done");
+    return;
+  }
+  console.error(
+    `monarch-poller: polling ${GQL} every ${INTERVAL}ms → ${VECTOR_BASE}/ingest/monarch/* ` +
+      `(txn window ${TXN_WINDOW_DAYS}d/backfill ${TXN_BACKFILL_DAYS}d)`,
+  );
+  for (;;) {
+    try {
+      await tick();
+    } catch (e) {
+      console.error(`monarch-poller: tick failed: ${e}`);
+    }
+    await Bun.sleep(ALIGN_TO_HOUR ? msToNextHourTick() : INTERVAL);
+  }
+}
+
+if (import.meta.main) void main();

--- a/ingest/schemas/070_monarch_accounts.sql
+++ b/ingest/schemas/070_monarch_accounts.sql
@@ -1,0 +1,42 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Monarch Money account balance snapshots. The poller records every account's
+-- balances on each tick, so this is an append-only time series — query the
+-- latest row per account for "current balance", or trend the series over time.
+--
+-- Net worth = SUM(current_balance) across accounts — current_balance is SIGNED:
+-- liability accounts (credit cards, loans) are NEGATIVE (verified: a mortgage
+-- reads -664038). So DON'T compute assets-minus-liabilities (that double-counts
+-- debt) and DON'T sum display_balance (it flips liability signs positive for the
+-- UI). SUM(current_balance) reconciles to Monarch's own net-worth aggregate
+-- (monarch_net_worth) within ~0.2% (investment-account valuation timing).
+-- `is_asset` = 1 for assets, 0 for liabilities. `include_in_net_worth` = 1 when
+-- the account counts toward net worth (hidden/excluded accounts are 0).
+--
+-- ⚠ No full account number is exposed by the API; `mask` is the last 4 only.
+-- Schema verified against the GetAccounts GraphQL query (2026).
+CREATE TABLE IF NOT EXISTS setoku.monarch_accounts
+(
+    snapshot_ts          DateTime64(3)           COMMENT 'when this balance was observed (poll time)',
+    id                   String                  COMMENT 'Monarch account id (stable)',
+    display_name         String                  COMMENT 'account name as shown in Monarch',
+    type                 LowCardinality(String)  COMMENT 'account type name (depository, credit, brokerage, loan, …)',
+    type_display         LowCardinality(String)  COMMENT 'human display of the type',
+    subtype              LowCardinality(String)  COMMENT 'account subtype (checking, savings, credit_card, …)',
+    institution          String                  COMMENT 'linked institution name (empty for manual accounts)',
+    mask                 String                  COMMENT 'last 4 digits of the account (no full number exists in the API)',
+    is_asset             UInt8                   COMMENT '1 = asset, 0 = liability',
+    is_manual            UInt8                   COMMENT '1 = manually tracked (not institution-synced)',
+    is_hidden            UInt8                   COMMENT '1 = hidden in the Monarch UI',
+    include_in_net_worth UInt8                   COMMENT '1 = counts toward net worth',
+    current_balance      Float64                 COMMENT 'signed balance, USD: assets positive, liabilities NEGATIVE. Net worth = SUM(current_balance).',
+    display_balance      Float64                 COMMENT 'UI balance: liability signs FLIPPED positive — do NOT sum for net worth; use current_balance',
+    transactions_count   UInt32                  COMMENT 'number of transactions Monarch has for this account',
+    created_at           DateTime64(3)           COMMENT 'account creation time in Monarch',
+    updated_at           DateTime64(3)           COMMENT 'last update time in Monarch',
+    raw                  String                  COMMENT 'full account JSON as observed'
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (id, snapshot_ts)
+TTL toDateTime(snapshot_ts) + INTERVAL 1095 DAY
+COMMENT 'Monarch account balance snapshots (poll-based). Latest row per id = current balance: argMax(current_balance, snapshot_ts) GROUP BY id, or ORDER BY snapshot_ts DESC LIMIT 1 BY id.';

--- a/ingest/schemas/071_monarch_transactions.sql
+++ b/ingest/schemas/071_monarch_transactions.sql
@@ -1,0 +1,45 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Monarch Money transactions. Like Mercury, a Monarch transaction is MUTABLE:
+-- it moves pending → posted, gets recategorized, the merchant is renamed, notes
+-- change. So the poller re-emits a rolling window every tick and this table is a
+-- ReplacingMergeTree keyed by id with `ingested_at` as the version — the newest
+-- observation of each transaction wins after a background merge.
+--
+-- ⚠ Because merges are async, a naive SELECT can briefly show two versions of a
+-- just-updated row. Query with FINAL (… FROM setoku.monarch_transactions FINAL …)
+-- or argMax/LIMIT 1 BY id to read current state. Sums over `amount` likewise want
+-- FINAL to avoid double-counting an in-flight update.
+--
+-- `amount` is SIGNED (Monarch's convention): negative = money out (expense),
+-- positive = money in (income/refund). `hide_from_reports` = 1 marks transactions
+-- the user excludes from spend/income reports (transfers, reimbursements) — mirror
+-- that exclusion when computing spend. `category`/`merchant`/`notes` are untrusted
+-- free text. Schema verified against GetTransactionsList (2026).
+CREATE TABLE IF NOT EXISTS setoku.monarch_transactions
+(
+    id                 String                  COMMENT 'Monarch transaction id (stable across edits)',
+    account_id         String                  COMMENT 'owning account id (→ monarch_accounts.id)',
+    account_name       String                  COMMENT 'account display name at observation time',
+    amount             Float64                 COMMENT 'signed amount, USD: negative = out/expense, positive = in/income',
+    date               Date                    COMMENT 'transaction date (accounting date, not post time)',
+    pending            UInt8                   COMMENT '1 = still pending',
+    category_id        String                  COMMENT 'Monarch category id',
+    category           LowCardinality(String)  COMMENT 'category name (untrusted; user-editable)',
+    merchant           String                  COMMENT 'merchant name (untrusted free text)',
+    merchant_id        String                  COMMENT 'Monarch merchant id when present',
+    plaid_name         String                  COMMENT 'raw name from the institution/Plaid feed',
+    notes              String                  COMMENT 'user note (untrusted free text)',
+    tags               String                  COMMENT 'comma-separated user tag names',
+    is_recurring       UInt8                   COMMENT '1 = flagged recurring',
+    is_split           UInt8                   COMMENT '1 = a split transaction',
+    needs_review       UInt8                   COMMENT '1 = flagged for review',
+    hide_from_reports  UInt8                   COMMENT '1 = excluded from spend/income reports (transfers etc.)',
+    created_at         DateTime64(3)           COMMENT 'when Monarch created the record',
+    updated_at         DateTime64(3)           COMMENT 'last edit time in Monarch',
+    raw                String                  COMMENT 'full transaction JSON as observed',
+    ingested_at        DateTime64(3)           COMMENT 'observation time — ReplacingMergeTree version (newest wins)'
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(date)
+ORDER BY (id)
+COMMENT 'Monarch transactions (poll-based, rolling window). Mutable rows → query with FINAL. amount is signed (negative = out); exclude hide_from_reports=1 for spend/income.';

--- a/ingest/schemas/072_monarch_net_worth.sql
+++ b/ingest/schemas/072_monarch_net_worth.sql
@@ -1,0 +1,22 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Monarch Money daily net worth history (the aggregateSnapshots query — the same
+-- series that drives Monarch's Net Worth chart). `balance` is already assets minus
+-- liabilities with all sign conventions resolved by Monarch, so this is the
+-- authoritative net-worth number — prefer it over summing monarch_accounts by hand.
+--
+-- Monarch REVISES history when an institution back-fills or a manual balance is
+-- edited, so the poller re-emits a rolling window each tick and this is a
+-- ReplacingMergeTree keyed by date with `ingested_at` as the version. The first
+-- run backfills years; query with FINAL for the current value of each day.
+--
+-- One row per calendar day. Schema verified against GetAggregateSnapshots (2026).
+CREATE TABLE IF NOT EXISTS setoku.monarch_net_worth
+(
+    date         Date          COMMENT 'calendar day',
+    balance      Float64       COMMENT 'net worth on that day, USD (assets − liabilities; Monarch-computed)',
+    ingested_at  DateTime64(3) COMMENT 'observation time — ReplacingMergeTree version (newest wins)'
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(date)
+ORDER BY (date)
+COMMENT 'Monarch daily net worth (assets − liabilities, Monarch-computed). One row per day; query with FINAL. Latest day = current net worth.';

--- a/ingest/schemas/073_monarch_budgets.sql
+++ b/ingest/schemas/073_monarch_budgets.sql
@@ -1,0 +1,29 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Monarch Money monthly budgets: planned vs. actual per category per month (from
+-- the Common_GetJointPlanningData / budgetData query). One row per (month,
+-- category). Budgets are edited over time, so this is a ReplacingMergeTree keyed
+-- by (month, category_id) with `ingested_at` as the version — newest wins.
+--
+-- `planned_amount` is the budget target (plannedCashFlowAmount). `actual_amount`
+-- is what was actually spent/earned in that category that month. Sign follows the
+-- category type: expense categories are negative actuals, income positive. Rows
+-- with no plan AND no actual are dropped by the poller. Empty-string category
+-- names mean the category was deleted after the budget was set.
+--
+-- Query current state with FINAL. Schema verified against budgetData (2026).
+CREATE TABLE IF NOT EXISTS setoku.monarch_budgets
+(
+    month            Date                    COMMENT 'budget month (first of month)',
+    category_id      String                  COMMENT 'Monarch category id',
+    category         LowCardinality(String)  COMMENT 'category name at observation time',
+    category_group   LowCardinality(String)  COMMENT 'parent category group name',
+    group_type       LowCardinality(String)  COMMENT 'group type (income / expense / transfer)',
+    planned_amount   Float64                 COMMENT 'budgeted/planned amount for the month, USD',
+    actual_amount    Float64                 COMMENT 'actual amount in the category that month, USD (signed by type)',
+    remaining_amount Float64                 COMMENT 'planned minus actual (Monarch-computed)',
+    ingested_at      DateTime64(3)           COMMENT 'observation time — ReplacingMergeTree version (newest wins)'
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(month)
+ORDER BY (month, category_id)
+COMMENT 'Monarch monthly budgets: planned vs actual per category. One row per (month, category); query with FINAL.';

--- a/ingest/schemas/074_monarch_holdings.sql
+++ b/ingest/schemas/074_monarch_holdings.sql
@@ -1,0 +1,37 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Monarch investment portfolio breakdown: one row per (investment account,
+-- security) captured each poll (the Web_GetHoldings / portfolio.aggregateHoldings
+-- query). Append-only time series like monarch_accounts — the latest snapshot per
+-- (account_id, security_id) is the current position; trend the series for value
+-- over time. Query the latest cut with argMax(...) GROUP BY, or
+-- ORDER BY snapshot_ts DESC LIMIT 1 BY (account_id, security_id).
+--
+-- `value` is market value (totalValue), `basis` is cost basis, `gain` = value −
+-- basis (unrealized). `price` is the latest close. Values move with the market
+-- but only actually update when Monarch syncs the account (see the daily
+-- force-refresh). Schema verified against Web_GetHoldings (2026).
+CREATE TABLE IF NOT EXISTS setoku.monarch_holdings
+(
+    snapshot_ts        DateTime64(3)           COMMENT 'when this position was observed (poll time)',
+    account_id         String                  COMMENT 'owning investment account (→ monarch_accounts.id)',
+    account_name       String                  COMMENT 'account display name at observation time',
+    security_id        String                  COMMENT 'Monarch security id',
+    ticker             LowCardinality(String)  COMMENT 'ticker symbol (empty for some manual/other holdings)',
+    name               String                  COMMENT 'security name',
+    type               LowCardinality(String)  COMMENT 'security type (equity, etf, mutual_fund, cryptocurrency, …)',
+    type_display       LowCardinality(String)  COMMENT 'human display of the type',
+    quantity           Float64                 COMMENT 'shares/units held',
+    value              Float64                 COMMENT 'market value of the position, USD (totalValue)',
+    basis              Float64                 COMMENT 'cost basis, USD',
+    gain               Float64                 COMMENT 'unrealized gain = value − basis, USD',
+    price              Float64                 COMMENT 'latest price per share (closing, falls back to current)',
+    day_change_dollars Float64                 COMMENT 'position value change on the day, USD',
+    day_change_pct     Float64                 COMMENT 'position value change on the day, percent',
+    is_manual          UInt8                   COMMENT '1 = manually tracked holding',
+    raw                String                  COMMENT 'full aggregateHoldings node JSON as observed'
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (account_id, security_id, snapshot_ts)
+TTL toDateTime(snapshot_ts) + INTERVAL 1095 DAY
+COMMENT 'Monarch investment holdings (poll-based snapshots). Latest per (account_id, security_id) = current portfolio. value=market, basis=cost, gain=unrealized. Total portfolio = sum(value) over the latest snapshot.';

--- a/plugin/skills/connect/SKILL.md
+++ b/plugin/skills/connect/SKILL.md
@@ -305,6 +305,16 @@ so enabling a source means adding its profile — see the cheat-sheet below.
 - **Mercury / generic SaaS API.** Read-only token → pull-bridge
   (`ingest/mercury-poller` is the template): set the token env, enable the
   source's profile, restart.
+- **Monarch Money (personal finance).** No API key, and Monarch **blocks
+  automated password logins** (CAPTCHA + an app-version gate; datacenter IPs also
+  hit a Cloudflare wall) — so don't try to log in from the box. Auth is a **browser
+  session**: have the human copy `session_id` + `csrftoken` from a logged-in Monarch
+  browser (DevTools → Network → an `api.monarch.com/graphql` request → Cookie header),
+  then run `deploy/set-monarch-cookie.sh --env-file /opt/setoku/.env`. Enable the
+  `monarch` profile (`ingest/monarch-poller`), restart. Pulls accounts, transactions,
+  net worth, budgets, and the investment portfolio; forces a daily institution
+  refresh at 1pm Pacific. The session expires in days-to-weeks — freshness signal is
+  `max(monarch_accounts.snapshot_ts)`.
 
 ## Box command cheat-sheet
 


### PR DESCRIPTION
Adds Monarch Money as a first-class pull-based source, modeled on the Mercury bridge. Enable with `monarch` in `COMPOSE_PROFILES`.

## What it ingests
| endpoint | table | engine |
|---|---|---|
| `/ingest/monarch/accounts` | `monarch_accounts` | MergeTree (append-only snapshots) |
| `/ingest/monarch/networth` | `monarch_net_worth` | ReplacingMergeTree — Monarch's own daily aggregate |
| `/ingest/monarch/transactions` | `monarch_transactions` | ReplacingMergeTree (rolling window) |
| `/ingest/monarch/budgets` | `monarch_budgets` | ReplacingMergeTree |
| `/ingest/monarch/holdings` | `monarch_holdings` | MergeTree — investment portfolio breakdown |

## Auth is a browser session, not an API key (the important bit)
Monarch has **no official data API**, and its `/auth/login/` endpoint **actively blocks automated password logins**. We verified all of these dead-ends against the live API:
- **Token/password login is walled off:** `/auth/login/` returns `CAPTCHA_REQUIRED`, or `"Please update to the latest version of the app"` (an app-version gate), and from a datacenter IP a Cloudflare `"You Shall Not Pass"` block.
- **The working path** — the same one the maintained community libraries moved to — is to lift a **`session_id` + `csrftoken`** from a logged-in browser and send them with an `X-Csrftoken` header. That authenticates the GraphQL API fine from the box.

So `deploy/set-monarch-cookie.sh` stores the two cookies (hidden prompt → `.env`); the poller sends cookie auth (with `MONARCH_TOKEN` kept as a best-effort fallback). Sessions last days-to-weeks; freshness signal is `max(monarch_accounts.snapshot_ts)`.

## Behavior
- **Reads hourly**, aligned to the top of the hour.
- **Daily institution force-refresh** (the UI's refresh button, `Common_ForceRefreshAccountsMutation`) at `MONARCH_REFRESH_HOUR` Pacific (default 1pm = US market close), waits ~5 min for the sync, then reads — fresh balances without hammering the banks.
- First run backfills (txns 3y, net worth 5y, budgets 18mo); later runs scan recent windows. State on the `monarch_state` volume.

## Data gotchas (in the schema comments)
- `monarch_accounts.current_balance` is **signed** (liabilities negative). Net worth = `SUM(current_balance)` — *not* assets−liabilities (double-counts debt) and *not* `SUM(display_balance)` (the UI flips liability signs). Reconciles to Monarch's own `monarch_net_worth` aggregate within ~0.2%.
- Transactions/net-worth/budgets are mutable → ReplacingMergeTree, query with `FINAL`. `amount` is signed; exclude `hide_from_reports=1` from spend/income.

## Touchpoints
`ingest/monarch-poller/` (poll.ts + Dockerfile + README), 5 schemas, `deploy/set-monarch-cookie.sh`, `docker-compose.yml` (service/profile/volume), `deploy/vector/vector.yaml` (routes/remaps/sinks), `.env.example`, and a Monarch entry in the connect skill.

## Validation
Running clean on a live box for a day+. `bun build` parses poll.ts, `docker compose config` validates, and `vector validate` passes.

https://claude.ai/code/session_01WKbk8rU1TXJVRTbXBCRvYt