### PR TITLE
apps: render panels to the byte budget, not run_query's 200-row cap

### DIFF
--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -22,7 +22,7 @@ import { combineSynonyms, synonymsOf } from "./lib/synonyms";
 import type { EmbedIndex } from "./lib/embed-index";
 import type { DerivedSynonyms } from "./lib/derived-synonyms";
 import { KnowledgeStore, type AppPanel, type DocType } from "./lib/store";
-import { MAX_PANELS, MIN_REFRESH_SECONDS, MAX_REFRESH_SECONDS, DEFAULT_REFRESH_SECONDS, runPanel, compilePanel, isFullDoc } from "./lib/apps";
+import { MAX_PANELS, MIN_REFRESH_SECONDS, MAX_REFRESH_SECONDS, DEFAULT_REFRESH_SECONDS, MAX_RENDER_ROW_BYTES, RENDER_FETCH_CEILING, runPanel, trimRowsToBytes, compilePanel, isFullDoc } from "./lib/apps";
 import { resolveParams, paramsVariant, type AppParam } from "./lib/params";
 import { lintAppTemplate } from "./lib/app-runtime";
 import { extractSql } from "./lib/lint";
@@ -1056,7 +1056,7 @@ server.registerTool(
       }
       lines.push(
         "",
-        `${result.rowCount} row(s) in ${result.ms}ms${result.truncated ? ` — TRUNCATED at row cap (${config.rowCap}); add aggregation or LIMIT` : ""}`,
+        `${result.rowCount} row(s) in ${result.ms}ms${result.truncated ? ` — TRUNCATED at the model-context row cap (${config.rowCap}); this caps rows entering the model, NOT what an app renders. To see more: aggregate, add LIMIT/OFFSET to page, or build a panel (published panels render the full result set up to a ~3.5MB payload).` : ""}`,
       );
       // Success-path capture nudge: the query worked AND computed an aggregate
       // no curated metric covers — the one moment the definition is fresh and
@@ -1145,7 +1145,7 @@ const publishUrl = (id: string, visibility: "team" | "public" = "team"): string 
 const PANEL_KEY_RE = /^[A-Za-z0-9_-]{1,64}$/;
 
 type PanelInput = { key: string; title?: string; description?: string; sql: string; dialect?: "postgres" | "clickhouse"; metricId?: string };
-type PanelSeed = { key: string; columns: string[]; rows: Record<string, unknown>[]; rowCount: number };
+type PanelSeed = { key: string; columns: string[]; rows: Record<string, unknown>[]; rowCount: number; truncated: boolean };
 
 // Validate + dry-run a panel set through the governed path. Shared by publish and
 // update so the rules (keys, caps, the I2/I9 lake membrane via runPanel, "every
@@ -1218,8 +1218,15 @@ async function prepPanels(
     const variant = paramsVariant(compiled.referenced, resolved);
     const cacheKey = variant ? `${p.key}::${variant}` : p.key; // seed the default-params variant
     try {
-      const r = await runPanel(projectDir, config, p, compiled, { denyLakeRead });
-      seeds.push({ key: cacheKey, columns: r.columns, rows: r.rows, rowCount: r.rowCount });
+      // Seed the RENDER cache, not the model context: use the render fetch ceiling
+      // (not config.rowCap) and trim to the payload budget, exactly like a live
+      // render — otherwise the first views right after publish/update would serve a
+      // silent 200-row prefix (truncated=false) for the whole refresh TTL, breaking
+      // the "panels render the full result set" contract precisely when the author
+      // is validating the app.
+      const r = await runPanel(projectDir, config, p, compiled, { denyLakeRead, rowCap: RENDER_FETCH_CEILING });
+      const fit = trimRowsToBytes(r.rows, MAX_RENDER_ROW_BYTES);
+      seeds.push({ key: cacheKey, columns: r.columns, rows: fit.rows, rowCount: fit.rows.length, truncated: r.truncated || fit.truncated });
     } catch (e) {
       return { ok: false, error: `Panel "${p.key}" failed to run: ${(e as Error).message}\nFix the query and try again.` };
     }
@@ -1312,8 +1319,15 @@ const APP_GUIDE = [
   "`format` is one of: money | int | num (default) | pct | raw — an unknown token renders unformatted.",
   "",
   "## Raw panel data",
-  "`window.__SETOKU__.panels[<key>]` = `{ columns, rows, rowCount, computedAt, error }`.",
+  "`window.__SETOKU__.panels[<key>]` = `{ columns, rows, rowCount, truncated, computedAt, error }`.",
   "DB numerics arrive as STRINGS — wrap in Number() before any math.",
+  "",
+  "## Row limits",
+  "A panel renders its FULL result set — no 200-row cap. The only bound is a ~3.5MB payload; past it the",
+  "heaviest panel is trimmed to the rows that fit, `panels[key].truncated` is set, and the built-in",
+  "Setoku.table appends a 'showing first N rows' note. If a panel could return an unbounded table,",
+  "aggregate or add a page param rather than leaning on the byte trim. (Note: run_query itself still caps",
+  "at ~200 rows — that's the model-context cap for the agent, NOT the app render cap.)",
   "",
   "## Panels (the `panels` arg)",
   "Each panel: `{ key, sql, dialect?, title?, description?, metricId? }`.",
@@ -1430,7 +1444,7 @@ server.registerTool(
       createdBy: user,
     });
     for (const s of seeds)
-      store.putPanelCache(id, s.key, { columns: s.columns, rows: s.rows, rowCount: s.rowCount, error: null });
+      store.putPanelCache(id, s.key, { columns: s.columns, rows: s.rows, rowCount: s.rowCount, truncated: s.truncated, error: null });
     store.audit(user, "publish_app", { id, title, bytes, panels: normalized.length });
 
     const noun = format === "app" ? "app" : "report";
@@ -1544,7 +1558,7 @@ server.registerTool(
     });
     if (!ok) return errorText(`Update failed — no active app "${id}".`);
     // Re-seed the cache for the re-derived panels (updatePublished cleared the old rows).
