### PR TITLE
Add full html/js retrieval to get_app (#59)

### DIFF
--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -1642,9 +1642,11 @@ server.registerTool(
           `- \`${pm.name}\` [${pm.type}]`,
           pm.label ? `label ${JSON.stringify(pm.label)}` : "",
           `default ${JSON.stringify(pm.default)}`,
-          pm.options?.length ? `options ${pm.options.map((o) => o.value).join("|")}` : "",
+          // Render each option as value(=label) so a round-trip preserves labels too.
+          pm.options?.length ? `options ${pm.options.map((o) => (o.label ? `${o.value}=${o.label}` : o.value)).join("|")}` : "",
           pm.min != null ? `min ${pm.min}` : "",
           pm.max != null ? `max ${pm.max}` : "",
+          pm.maxLength != null ? `maxLength ${pm.maxLength}` : "",
         ].filter(Boolean);
         lines.push(bits.join(" · "));
       }

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -1293,6 +1293,13 @@ const APP_GUIDE = [
   "read-only queries the box re-runs live and injects). Validate every panel's SQL with run_query",
   "FIRST, then publish_app; edit later with update_app (same link).",
   "",
+  "## Editing an existing app — get_app FIRST, don't rebuild",
+  "To change an app you (or anyone) already published, call get_app(id): it returns the EXACT current",
+  "`html` template, its `params`, and every panel's SQL. Edit that template and pass it back to",
+  "update_app — never reconstruct the presentation layer from inference (you'd drop custom tabs, layout,",
+  "and state-keyed overrides). update_app REPLACES what you pass, so carry back the html/panels/params you",
+  "aren't intentionally changing. You never need a browser to read an app's current markup — get_app has it.",
+  "",
   "## The template (`html`)",
   "A self-contained HTML fragment: inline <style>/<script>, inline SVG. NO external/CDN assets and NO",
   "network — data is injected, not fetched (the iframe runs under a no-network CSP).",
@@ -1602,14 +1609,20 @@ server.registerTool(
   "get_app",
   {
     annotations: { readOnlyHint: true },
-    title: "Inspect an app's panels (how it's calculated)",
+    title: "Inspect an app — its full template + panels (how it's built)",
     description:
-      "Returns a published app's panel definitions — each panel's SQL, dialect, linked metric, and " +
-      "when it last ran — so you can audit or iterate how a number is computed. Read-only.",
+      "Returns everything needed to edit a published app in place: the full presentation TEMPLATE " +
+      "(the exact `html`/JS you'd pass back to update_app), its interactive `params`, and each panel's " +
+      "SQL, dialect, linked metric, and when it last ran. Read this FIRST when iterating on an app so " +
+      "you edit the existing template rather than rebuilding it from scratch (update_app REPLACES what " +
+      "you pass). Read-only.",
     inputSchema: { id: z.string().describe("The app id from publish_app / list_apps") },
   },
   async ({ id }) => {
-    const dash = store.getPublishedMeta(id.trim());
+    // Full record (incl. the up-to-2MB template body) — get_app is the low-rate
+    // read-before-edit path, so we serve the whole template, not the body-less
+    // meta the hot viewer/gating paths use.
+    const dash = store.getPublished(id.trim());
     store.audit(user, "get_app", { id, ok: !!dash });
     if (!dash || dash.archivedAt)
       return errorText(`No active app "${id}" (archived or unknown). Call list_apps.`);
@@ -1619,9 +1632,27 @@ server.registerTool(
         (dash.refreshSeconds ? ` · refresh ${dash.refreshSeconds}s` : ""),
       "",
     ];
+    // Params first — update_app REPLACES the whole param set, so a round-trip
+    // must carry them back verbatim (name/type/default drive the shell controls).
+    const params = dash.params ?? [];
+    if (params.length) {
+      lines.push("## params (interactive inputs — bound in panel SQL as `:name`)");
+      for (const pm of params) {
+        const bits = [
+          `- \`${pm.name}\` [${pm.type}]`,
+          pm.label ? `label ${JSON.stringify(pm.label)}` : "",
+          `default ${JSON.stringify(pm.default)}`,
+          pm.options?.length ? `options ${pm.options.map((o) => o.value).join("|")}` : "",
+          pm.min != null ? `min ${pm.min}` : "",
+          pm.max != null ? `max ${pm.max}` : "",
+        ].filter(Boolean);
+        lines.push(bits.join(" · "));
+      }
+      lines.push("");
+    }
     const ps = dash.panels ?? [];
     if (!ps.length) {
-      lines.push("(no live panels — a static report.)");
+      lines.push("(no live panels — a static report.)", "");
     }
     for (const p of ps) {
       const cache = store.getPanelCache(dash.id, p.key);
@@ -1641,6 +1672,9 @@ server.registerTool(
       }
       lines.push("```sql", p.sql.trim(), "```", "");
     }
+    // The presentation template last — it's the biggest section, and the exact
+    // `html` an agent edits and passes straight back to update_app.
+    lines.push("## template (the `html` — edit this and pass it back to update_app)", "```html", dash.body, "```");
     return text(lines.join("\n"));
   },
 );

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -1633,24 +1633,18 @@ server.registerTool(
       "",
     ];
     // Params first — update_app REPLACES the whole param set, so a round-trip
-    // must carry them back verbatim (name/type/default drive the shell controls).
+    // must carry them back VERBATIM. Emit them as the exact `params` arg JSON
+    // (labels, options, min/max/maxLength and all) rather than a lossy human
+    // summary — same fidelity the body/SQL get from their fenced blocks.
     const params = dash.params ?? [];
     if (params.length) {
-      lines.push("## params (interactive inputs — bound in panel SQL as `:name`)");
-      for (const pm of params) {
-        const bits = [
-          `- \`${pm.name}\` [${pm.type}]`,
-          pm.label ? `label ${JSON.stringify(pm.label)}` : "",
-          `default ${JSON.stringify(pm.default)}`,
-          // Render each option as value(=label) so a round-trip preserves labels too.
-          pm.options?.length ? `options ${pm.options.map((o) => (o.label ? `${o.value}=${o.label}` : o.value)).join("|")}` : "",
-          pm.min != null ? `min ${pm.min}` : "",
-          pm.max != null ? `max ${pm.max}` : "",
-          pm.maxLength != null ? `maxLength ${pm.maxLength}` : "",
-        ].filter(Boolean);
-        lines.push(bits.join(" · "));
-      }
-      lines.push("");
+      lines.push(
+        "## params (interactive inputs, bound in panel SQL as `:name` — pass this array straight back to update_app)",
+        "```json",
+        JSON.stringify(params, null, 2),
+        "```",
+        "",
+      );
     }
     const ps = dash.panels ?? [];
     if (!ps.length) {

--- a/test/apps-integration.test.ts
+++ b/test/apps-integration.test.ts
@@ -125,10 +125,10 @@ describe("get_app — full round-trip (template + params + panels) (#59)", () =>
     // The template comes back verbatim — no rebuild-from-inference needed.
     expect(got.text).toContain("## template");
     expect(got.text).toContain(html);
-    // Params round-trip too (update_app REPLACES the set).
+    // Params round-trip VERBATIM (as the exact update_app arg) — not a lossy summary.
     expect(got.text).toContain("## params");
-    expect(got.text).toContain("`region` [enum]");
-    expect(got.text).toContain("options NA|EMEA|APAC");
+    const paramsJson = got.text.split("```json")[1]?.split("```")[0] ?? "";
+    expect(JSON.parse(paramsJson)).toEqual([REGION_PARAM]);
     // Panels still surfaced as before.
     expect(got.text).toContain("panel kpi");
     expect(got.text).toContain(":region");

--- a/test/apps-integration.test.ts
+++ b/test/apps-integration.test.ts
@@ -115,6 +115,26 @@ describe("publish_app — param validation", () => {
   });
 });
 
+describe("get_app — full round-trip (template + params + panels) (#59)", () => {
+  it("hands back the exact html template and declared params for edit-in-place", async () => {
+    const c = await gwConnect(BASE, "tok_boss", "pub");
+    const html = '<div id=kpi data-tab="pnl"></div><script>/*custom presentation*/renderPnl(window.__SETOKU__.panels.kpi)</script>';
+    const id = idOf((await call(c, "publish_app", { title: "Round-trip", html, panels: [REGION_PANEL], params: [REGION_PARAM] })).text);
+    const got = await call(c, "get_app", { id });
+    expect(got.isError).toBeFalsy();
+    // The template comes back verbatim — no rebuild-from-inference needed.
+    expect(got.text).toContain("## template");
+    expect(got.text).toContain(html);
+    // Params round-trip too (update_app REPLACES the set).
+    expect(got.text).toContain("## params");
+    expect(got.text).toContain("`region` [enum]");
+    expect(got.text).toContain("options NA|EMEA|APAC");
+    // Panels still surfaced as before.
+    expect(got.text).toContain("panel kpi");
+    expect(got.text).toContain(":region");
+  });
+});
+
 describe("update_app — params are first-class (validate + I9 re-gate)", () => {
   it("rejects a params-only update whose new default doesn't coerce", async () => {
     const c = await gwConnect(BASE, "tok_boss", "pub");

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -406,6 +406,9 @@ describe("app surface", () => {
     expect(got.text).toContain("count(*)");
     expect(got.text).toContain("metric:revenue");
     expect(got.text).toMatch(/1 row\(s\)/); // seeded from the publish dry-run
+    // ...and hands back the full HTML/JS template for edit-in-place (#59)
+    expect(got.text).toContain("## template");
+    expect(got.text).toContain("window.__SETOKU__.panels.paid.rows[0].n");
 
     const listed = await call("list_apps");
     expect(listed.text).toContain("Paid orders");


### PR DESCRIPTION
Closes #59.

## Problem

`get_app` called `store.getPublishedMeta()`, which deliberately omits the `body` column (the presentation template), so the tool only ever surfaced panel SQL. An agent iterating on an existing app couldn't retrieve its HTML/JS, forcing it to rebuild the presentation layer from inference — dropping custom tabs, layout, and app-state-keyed overrides — or fall back to a browser to read the markup. This is the exact frustration reported in the issue.

## Change

`get_app` now returns everything needed to edit an app in place and round-trip it back through `update_app`:

- Switches to `store.getPublished()` and appends the **exact `html` template** in a fenced block.
- Emits the app's **`params`** as a verbatim JSON block (the precise `update_app` arg — labels, options, min/max/maxLength and all), so nothing is lost on a reconstruct.
- Keeps the existing panel SQL / dialect / metric / last-run output.
- Updates the tool title + description, and adds a "get_app FIRST, don't rebuild" section to `app_guide`.

`getPublishedMeta` is unchanged and still used on the hot viewer/gating paths — this only affects the low-rate read-before-edit tool. No auth/membrane impact: `get_app` is a read (registered outside the `canWrite` block, as before), the body is presentation markup only (no injected data), and `update_app` stays author-gated.

## Tests

- New round-trip test in `test/apps-integration.test.ts` (template verbatim + params JSON parse-equal + panels).
- Extended the `app surface` e2e in `test/e2e.test.ts` to assert the template comes back.
- `bun run typecheck` clean; full fast suite green (pre-push hook).

## Review

Codex was unavailable (usage limit). Reviewed via a subagent; its main finding (params round-tripped lossily) is addressed by the verbatim-JSON approach above.