-    if (seeds) for (const s of seeds) store.putPanelCache(tid, s.key, { columns: s.columns, rows: s.rows, rowCount: s.rowCount, error: null });
+    if (seeds) for (const s of seeds) store.putPanelCache(tid, s.key, { columns: s.columns, rows: s.rows, rowCount: s.rowCount, truncated: s.truncated, error: null });
 
     // Panels OR params alter what the public link exposes — if it was public,
     // revert to team so an admin re-approves (the human promotion gate, I9).

--- a/plugin/gateway/http.ts
+++ b/plugin/gateway/http.ts
@@ -706,6 +706,9 @@ function frameDocument(dash: PublishedReport, panels: RenderedPanel[], opts: { t
           columns: p.columns,
           rows: p.rows as unknown[],
           rowCount: p.rowCount,
+          // The served rows are a prefix of a larger result — drives the built-in
+          // table's "showing first N" note so a byte-trimmed panel isn't silent.
+          truncated: p.truncated ?? false,
           computedAt: p.computedAt,
           error: scrub(p.error),
           refreshError: scrub(p.refreshError),
@@ -765,6 +768,7 @@ function appProvenance(
         metricSummary: doc ? String(doc.meta.summary ?? "") : null,
         sql: p.sql,
         rowCount: r?.rowCount ?? 0,
+        truncated: r?.truncated ?? false,
         computedAt: r?.computedAt ?? null,
         error: r?.error ?? null,
         refreshError: r?.refreshError ?? null,

--- a/plugin/gateway/lib/app-runtime.ts
+++ b/plugin/gateway/lib/app-runtime.ts
@@ -38,11 +38,11 @@ export const APP_RUNTIME = `(function () {
   function fmtOf(f) { return typeof f === "function" ? f : (fmt[f] || fmt.raw); }
   // src is a panel key (looked up in __SETOKU__, with its error/rows) or a rows array.
   function resolve(src) {
-    if (Array.isArray(src)) return { rows: src, error: null };
+    if (Array.isArray(src)) return { rows: src, error: null, truncated: false };
     var P = (window.__SETOKU__ && window.__SETOKU__.panels) || {};
     var p = P[src];
-    if (!p) return { rows: [], error: 'unknown panel "' + src + '"' };
-    return { rows: p.rows || [], error: p.error || p.refreshError || null };
+    if (!p) return { rows: [], error: 'unknown panel "' + src + '"', truncated: false };
+    return { rows: p.rows || [], error: p.error || p.refreshError || null, truncated: !!p.truncated };
   }
   function guard(el, r) {
     if (!el) return true;
@@ -79,7 +79,13 @@ export const APP_RUNTIME = `(function () {
     var body = r.rows.map(function (row) {
       return "<tr>" + cols.map(function (c, i) { var f = fmtOf(fmts[c] || "raw"); var nums = aligns[i] === "right";
         return '<td style="padding:6px 10px;border-bottom:1px solid #f1f4f7;text-align:' + aligns[i] + (nums ? ";font-variant-numeric:tabular-nums" : "") + '">' + esc(f(row[c])) + "</td>"; }).join("") + "</tr>"; }).join("");
-    el.innerHTML = '<table style="width:100%;border-collapse:collapse;font:13px system-ui">' + head + body + "</table>";
+    // The rows are a prefix of a larger result (byte-budget trim) — say so rather
+    // than render a silently-partial table. We only know ">this many exist", never
+    // the true total, so the copy is "first N", not "N of M".
+    var note = r.truncated
+      ? '<div style="padding:6px 10px;font:12px system-ui;color:#8a99a8">showing first ' + esc(fmt.int(r.rows.length)) + " rows</div>"
+      : "";
+    el.innerHTML = '<table style="width:100%;border-collapse:collapse;font:13px system-ui">' + head + body + "</table>" + note;
   }
   function stat(target, src, opts) {
     opts = opts || {}; var el = elOf(target); if (!el) return; var r = resolve(src);
@@ -165,7 +171,7 @@ export const APP_RUNTIME = `(function () {
       var prov = {};
       for (var pk in sp) if (Object.prototype.hasOwnProperty.call(sp, pk)) {
         var pv = sp[pk];
-        prov[pk] = { rowCount: pv.rowCount, computedAt: pv.computedAt, error: pv.error, refreshError: pv.refreshError, refreshing: pv.refreshing || false, durationMs: pv.durationMs == null ? null : pv.durationMs };
+        prov[pk] = { rowCount: pv.rowCount, truncated: pv.truncated || false, computedAt: pv.computedAt, error: pv.error, refreshError: pv.refreshError, refreshing: pv.refreshing || false, durationMs: pv.durationMs == null ? null : pv.durationMs };
       }
       var t = null;
       try { t = new URLSearchParams(location.search).get("t"); } catch (e2) { /* no location */ }

--- a/plugin/gateway/lib/apps.ts
+++ b/plugin/gateway/lib/apps.ts
@@ -45,9 +45,22 @@ export const MAX_REFRESH_SECONDS = 86_400;
  *  (seeing how rich a single app wants to get); the real backstop is
  *  MAX_RENDER_ROW_BYTES, which bounds the payload regardless of panel count. */
 export const MAX_PANELS = 100;
-/** Ceiling on the serialized panel-rows payload handed to one render. Bounds the
- *  injected frame document + the cached/served JSON regardless of rowCap × panels. */
+/** Ceiling on the serialized panel-rows payload. The SOLE product bound on how many
+ *  rows a panel renders: a panel keeps its full result set until its JSON hits this,
+ *  then it's trimmed. Enforced in TWO places off this one number — per panel before
+ *  it's cached (so the durable knowledge.db entry stays bounded, I4) and across all
+ *  panels on the served copy (capRenderBytes) — so neither the injected frame nor the
+ *  cached JSON can balloon regardless of the fetch ceiling × panel count. */
 export const MAX_RENDER_ROW_BYTES = 3_500_000;
+/** Memory backstop on rows pulled into the gateway for ONE panel render before we
+ *  trim to MAX_RENDER_ROW_BYTES. NOT a product cap — the byte budget above is the
+ *  real bound; this only stops a runaway panel (a wide `SELECT *` over a huge table)
+ *  from materializing hundreds of MB and OOM-killing the gateway on a small box,
+ *  since the trim happens post-fetch and SQL can't LIMIT by bytes. Held low enough
+ *  that even KB-wide rows stay well under the box's memory, yet ~100× run_query's
+ *  200-row model-context cap — no real dashboard panel renders 25k rows to a human,
+ *  and for normal-width rows the 3.5MB byte budget bites first anyway. */
+export const RENDER_FETCH_CEILING = 25_000;
 
 /**
  * Whether a published body is a FULL HTML document (legacy "html" format, served
@@ -90,17 +103,22 @@ export async function runPanel(
   config: SetokuConfig,
   panel: AppPanel,
   compiled: CompiledPanel,
-  opts: { denyLakeRead?: boolean } = {},
+  opts: { denyLakeRead?: boolean; rowCap?: number } = {},
 ): Promise<QueryOutcome> {
+  // The render path passes RENDER_FETCH_CEILING here so panels aren't held to
+  // run_query's small model-context rowCap — rows go into a human-viewed iframe
+  // bounded by MAX_RENDER_ROW_BYTES, not into the model. Absent (run_query, the
+  // publish dry-run), it falls back to config.rowCap (the 200-row context cap).
+  const caps = { rowCap: opts.rowCap ?? config.rowCap, statementTimeoutMs: config.statementTimeoutMs };
   if (panel.dialect === "clickhouse") {
     if (opts.denyLakeRead) throw new Error(LAKE_MEMBRANE_ERROR);
     const lake = resolveLakeUrl(projectDir, config);
     if (!lake.ok) throw new Error(lake.error);
-    return runLakeQuery(lake.url, compiled.text, config, compiled.chParams ?? {});
+    return runLakeQuery(lake.url, compiled.text, caps, compiled.chParams ?? {});
   }
   const db = resolveDatabaseUrl(projectDir, config);
   if (!db.ok) throw new Error(db.error);
-  return runReadOnlyQuery(db.url, compiled.text, config, compiled.values ?? []);
+  return runReadOnlyQuery(db.url, compiled.text, caps, compiled.values ?? []);
 }
 
 /** Compile a panel's `:name` tokens to engine placeholders + bound values, using
@@ -128,6 +146,10 @@ export interface RenderedPanel {
   columns: string[];
   rows: Record<string, unknown>[];
   rowCount: number;
+  /** The served rows are a PREFIX of a larger result — either the render fetch
+   *  ceiling was hit (rare) or capRenderBytes trimmed the panel to fit the
+   *  payload budget. Drives the "showing first N rows" affordance; never silent. */
+  truncated: boolean;
   /** When the served rows were computed (cache or fresh run). */
   computedAt: string;
   /** A hard error with no prior good data to fall back to. */
@@ -193,11 +215,15 @@ function startBackgroundRefresh(
   const p = (async () => {
     const t0 = performance.now();
     try {
-      const r = await runPanel(projectDir, config, panel, compiled, { denyLakeRead: opts.denyLakeRead });
+      const r = await runPanel(projectDir, config, panel, compiled, { denyLakeRead: opts.denyLakeRead, rowCap: RENDER_FETCH_CEILING });
+      // Trim to the payload budget before caching — keep the durable cache bounded
+      // (see the blocking path in renderUncoalesced for why).
+      const fit = trimRowsToBytes(r.rows, MAX_RENDER_ROW_BYTES);
       store.putPanelCache(appId, cacheKey, {
         columns: r.columns,
-        rows: r.rows,
-        rowCount: r.rowCount,
+        rows: fit.rows,
+        rowCount: fit.rows.length,
+        truncated: r.truncated || fit.truncated,
         error: null,
         durationMs: Math.round(performance.now() - t0),
       });
@@ -276,7 +302,7 @@ async function renderUncoalesced(
   // promise and fan a 500 out to every concurrent viewer of this app.
   const rendered = await Promise.all(
     panels.map(async (panel): Promise<RenderedPanel> => {
-      const base = { key: panel.key, title: panel.title, dialect: panel.dialect, metricId: panel.metricId ?? null };
+      const base = { key: panel.key, title: panel.title, dialect: panel.dialect, metricId: panel.metricId ?? null, truncated: false };
       try {
         // Compile + bind first (throws on an undeclared :param → caught below as a
         // panel error). The cache key folds in the param VARIANT so different
@@ -289,7 +315,7 @@ async function renderUncoalesced(
         const cacheLimit = cached?.error ? Math.min(ERROR_TTL_MS, limit) : limit;
         const fresh = !opts.force && cached != null && now - Date.parse(cached.computedAt) < cacheLimit;
         if (fresh && cached) {
-          return { ...base, columns: cached.columns, rows: cached.rows, rowCount: cached.rowCount, computedAt: cached.computedAt, error: cached.error, durationMs: cached.durationMs };
+          return { ...base, columns: cached.columns, rows: cached.rows, rowCount: cached.rowCount, truncated: cached.truncated, computedAt: cached.computedAt, error: cached.error, durationMs: cached.durationMs };
         }
         // Stale-while-revalidate: past the TTL but holding last-good rows within
         // the stale ceiling, serve them IMMEDIATELY (their real computedAt keeps
@@ -302,8 +328,8 @@ async function renderUncoalesced(
         if (!opts.force && cached != null && !cached.error && config != null && now - Date.parse(cached.computedAt) < staleCeiling) {
           const running = startBackgroundRefresh(store, projectDir, config, dash.id, panel, compiled, cacheKey, opts);
           return running
-            ? { ...base, columns: cached.columns, rows: cached.rows, rowCount: cached.rowCount, computedAt: cached.computedAt, error: null, refreshing: true, durationMs: cached.durationMs }
-            : { ...base, columns: cached.columns, rows: cached.rows, rowCount: cached.rowCount, computedAt: cached.computedAt, error: null, refreshError: "refresh rate-limited — showing the last cached result", durationMs: cached.durationMs };
+            ? { ...base, columns: cached.columns, rows: cached.rows, rowCount: cached.rowCount, truncated: cached.truncated, computedAt: cached.computedAt, error: null, refreshing: true, durationMs: cached.durationMs }
+            : { ...base, columns: cached.columns, rows: cached.rows, rowCount: cached.rowCount, truncated: cached.truncated, computedAt: cached.computedAt, error: null, refreshError: "refresh rate-limited — showing the last cached result", durationMs: cached.durationMs };
         }
         // About to run a fresh query — but the caller may cap fresh executions
         // (the public per-app budget). Charge ONLY here, on a real cache miss, so
@@ -312,7 +338,7 @@ async function renderUncoalesced(
         // open-domain params can't keep missing the cache and re-hitting prod.
         if (opts.tryFreshRun && !opts.tryFreshRun()) {
           if (cached && !cached.error)
-            return { ...base, columns: cached.columns, rows: cached.rows, rowCount: cached.rowCount, computedAt: cached.computedAt, error: null, refreshError: "refresh rate-limited — showing the last cached result" };
+            return { ...base, columns: cached.columns, rows: cached.rows, rowCount: cached.rowCount, truncated: cached.truncated, computedAt: cached.computedAt, error: null, refreshError: "refresh rate-limited — showing the last cached result" };
           return { ...base, columns: [], rows: [], rowCount: 0, computedAt: new Date(now).toISOString(), error: "Too many distinct queries on this link right now — try again shortly." };
         }
         // Keep last-good rows on a failed refresh ONLY while they're within the
@@ -321,20 +347,27 @@ async function renderUncoalesced(
         if (!config) {
           const msg = cfg.ok ? "no config" : cfg.error;
           if (keepLastGood && cached)
-            return { ...base, columns: cached.columns, rows: cached.rows, rowCount: cached.rowCount, computedAt: cached.computedAt, error: null, refreshError: msg };
+            return { ...base, columns: cached.columns, rows: cached.rows, rowCount: cached.rowCount, truncated: cached.truncated, computedAt: cached.computedAt, error: null, refreshError: msg };
           return { ...base, columns: [], rows: [], rowCount: 0, computedAt: new Date(now).toISOString(), error: msg };
         }
         const t0 = performance.now();
         try {
-          const r = await runPanel(projectDir, config, panel, compiled, { denyLakeRead: opts.denyLakeRead });
+          const r = await runPanel(projectDir, config, panel, compiled, { denyLakeRead: opts.denyLakeRead, rowCap: RENDER_FETCH_CEILING });
           const durationMs = Math.round(performance.now() - t0);
-          const computedAt = store.putPanelCache(dash.id, cacheKey, { columns: r.columns, rows: r.rows, rowCount: r.rowCount, error: null, durationMs });
-          return { ...base, columns: r.columns, rows: r.rows, rowCount: r.rowCount, computedAt, error: null, durationMs };
+          // Trim to the payload budget BEFORE caching so the durable knowledge.db
+          // (I4) never stores more than MAX_RENDER_ROW_BYTES per entry — capRenderBytes
+          // trims only the served copy, so without this the cache would keep the full
+          // up-to-RENDER_FETCH_CEILING result. A warm hit then serves this bounded copy
+          // and capRenderBytes early-returns (no re-serialization) unless co-panels overflow.
+          const fit = trimRowsToBytes(r.rows, MAX_RENDER_ROW_BYTES);
+          const truncated = r.truncated || fit.truncated;
+          const computedAt = store.putPanelCache(dash.id, cacheKey, { columns: r.columns, rows: fit.rows, rowCount: fit.rows.length, truncated, error: null, durationMs });
+          return { ...base, columns: r.columns, rows: fit.rows, rowCount: fit.rows.length, truncated, computedAt, error: null, durationMs };
         } catch (e) {
           const msg = (e as Error).message;
           const durationMs = Math.round(performance.now() - t0);
           if (keepLastGood && cached)
-            return { ...base, columns: cached.columns, rows: cached.rows, rowCount: cached.rowCount, computedAt: cached.computedAt, error: null, refreshError: msg, durationMs: cached.durationMs };
+            return { ...base, columns: cached.columns, rows: cached.rows, rowCount: cached.rowCount, truncated: cached.truncated, computedAt: cached.computedAt, error: null, refreshError: msg, durationMs: cached.durationMs };
           const computedAt = store.putPanelCache(dash.id, cacheKey, { columns: [], rows: [], rowCount: 0, error: msg, durationMs });
           return { ...base, columns: [], rows: [], rowCount: 0, computedAt, error: msg, durationMs };
         }
@@ -348,23 +381,64 @@ async function renderUncoalesced(
   return rendered;
 }
 
+/** Largest row PREFIX whose serialized JSON fits `budget` bytes, plus whether we
+ *  actually dropped any (so a partial result flags itself). Binary-searches the
+ *  cut point; only called on an over-budget panel, so the common case never pays
+ *  it. `budget <= 0` (a co-panel already filled the payload) yields no rows. */
+export function trimRowsToBytes(
+  rows: Record<string, unknown>[],
+  budget: number,
+): { rows: Record<string, unknown>[]; truncated: boolean } {
+  if (budget <= 0) return { rows: [], truncated: rows.length > 0 };
+  if (JSON.stringify(rows).length <= budget) return { rows, truncated: false };
+  let lo = 0;
+  let hi = rows.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (JSON.stringify(rows.slice(0, mid)).length <= budget) lo = mid;
+    else hi = mid - 1;
+  }
+  return { rows: rows.slice(0, lo), truncated: true };
+}
+
 /**
- * Bound the serialized panel-rows payload so the injected frame and the cached
- * JSON can't balloon past MAX_RENDER_ROW_BYTES (rowCap × MAX_PANELS could). Drop
- * the heaviest panels' rows first and mark them errored — applied to the shared
- * RenderedPanel[] so the frame AND the provenance drawer agree. Sizes are
- * computed once (no re-serialization per comparison).
+ * Bound the SERVED panel-rows payload (the injected frame + provenance) so it can't
+ * balloon past MAX_RENDER_ROW_BYTES across all panels. Each panel is already trimmed
+ * to the budget individually before caching (see renderUncoalesced), so this only
+ * bites when SEVERAL panels together overflow. Allocates the budget MAX-MIN FAIRLY —
+ * lightest-first, each panel may take an equal split of what's left, and a panel
+ * under its share frees the remainder for the heavier ones — so every over-budget
+ * panel is trimmed to a partial prefix rather than the single heaviest one vanishing
+ * (a partial table, with its "showing first N" note, beats a dropped one). A panel is
+ * dropped with an error only if its fair share can't hold even one row. Mutates the
+ * shared RenderedPanel[] so the frame AND the provenance drawer agree.
  */
 function capRenderBytes(panels: RenderedPanel[]): void {
   const sizes = panels.map((p) => JSON.stringify(p.rows).length);
-  let total = sizes.reduce((a, b) => a + b, 0);
-  if (total <= MAX_RENDER_ROW_BYTES) return;
-  for (const i of panels.map((_, i) => i).sort((a, b) => sizes[b] - sizes[a])) {
-    if (total <= MAX_RENDER_ROW_BYTES) break;
-    total -= sizes[i];
-    panels[i].error = panels[i].error ?? `result too large to render (${panels[i].rowCount} rows) — aggregate in the panel query`;
-    panels[i].rows = [];
-    panels[i].columns = [];
+  if (sizes.reduce((a, b) => a + b, 0) <= MAX_RENDER_ROW_BYTES) return;
+  const order = panels.map((_, i) => i).sort((a, b) => sizes[a] - sizes[b]);
+  let remaining = MAX_RENDER_ROW_BYTES;
+  let left = order.length;
+  for (const i of order) {
+    const share = Math.floor(remaining / left);
+    left--;
+    if (sizes[i] <= share) {
+      remaining -= sizes[i]; // fits its fair share whole — surplus flows to the rest
+      continue;
+    }
+    const p = panels[i];
+    const { rows } = trimRowsToBytes(p.rows, share);
+    if (rows.length === 0) {
+      // Even one row won't fit this panel's share — nothing partial to show.
+      p.error = p.error ?? `result too large to render (${p.rowCount} rows) — aggregate in the panel query`;
+      p.rows = [];
+      p.columns = [];
+    } else {
+      p.rows = rows;
+      p.rowCount = rows.length;
+      p.truncated = true;
+    }
+    remaining -= JSON.stringify(p.rows).length;
   }
 }
 

--- a/plugin/gateway/lib/store.ts
+++ b/plugin/gateway/lib/store.ts
@@ -172,6 +172,9 @@ export interface PanelCacheRow {
   columns: string[];
   rows: Record<string, unknown>[];
   rowCount: number;
+  /** The cached rows are a PREFIX of a larger result (byte-budget trim). Legacy
+   *  rows written before this column read as false. */
+  truncated: boolean;
   computedAt: string;
   error: string | null;
   /** Wall-clock ms of the query execution that produced this row (null on
@@ -419,6 +422,7 @@ export class KnowledgeStore {
       PRIMARY KEY (app_id, panel_key)
     )`);
     this.ensureColumn("app_cache", "duration_ms", "INTEGER");
+    this.ensureColumn("app_cache", "truncated", "INTEGER");
     // Carry the pre-rename cache forward (dashboard_cache → app_cache, same shape
     // but for the renamed key column). Without this an upgraded box cold-starts
     // every app's cache — the first view of each re-runs all its panels against
@@ -1101,16 +1105,17 @@ export class KnowledgeStore {
   getPanelCache(appId: string, panelKey: string): PanelCacheRow | null {
     const row = this.db
       .query(
-        "SELECT columns, rows, row_count AS rowCount, computed_at AS computedAt, error, duration_ms AS durationMs FROM app_cache WHERE app_id = ? AND panel_key = ?",
+        "SELECT columns, rows, row_count AS rowCount, truncated, computed_at AS computedAt, error, duration_ms AS durationMs FROM app_cache WHERE app_id = ? AND panel_key = ?",
       )
       .get(appId, panelKey) as
-      | { columns: string; rows: string; rowCount: number; computedAt: string; error: string | null; durationMs: number | null }
+      | { columns: string; rows: string; rowCount: number; truncated: number | null; computedAt: string; error: string | null; durationMs: number | null }
       | null;
     if (!row) return null;
     return {
       columns: parseJsonArray(row.columns) as string[],
       rows: parseJsonArray(row.rows) as Record<string, unknown>[],
       rowCount: row.rowCount,
+      truncated: !!row.truncated,
       computedAt: row.computedAt,
       error: row.error,
       durationMs: row.durationMs,
@@ -1121,21 +1126,23 @@ export class KnowledgeStore {
   putPanelCache(
     appId: string,
     panelKey: string,
-    data: { columns: string[]; rows: Record<string, unknown>[]; rowCount: number; error?: string | null; durationMs?: number | null },
+    data: { columns: string[]; rows: Record<string, unknown>[]; rowCount: number; truncated?: boolean; error?: string | null; durationMs?: number | null },
   ): string {
     const computedAt = new Date().toISOString();
     this.db.run(
-      `INSERT INTO app_cache (app_id, panel_key, columns, rows, row_count, computed_at, error, duration_ms)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO app_cache (app_id, panel_key, columns, rows, row_count, truncated, computed_at, error, duration_ms)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(app_id, panel_key) DO UPDATE SET
          columns = excluded.columns, rows = excluded.rows, row_count = excluded.row_count,
-         computed_at = excluded.computed_at, error = excluded.error, duration_ms = excluded.duration_ms`,
+         truncated = excluded.truncated, computed_at = excluded.computed_at,
+         error = excluded.error, duration_ms = excluded.duration_ms`,
       [
         appId,
         panelKey,
         JSON.stringify(data.columns ?? []),
         JSON.stringify(data.rows ?? []),
         data.rowCount ?? 0,
+        data.truncated ? 1 : 0,
         computedAt,
         data.error ?? null,
         data.durationMs ?? null,

--- a/test/apps-integration.test.ts
+++ b/test/apps-integration.test.ts
@@ -14,7 +14,7 @@ import path from "node:path";
 import pgPkg from "pg";
 import { Database } from "bun:sqlite";
 import { KnowledgeStore } from "../plugin/gateway/lib/store";
-import { renderApp, flushBackgroundPanelRefreshes } from "../plugin/gateway/lib/apps";
+import { renderApp, flushBackgroundPanelRefreshes, MAX_RENDER_ROW_BYTES } from "../plugin/gateway/lib/apps";
 import { hashPassword } from "../plugin/gateway/lib/accounts";
 import { spawnGateway, waitHealthy, connect as gwConnect, call, ROOT } from "./lib/gateway";
 
@@ -33,7 +33,7 @@ const idOf = (text: string): string => text.match(/update_app\("([^"]+)"/)?.[1] 
 
 /** Parse the injected window.__SETOKU__ from a rendered frame document. */
 function setokuOf(html: string): {
-  panels: Record<string, { rows: Record<string, unknown>[]; error: string | null }>;
+  panels: Record<string, { rows: Record<string, unknown>[]; error: string | null; truncated?: boolean; rowCount?: number }>;
   params: Record<string, string>;
 } {
   const json = html.split("window.__SETOKU__=")[1]?.split("</script>")[0]?.replace(/;\s*$/, "") ?? "{}";
@@ -337,6 +337,20 @@ describe("cache migration — pre-rename dashboard_cache carries forward", () =>
   });
 });
 
+describe("publish seeds the FULL result set (no silent 200-row prefix)", () => {
+  it("serves all rows on the first render after publish, not a 200-row seed", async () => {
+    const c = await gwConnect(BASE, "tok_boss", "seed");
+    const panel = { key: "kpi", title: "rows", sql: "select g from generate_series(1, 500) g", dialect: "postgres" };
+    const id = idOf((await call(c, "publish_app", { title: "Big seed", html: "<div id=kpi></div>", panels: [panel] })).text);
+    // The FIRST view (well within the TTL) is served straight from the publish seed —
+    // it must already carry all 500 rows, not a 200-row prefix, and not flag truncated.
+    const { cookie } = await login();
+    const kpi = setokuOf(await (await fetch(`${BASE}/admin/frame/${id}`, { headers: { cookie } })).text()).panels.kpi;
+    expect(kpi.rows.length).toBe(500);
+    expect(kpi.truncated).toBe(false);
+  });
+});
+
 describe("stale-while-revalidate + run-duration telemetry (renderApp direct)", () => {
   // renderApp resolves the business DB in-process (same config path the gateway
   // uses) — point it at this suite's throwaway Postgres.
@@ -433,6 +447,74 @@ describe("stale-while-revalidate + run-duration telemetry (renderApp direct)", (
     expect(forced[0].refreshing).toBeFalsy();
     expect(Date.parse(forced[0].computedAt)).toBeGreaterThanOrEqual(Date.parse(cold[0].computedAt));
     expect(forced[0].computedAt).not.toBe(cold[0].computedAt);
+    store.db.close();
+  });
+});
+
+describe("panel row cap decoupled from run_query (byte-bounded render)", () => {
+  // Panels render to a human in the iframe, not into the model's context, so the
+  // render path passes RENDER_FETCH_CEILING to runPanel — NOT config.rowCap (200,
+  // which still governs run_query). The only bound on a panel is MAX_RENDER_ROW_BYTES.
+  process.env.SETOKU_DATABASE_URL = DB_URL;
+
+  const mkRowsDash = (id: string, sql: string) => ({
+    id, title: "t", format: "app" as const, body: "<div id=kpi></div>",
+    refreshSeconds: 30, visibility: "team" as const, createdBy: "test",
+    createdAt: new Date().toISOString(), archivedAt: null,
+    panels: [{ key: "kpi", title: "n", sql, dialect: "postgres" as const }],
+    params: [],
+  });
+
+  it("renders the full result set — no 200-row model-context cap on panels", async () => {
+    const store = new KnowledgeStore(":memory:");
+    // 500 rows > the 200 run_query rowCap; a panel must return them ALL.
+    const r = await renderApp(store, tmp, mkRowsDash("cap-full", "select g from generate_series(1, 500) g"));
+    expect(r[0].error).toBeNull();
+    expect(r[0].rows.length).toBe(500);
+    expect(r[0].truncated).toBe(false);
+    store.db.close();
+  });
+
+  it("trims to the byte budget and marks truncated (a partial table, never dropped)", async () => {
+    const store = new KnowledgeStore(":memory:");
+    // Wide rows whose full set (~12k × ~400B) blows past MAX_RENDER_ROW_BYTES (3.5MB).
+    const r = await renderApp(store, tmp, mkRowsDash("cap-bytes", "select g, repeat('x', 400) pad from generate_series(1, 12000) g"));
+    expect(r[0].error).toBeNull(); // trimmed to fit — NOT dropped with an error
+    expect(r[0].truncated).toBe(true);
+    expect(r[0].rows.length).toBeGreaterThan(0); // still a usable prefix
+    expect(r[0].rows.length).toBeLessThan(12000);
+    expect(JSON.stringify(r[0].rows).length).toBeLessThanOrEqual(MAX_RENDER_ROW_BYTES);
+    store.db.close();
+  });
+
+  it("splits the byte budget fairly across panels — none is dropped whole", async () => {
+    const store = new KnowledgeStore(":memory:");
+    // Two panels each ~3.3MB (under the 3.5MB per-panel budget on their own) but
+    // ~6.6MB together — capRenderBytes must trim BOTH to a fair share, not vanish one.
+    const wide = "select g, repeat('x', 400) pad from generate_series(1, 8000) g";
+    const dash = {
+      id: "cap-fair", title: "t", format: "app" as const, body: "<div></div>",
+      refreshSeconds: 30, visibility: "team" as const, createdBy: "test", createdAt: new Date().toISOString(), archivedAt: null,
+      panels: [{ key: "a", title: "a", sql: wide, dialect: "postgres" as const }, { key: "b", title: "b", sql: wide, dialect: "postgres" as const }],
+      params: [],
+    };
+    const r = await renderApp(store, tmp, dash);
+    const byKey = Object.fromEntries(r.map((p) => [p.key, p]));
+    for (const k of ["a", "b"]) {
+      expect(byKey[k].error).toBeNull();       // trimmed, not dropped with an error
+      expect(byKey[k].truncated).toBe(true);
+      expect(byKey[k].rows.length).toBeGreaterThan(0);
+    }
+    expect(r.reduce((n, p) => n + JSON.stringify(p.rows).length, 0)).toBeLessThanOrEqual(MAX_RENDER_ROW_BYTES);
+    store.db.close();
+  });
+
+  it("persists and reads back the truncated flag (rows without it read false)", () => {
+    const store = new KnowledgeStore(":memory:");
+    store.putPanelCache("t", "cut", { columns: ["g"], rows: [{ g: 1 }], rowCount: 1, truncated: true });
+    expect(store.getPanelCache("t", "cut")!.truncated).toBe(true);
+    store.putPanelCache("t", "whole", { columns: ["g"], rows: [{ g: 1 }], rowCount: 1 });
+    expect(store.getPanelCache("t", "whole")!.truncated).toBe(false);
     store.db.close();
   });
 });

--- a/test/lake.test.ts
+++ b/test/lake.test.ts
@@ -104,7 +104,7 @@ describe.skipIf(!CH_URL)("run_query dialect routing (lake)", () => {
       dialect: "clickhouse",
     });
     expect(r.isError).toBe(false);
-    expect(r.text).toContain("TRUNCATED at row cap"); // fixture config caps at 50
+    expect(r.text).toContain("TRUNCATED at the model-context row cap (50)"); // fixture config caps at 50
   });
 
   it("rejects mutations at the statement gate", async () => {


### PR DESCRIPTION
## What & why

Two teammates hit the same thing: app **panels cap at ~200 rows** instead of returning all results, and Setoku only paginates when explicitly asked.

**Root cause:** one global `rowCap` (200) was shared by two paths with opposite needs — `run_query` (rows enter Claude's *context*, where 200 is protective) and **live app panels** (rows render into a human-viewed iframe that's *already* separately bounded to ~3.5MB). Panels inheriting the model-context cap is the bug: a "top customers" table silently showed its first 200 rows, and `RenderedPanel` had no `truncated` flag, so nothing — viewer or app JS — knew data was cut.

## The change

- **Decouple the caps.** `runPanel` takes an optional `rowCap`; the render, background-refresh, and publish/update **seed** paths pass `RENDER_FETCH_CEILING` (a memory backstop) instead of `config.rowCap`. `run_query` and validation stay at 200. Panels are now bounded solely by the existing `MAX_RENDER_ROW_BYTES` (~3.5MB).
- **Kill silent truncation.** Thread a `truncated` flag through `RenderedPanel` → the `app_cache` table (new column + idempotent migration) → `window.__SETOKU__` → provenance drawer → runtime echo. The built-in `Setoku.table` appends a "showing first N rows" note.
- **Trim before caching.** Each panel is trimmed to the byte budget *before* `putPanelCache`, so the durable `knowledge.db` (I4) never stores more than `MAX_RENDER_ROW_BYTES` per entry.
- **Fair multi-panel trim.** `capRenderBytes` now splits the payload budget max-min fairly and trims each over-budget panel to a partial prefix, instead of dropping the single heaviest whole.
- **Guidance.** `run_query`'s truncation footer explains the two caps and how to get more; `APP_GUIDE` gains a "Row limits" note and `truncated` in the panel-data shape.

## Review notes

This branch was reviewed with `/code-review high`, which surfaced five real defects in the first cut (an OOM window from a 200k fetch ceiling, durable-cache bloat from caching untrimmed rows, a publish-seed path that served a silent 200-row prefix, `capRenderBytes` dropping the heaviest panel instead of trimming it, and repeated multi-MB re-serialization). All five are fixed here and covered by the tests below.

## Tests

`bun run typecheck` clean; full fast suite **352 pass / 0 fail**. New regression tests in `test/apps-integration.test.ts`:
- full result set renders past the old 200-row cap (`truncated: false`)
- byte-budget trim marks `truncated` and serves a non-empty prefix (never dropped)
- fair split across two large panels — neither vanishes
- publish seed serves the full set on the first render (no silent 200-row prefix)
- `truncated` round-trips through the cache

## Follow-up (not automated here)

The visual "showing first N rows" caption in a real Chrome render is covered by inspection, not an e2e — worth a pass through the `dashboard-visual-e2e` loop before/after deploy.