### PR TITLE
Activity notifications + app update messages (#63)

### DIFF
--- a/demo/docker-compose.demo.yml
+++ b/demo/docker-compose.demo.yml
@@ -113,6 +113,9 @@ services:
       # Optional curator token (commit curated knowledge; cannot read the lake — I2)
       SETOKU_CURATOR_TOKENS: ${DEMO_CURATOR_TOKENS:-}
       SETOKU_PUBLIC_URL: ${DEMO_PUBLIC_URL:-http://localhost:8788}
+      # Optional Slack incoming webhook for activity notifications (issue #63):
+      # app published/updated, and a new version deployed. Unset → off.
+      SETOKU_NOTIFY_WEBHOOK: ${DEMO_NOTIFY_WEBHOOK:-}
       # The demo lake — run_query dialect "clickhouse" + the biz.* mirror.
       # Connects as the engine-constrained read-only user (I9), like prod.
       SETOKU_LAKE_URL: http://setoku_ro:${DEMO_CH_RO_PASSWORD:-demo}@demo-clickhouse:8123/setoku

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -129,6 +129,10 @@ The net loop: canary + generate + triage turn every pending item into a linted, 
 
 `deploy.sh` also runs the lint once after each deploy as a **warn-only** step (it never blocks a ship). See [`deploy/backup/cron.example`](./backup/cron.example) for the full crontab.
 
+## 6. Activity notifications (optional)
+
+Set `SETOKU_NOTIFY_WEBHOOK` in `/opt/setoku/.env` to a Slack incoming-webhook URL and the box posts a line when an app is **published** or **updated** (with the author’s update note), and when a **new version is deployed** (fired once, on the first boot of a changed version). It uses the same `{"text": …}` shape as the alert webhook, so any Slack-compatible endpoint works. Unset means notifications are off. To read the URL from a different env var, set `notifications.slackWebhookEnv` in `.setoku/config.json`; the URL itself never lives in config (so it never reaches the model).
+
 ## Notes
 
 - **Analyst tokens are propose-only (I2/I9).** They get the read tools +

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,11 @@ services:
       SETOKU_JANITOR_TOKENS: ${SETOKU_JANITOR_TOKENS:-}
       SETOKU_DATABASE_URL: ${SETOKU_DATABASE_URL:-}
       SETOKU_PUBLIC_URL: https://${SETOKU_DOMAIN:-localhost}
+      # Optional Slack incoming webhook for activity notifications (issue #63):
+      # app published/updated, and a new version deployed. Same `{text}` shape as
+      # the alert webhook. Unset → notifications are simply off. Override the env
+      # var name with .setoku/config.json notifications.slackWebhookEnv.
+      SETOKU_NOTIFY_WEBHOOK: ${SETOKU_NOTIFY_WEBHOOK:-}
       SETOKU_HEALTHZ_PING: ${SETOKU_HEALTHZ_PING:-}
       # run_query dialect "clickhouse" (I5) — connects as the read-only
       # engine-constrained user (deploy/clickhouse/lake-users.xml), NOT the

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -29,6 +29,7 @@ import { extractSql } from "./lib/lint";
 import { queryCaptureNudge, panelCaptureNote, mirrorSteerNote, panelMirrorNote, mirrorHits, type MirrorRef } from "./lib/nudge";
 import { mirroredTables, type MirroredTable } from "./lib/mirror";
 import { LAKE_SOURCES } from "./lib/sources";
+import { notifyActivity } from "./lib/notify";
 import { VERSION } from "./lib/version";
 
 /**
@@ -1125,6 +1126,9 @@ server.registerTool(
 // a clickhouse-dialect panel, see runPanel's membrane check).
 
 const MAX_REPORT_BYTES = 2_000_000; // ~2 MB of template HTML; keep it self-contained, not an asset bundle
+// A one-line changelog note for an update, shown in version history and the
+// activity notification (issue #63). A sentence, not a document.
+const MAX_UPDATE_MESSAGE_CHARS = 500;
 
 const mintShareId = (): string =>
   Array.from(crypto.getRandomValues(new Uint8Array(12)))
@@ -1446,6 +1450,15 @@ server.registerTool(
     for (const s of seeds)
       store.putPanelCache(id, s.key, { columns: s.columns, rows: s.rows, rowCount: s.rowCount, truncated: s.truncated, error: null });
     store.audit(user, "publish_app", { id, title, bytes, panels: normalized.length });
+    // Announce it to the team channel (issue #63) — detached and best-effort, so
+    // a slow/absent webhook never delays the publish response.
+    void notifyActivity(projectDir, {
+      kind: "app_published",
+      title: title.trim() || "Untitled app",
+      url: publishUrl(id),
+      by: user,
+      panels: normalized.length,
+    });
 
     const noun = format === "app" ? "app" : "report";
     return text(
@@ -1472,6 +1485,8 @@ server.registerTool(
       "Only the app's AUTHOR can edit it. " +
       "Note: changing `panels` or `params` on an app that's currently public reverts it to team-only — an admin " +
       "must re-approve it for the public link, since the data it exposes changed. " +
+      "Pass a `message` describing WHAT changed — it shows in the app's version history and the team's activity " +
+      "notification. " +
       "The `html` template + `Setoku.*` helper + panels/params contract is documented by app_guide — call it if you haven't.",
     inputSchema: {
       id: z.string().describe("The app id (from publish_app / list_apps)"),
@@ -1480,9 +1495,13 @@ server.registerTool(
       panels: z.array(PANEL_SCHEMA).optional().describe("New panel set — REPLACES all panels. Pass [] for a state-only or static app."),
       params: z.array(PARAM_SCHEMA).optional().describe("New interactive inputs — REPLACES all params (pass [] to remove). See publish_app."),
       refreshSeconds: z.number().optional().describe(`New refresh interval (${MIN_REFRESH_SECONDS}–${MAX_REFRESH_SECONDS})`),
+      message: z
+        .string()
+        .optional()
+        .describe('A short note on WHAT changed, shown in version history and the activity notification (e.g. "Added a weekly revenue panel").'),
     },
   },
-  async ({ id, title, html, panels, params, refreshSeconds }) => {
+  async ({ id, title, html, panels, params, refreshSeconds, message }) => {
     const tid = id.trim();
     const meta = store.getPublishedMeta(tid);
     if (!meta || meta.archivedAt)
@@ -1497,6 +1516,11 @@ server.registerTool(
       if (bytes > MAX_REPORT_BYTES)
         return errorText(`Template is ${(bytes / 1e6).toFixed(1)} MB — over the ${MAX_REPORT_BYTES / 1e6} MB cap.`);
     }
+    // Whitespace-only message is a no-op (same as an unset one); a real note is
+    // capped to a sentence — it's a changelog line, not a document.
+    const note = message?.trim() || undefined;
+    if (note && note.length > MAX_UPDATE_MESSAGE_CHARS)
+      return errorText(`message is ${note.length} chars — keep it under ${MAX_UPDATE_MESSAGE_CHARS} (a one-line summary of what changed).`);
 
     // Panels AND params both determine what the panels compute (params bind into
     // the SQL), so a change to EITHER must be validated and re-seeded — and, on a
@@ -1555,7 +1579,7 @@ server.registerTool(
       params: paramsChanged ? (params as AppParam[]) : undefined,
       format,
       refreshSeconds: refresh,
-    }, { editor: user });
+    }, { editor: user, note });
     if (!ok) return errorText(`Update failed — no active app "${id}".`);
     // Re-seed the cache for the re-derived panels (updatePublished cleared the old rows).
     if (seeds) for (const s of seeds) store.putPanelCache(tid, s.key, { columns: s.columns, rows: s.rows, rowCount: s.rowCount, truncated: s.truncated, error: null });
@@ -1571,6 +1595,24 @@ server.registerTool(
       id: tid,
       changed: [newTitle !== undefined && "title", html !== undefined && "html", panelsChanged && "panels", paramsChanged && "params", refreshSeconds !== undefined && "refreshSeconds"].filter(Boolean),
       reverted,
+    });
+    // Announce it to the team channel (issue #63). The changed-facet vocabulary
+    // matches the version-history drawer (content/data/inputs) so the note and
+    // the UI read the same way. Detached + best-effort — never blocks the reply.
+    const changedFacets = [
+      newTitle !== undefined && "title",
+      html !== undefined && "content",
+      panelsChanged && "data",
+      paramsChanged && "inputs",
+      refreshSeconds !== undefined && "refresh",
+    ].filter(Boolean) as string[];
+    void notifyActivity(projectDir, {
+      kind: "app_updated",
+      title: newTitle ?? meta.title,
+      url: publishUrl(tid, reverted ? "team" : meta.visibility),
+      by: user,
+      changed: changedFacets,
+      message: note,
     });
 
     const finalHtml = html ?? store.getPublished(tid)?.body ?? "";

--- a/plugin/gateway/http.ts
+++ b/plugin/gateway/http.ts
@@ -31,6 +31,7 @@ import { buildServer, type TokenRole } from "./app";
 import { EmbedIndex } from "./lib/embed-index";
 import { DerivedSynonyms } from "./lib/derived-synonyms";
 import { loadConfig, resolveProjectDir, connectorName } from "./lib/config";
+import { notifyActivity } from "./lib/notify";
 import {
   KnowledgeStore,
   defaultDbPath,
@@ -234,6 +235,14 @@ if (store.empty) {
   const imported = seedFromFiles(store, projectDir);
   if (imported > 0) store.audit("system", "seed_from_files", { imported });
 }
+// Detect a version change across restarts (issue #63): the gateway boots fresh
+// after `docker compose up --build`, so a startup where VERSION differs from the
+// last one we recorded is a real deploy. Record it now (so a crash-loop doesn't
+// re-announce), and remember whether to announce once we're actually listening.
+// A first-ever boot (no prior version) is onboarding, not a deploy — no notice.
+const previousVersion = store.getKv("last_deployed_version");
+const versionChanged = previousVersion !== null && previousVersion !== VERSION;
+if (previousVersion !== VERSION) store.setKv("last_deployed_version", VERSION);
 // Semantic index for hybrid retrieval (I8 opt-in local embeddings). Built in the
 // background so startup isn't blocked; find_context falls back to keyword
 // retrieval until (and unless) it's ready. Inert when SETOKU_EMBEDDINGS!=1.
@@ -1832,4 +1841,15 @@ httpServer.listen(PORT, () => {
   console.error(
     `setoku gateway (http) listening on :${PORT} — ${tokens.size} token(s), project ${projectDir}`,
   );
+  // Announce a new deployed version once the box is actually serving it (issue
+  // #63). Detached + best-effort; a no-op unless a notify webhook is configured.
+  if (versionChanged) {
+    const cfg = loadConfig(projectDir);
+    void notifyActivity(projectDir, {
+      kind: "deploy",
+      version: VERSION,
+      previous: previousVersion,
+      box: cfg.ok ? cfg.config.name ?? null : null,
+    });
+  }
 });

--- a/plugin/gateway/lib/config.ts
+++ b/plugin/gateway/lib/config.ts
@@ -16,10 +16,23 @@ export interface LakeConfig {
   url?: string;
 }
 
+export interface NotificationsConfig {
+  /**
+   * Env var holding a Slack-compatible incoming-webhook URL (a POST of
+   * `{"text": "…"}`, the same shape deploy/monitor/alert.sh already uses).
+   * Default SETOKU_NOTIFY_WEBHOOK. The URL embeds a secret, so — like every
+   * other credential — config stores the env-var NAME, never the URL itself, so
+   * it never reaches the model.
+   */
+  slackWebhookEnv?: string;
+}
+
 export interface SetokuConfig {
   dataSource: DataSourceConfig;
   /** The bundled ClickHouse lake, target of run_query's `clickhouse` dialect (I5). */
   lake?: LakeConfig;
+  /** Outbound activity notifications — Slack today, more channels later (issue #63). */
+  notifications?: NotificationsConfig;
   allowTables: string[];
   denyTables: string[];
   rowCap: number;
@@ -208,6 +221,26 @@ export function resolveLakeUrl(
       `No lake configured: set ${varName} (e.g. http://user:pass@clickhouse:8123/setoku) ` +
       "or .setoku/config.json lake.urlEnv. The clickhouse dialect targets the bundled lake.",
   };
+}
+
+/**
+ * Resolve the Slack incoming-webhook URL for activity notifications, WITHOUT
+ * exposing it to the model. Mirrors resolveLakeUrl's precedence: env[varName]
+ * (varName from config.notifications.slackWebhookEnv, default
+ * SETOKU_NOTIFY_WEBHOOK) → project .env file. Returns null when no webhook is
+ * configured — notifications are opt-in, so an unset webhook is not an error,
+ * just a silent no-op.
+ */
+export function resolveNotifyWebhook(
+  projectDir: string,
+  config: SetokuConfig,
+): string | null {
+  const varName = config.notifications?.slackWebhookEnv ?? "SETOKU_NOTIFY_WEBHOOK";
+  if (process.env[varName]) return process.env[varName]!;
+  const parsed = parseEnvFile(
+    path.join(projectDir, config.dataSource?.envFile ?? ".env"),
+  );
+  return parsed[varName] ?? null;
 }
 
 /** Identity for audit attribution: SETOKU_USER env → git config user.email → "unknown". */

--- a/plugin/gateway/lib/notify.ts
+++ b/plugin/gateway/lib/notify.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Outbound activity notifications (issue #63).
+ *
+ * A best-effort, fire-and-forget side channel that announces box activity —
+ * an app published or updated, a new Setoku version deployed — to a Slack
+ * channel. Two hard rules:
+ *
+ *  1. A notification NEVER blocks or breaks the action it reports. A publish
+ *     must succeed even if Slack is down or slow, so the send is detached
+ *     (`void notifyActivity(...)`) and every failure is swallowed.
+ *  2. The webhook URL is a secret resolved from an env-var NAME (see
+ *     resolveNotifyWebhook), never a literal in config, so it never reaches the
+ *     model — same discipline as the DB/lake URLs.
+ *
+ * Transport today is a single Slack-compatible incoming webhook (`POST {text}`,
+ * the shape deploy/monitor/alert.sh already speaks). The event is modeled as a
+ * transport-agnostic union so a future channel/connector (a different Slack
+ * workspace, email, a webhook per event kind) can render the same events
+ * differently without touching the call sites.
+ */
+import { loadConfig, resolveNotifyWebhook } from "./config";
+
+/** An app was published for the first time. */
+export interface AppPublishedEvent {
+  kind: "app_published";
+  title: string;
+  /** Shareable link (may be a bare path when SETOKU_PUBLIC_URL is unset). */
+  url: string;
+  /** Identity that published it. */
+  by: string;
+  /** Live panel count (0 for a static report / state-only app). */
+  panels: number;
+}
+
+/** An existing app was edited in place. */
+export interface AppUpdatedEvent {
+  kind: "app_updated";
+  title: string;
+  url: string;
+  by: string;
+  /** Which facets changed (title / content / data / inputs / refresh). */
+  changed: string[];
+  /** The author's human note on WHAT changed (update_app `message`), if given. */
+  message?: string | null;
+}
+
+/** A new gateway version is now serving (fired once per version, on startup). */
+export interface DeployEvent {
+  kind: "deploy";
+  version: string;
+  /** The version this replaced (null on a box's very first boot — not sent). */
+  previous: string | null;
+  /** Human box name (config.name), for a multi-box channel. */
+  box?: string | null;
+}
+
+export type ActivityEvent = AppPublishedEvent | AppUpdatedEvent | DeployEvent;
+
+/** How long we'll wait on the webhook before giving up — a notification must
+ *  never keep a request (or shutdown) hanging on a slow Slack. */
+const NOTIFY_TIMEOUT_MS = 5_000;
+
+/** Human-readable list of what changed, for the update message. */
+function changeSummary(changed: string[]): string {
+  const clean = changed.filter(Boolean);
+  return clean.length ? clean.join(", ") : "no visible fields";
+}
+
+/** Render an event as the Slack message text. Exported for tests and so a future
+ *  transport can reuse the same phrasing. Kept plain-text (no Slack blocks) so it
+ *  degrades cleanly to any `{text}` webhook. */
+export function formatEvent(event: ActivityEvent): string {
+  switch (event.kind) {
+    case "app_published":
+      return (
+        `📊 *App published:* “${event.title}” by ${event.by}` +
+        (event.panels ? ` — ${event.panels} live panel${event.panels === 1 ? "" : "s"}` : "") +
+        `\n${event.url}`
+      );
+    case "app_updated": {
+      const note = event.message?.trim();
+      return (
+        `✏️ *App updated:* “${event.title}” by ${event.by}` +
+        (note ? `\n> ${note}` : "") +
+        `\n_changed: ${changeSummary(event.changed)}_` +
+        `\n${event.url}`
+      );
+    }
+    case "deploy":
+      return (
+        `🚀 *Setoku ${event.box ? `(${event.box}) ` : ""}updated* to v${event.version}` +
+        (event.previous ? ` (was v${event.previous})` : "")
+      );
+  }
+}
+
+/**
+ * Send an activity notification. Best-effort and detached: resolves the webhook
+ * from config, and if none is configured returns immediately (notifications are
+ * opt-in). Any transport error — no webhook, network failure, non-2xx, timeout —
+ * is swallowed so the caller's real work is never affected. Callers `void` this;
+ * it is not awaited on the hot path.
+ */
+export async function notifyActivity(projectDir: string, event: ActivityEvent): Promise<void> {
+  try {
+    const cfg = loadConfig(projectDir);
+    if (!cfg.ok) return;
+    const webhook = resolveNotifyWebhook(projectDir, cfg.config);
+    if (!webhook) return;
+    const ctl = new AbortController();
+    const timer = setTimeout(() => ctl.abort(), NOTIFY_TIMEOUT_MS);
+    try {
+      await fetch(webhook, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: formatEvent(event) }),
+        signal: ctl.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    // A notification must never break the action it reports (issue #63).
+  }
+}

--- a/plugin/gateway/lib/notify.ts
+++ b/plugin/gateway/lib/notify.ts
@@ -111,16 +111,23 @@ export async function notifyActivity(projectDir: string, event: ActivityEvent): 
     const ctl = new AbortController();
     const timer = setTimeout(() => ctl.abort(), NOTIFY_TIMEOUT_MS);
     try {
-      await fetch(webhook, {
+      const res = await fetch(webhook, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ text: formatEvent(event) }),
         signal: ctl.signal,
       });
+      // A misconfigured webhook (wrong URL, revoked hook) fails silently
+      // otherwise — `fetch` resolves for a non-2xx. Give the operator a signal
+      // WITHOUT the webhook URL (a secret) or the response body.
+      if (!res.ok) console.error(`notify: webhook returned HTTP ${res.status} for a ${event.kind} event`);
     } finally {
       clearTimeout(timer);
     }
   } catch {
-    // A notification must never break the action it reports (issue #63).
+    // A notification must never break the action it reports (issue #63). The
+    // error is NOT logged — a fetch failure message can echo the (secret)
+    // webhook URL — so we surface only the event kind, not the transport error.
+    console.error(`notify: could not deliver a ${event.kind} event (webhook unreachable or timed out)`);
   }
 }

--- a/plugin/gateway/lib/store.ts
+++ b/plugin/gateway/lib/store.ts
@@ -361,6 +361,14 @@ export class KnowledgeStore {
       tool TEXT NOT NULL,
       payload TEXT
     )`);
+    // Small persistent key/value scratch for gateway-internal bookkeeping that
+    // must survive a restart but isn't knowledge — e.g. the last VERSION we sent
+    // a "deployed" notification for, so an ordinary restart doesn't re-announce
+    // (issue #63). Not for anything user-facing or secret.
+    this.db.run(`CREATE TABLE IF NOT EXISTS kv (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )`);
     // Provisioning audit trail (Phase 4, task 4.1) — append-only. Every planned,
     // applied, skipped, or failed provisioning step lands here so a `setoku init`
     // run is fully reconstructable, and so re-runs can skip already-applied steps
@@ -796,6 +804,22 @@ export class KnowledgeStore {
     );
     if (res.changes > 0) this.audit(user, "unreject_correction", { id });
     return res.changes > 0;
+  }
+
+  /* --------------------------------- kv --------------------------------- */
+
+  /** Read a gateway-internal bookkeeping value (see the `kv` table). */
+  getKv(key: string): string | null {
+    const row = this.db.query("SELECT value FROM kv WHERE key = ?").get(key) as { value: string } | undefined;
+    return row?.value ?? null;
+  }
+
+  /** Upsert a gateway-internal bookkeeping value. */
+  setKv(key: string, value: string): void {
+    this.db.run(
+      "INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+      [key, value],
+    );
   }
 
   /* -------------------------------- audit ------------------------------- */

--- a/test/app-history.test.ts
+++ b/test/app-history.test.ts
@@ -121,6 +121,30 @@ describe("retention", () => {
   });
 });
 
+describe("update message (issue #63)", () => {
+  it("stores a content edit's note and surfaces it in history", () => {
+    const store = new KnowledgeStore(dbPath);
+    store.createPublished({ id: "msgapp", title: "M", body: "b0", refreshSeconds: 60, createdBy: "alice" });
+    // A normal edit carrying a "what changed" note (update_app's `message`).
+    store.updatePublished("msgapp", { body: "b1" }, { editor: "bob", note: "Added the revenue panel" });
+    const revs = store.listAppHistory("msgapp"); // newest first
+    expect(revs[0].note).toBe("Added the revenue panel");
+    // v1 (the original publish) carries no note.
+    expect(revs[revs.length - 1].note).toBeNull();
+  });
+});
+
+describe("kv (deploy-notice bookkeeping, issue #63)", () => {
+  it("round-trips and upserts a value", () => {
+    const store = new KnowledgeStore(dbPath);
+    expect(store.getKv("last_deployed_version")).toBeNull();
+    store.setKv("last_deployed_version", "0.20.0");
+    expect(store.getKv("last_deployed_version")).toBe("0.20.0");
+    store.setKv("last_deployed_version", "0.21.0"); // upsert, not a second row
+    expect(store.getKv("last_deployed_version")).toBe("0.21.0");
+  });
+});
+
 describe("backfill", () => {
   it("gives an app published before history a v1 from its current row", () => {
     // Write a published row directly (no snapshot), then reopen the store to run

--- a/test/apps-integration.test.ts
+++ b/test/apps-integration.test.ts
@@ -169,6 +169,32 @@ describe("update_app — params are first-class (validate + I9 re-gate)", () => 
   });
 });
 
+describe("update_app — change message lands in version history (issue #63)", () => {
+  it("threads `message` into the app_revisions note the header drawer reads", async () => {
+    const c = await gwConnect(BASE, "tok_boss", "pub");
+    const id = idOf((await call(c, "publish_app", { title: "Changelog", html: "<div id=kpi></div>", panels: [REGION_PANEL], params: [REGION_PARAM] })).text);
+    const r = await call(c, "update_app", { id, html: "<div id=kpi>v2</div>", message: "Reworked the KPI header" });
+    expect(r.isError).toBeFalsy();
+
+    const { cookie } = await login();
+    const hist = await (await fetch(`${BASE}/admin/api/app_history?id=${id}`, { headers: { cookie } })).json();
+    // Newest first: the edit carries the note, the original publish does not.
+    expect(hist[0].note).toBe("Reworked the KPI header");
+    expect(hist[hist.length - 1].note).toBeNull();
+  });
+
+  it("rejects an over-long message and never mutates the app", async () => {
+    const c = await gwConnect(BASE, "tok_boss", "pub");
+    const id = idOf((await call(c, "publish_app", { title: "Cap", html: "<div id=kpi></div>", panels: [REGION_PANEL], params: [REGION_PARAM] })).text);
+    const r = await call(c, "update_app", { id, title: "Cap2", message: "x".repeat(501) });
+    expect(r.isError).toBe(true);
+    expect(r.text.toLowerCase()).toContain("under 500");
+    const { cookie } = await login();
+    const hist = await (await fetch(`${BASE}/admin/api/app_history?id=${id}`, { headers: { cookie } })).json();
+    expect(hist.length).toBe(1); // still just the original publish — no phantom edit
+  });
+});
+
 describe("public /frame — fresh-execution budget bounds prod load", () => {
   it("serves cache-only (soft error) once an app's budget is spent on distinct params", async () => {
     const c = await gwConnect(BASE, "tok_boss", "pub");

--- a/test/notify.test.ts
+++ b/test/notify.test.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Activity notifications (issue #63): the event → Slack-text rendering, the
+// env-var-name webhook resolution (the URL never lands in config), and the
+// best-effort POST that must never throw into its caller.
+import { describe, it, expect, afterAll } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveNotifyWebhook } from "../plugin/gateway/lib/config";
+import { formatEvent, notifyActivity, type ActivityEvent } from "../plugin/gateway/lib/notify";
+
+const dirs: string[] = [];
+function projectWith(config: Record<string, unknown>, env?: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "setoku-notify-"));
+  dirs.push(dir);
+  fs.mkdirSync(path.join(dir, ".setoku"), { recursive: true });
+  fs.writeFileSync(path.join(dir, ".setoku", "config.json"), JSON.stringify(config));
+  if (env) fs.writeFileSync(path.join(dir, ".env"), env);
+  return dir;
+}
+afterAll(() => {
+  for (const d of dirs) fs.rmSync(d, { recursive: true, force: true });
+});
+
+describe("formatEvent", () => {
+  it("renders a published app with its link and panel count", () => {
+    const t = formatEvent({ kind: "app_published", title: "Sales", url: "/admin/p/x", by: "al@co", panels: 3 });
+    expect(t).toContain("App published");
+    expect(t).toContain("Sales");
+    expect(t).toContain("al@co");
+    expect(t).toContain("3 live panels");
+    expect(t).toContain("/admin/p/x");
+  });
+
+  it("renders an update with the author note and the changed facets", () => {
+    const t = formatEvent({
+      kind: "app_updated",
+      title: "Sales",
+      url: "/admin/p/x",
+      by: "bo@co",
+      changed: ["content", "data"],
+      message: "Added a weekly revenue panel",
+    });
+    expect(t).toContain("App updated");
+    expect(t).toContain("Added a weekly revenue panel");
+    expect(t).toContain("content, data");
+  });
+
+  it("omits the note line when no message was given", () => {
+    const t = formatEvent({ kind: "app_updated", title: "S", url: "/p/x", by: "b", changed: ["title"] });
+    expect(t).not.toContain(">"); // the blockquote note prefix
+    expect(t).toContain("title");
+  });
+
+  it("renders a deploy with the box name and prior version", () => {
+    const t = formatEvent({ kind: "deploy", version: "0.21.0", previous: "0.20.0", box: "campsh" });
+    expect(t).toContain("0.21.0");
+    expect(t).toContain("was v0.20.0");
+    expect(t).toContain("campsh");
+  });
+});
+
+describe("resolveNotifyWebhook", () => {
+  const load = (dir: string) =>
+    JSON.parse(fs.readFileSync(path.join(dir, ".setoku", "config.json"), "utf8"));
+
+  it("defaults to SETOKU_NOTIFY_WEBHOOK from process env", () => {
+    const dir = projectWith({});
+    process.env.SETOKU_NOTIFY_WEBHOOK = "https://hooks.example/default";
+    try {
+      expect(resolveNotifyWebhook(dir, { ...load(dir) } as any)).toBe("https://hooks.example/default");
+    } finally {
+      delete process.env.SETOKU_NOTIFY_WEBHOOK;
+    }
+  });
+
+  it("reads a custom env-var name from config, falling back to the project .env", () => {
+    const dir = projectWith(
+      { notifications: { slackWebhookEnv: "MY_HOOK" } },
+      "MY_HOOK=https://hooks.example/from-env-file\n",
+    );
+    expect(resolveNotifyWebhook(dir, load(dir) as any)).toBe("https://hooks.example/from-env-file");
+  });
+
+  it("returns null when no webhook is configured (notifications are opt-in)", () => {
+    const dir = projectWith({});
+    expect(resolveNotifyWebhook(dir, load(dir) as any)).toBeNull();
+  });
+});
+
+describe("notifyActivity", () => {
+  async function capture(event: ActivityEvent, config: Record<string, unknown>, envName: string) {
+    let received: { text?: string } | null = null;
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        received = (await req.json()) as { text?: string };
+        return new Response("ok");
+      },
+    });
+    const url = `http://localhost:${server.port}/hook`;
+    const dir = projectWith(config);
+    process.env[envName] = url;
+    try {
+      await notifyActivity(dir, event);
+    } finally {
+      delete process.env[envName];
+      server.stop(true);
+    }
+    return received as { text?: string } | null;
+  }
+
+  it("POSTs the formatted text to the configured webhook", async () => {
+    const event: ActivityEvent = { kind: "app_published", title: "Sales", url: "/p/x", by: "al", panels: 1 };
+    const received = await capture(event, {}, "SETOKU_NOTIFY_WEBHOOK");
+    expect(received).not.toBeNull();
+    expect(received!.text).toBe(formatEvent(event));
+  });
+
+  it("is a silent no-op — and never throws — when no webhook is configured", async () => {
+    const dir = projectWith({});
+    // Must resolve without throwing even though there's nowhere to send.
+    await expect(
+      notifyActivity(dir, { kind: "deploy", version: "1.0.0", previous: "0.9.0" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("swallows a transport failure (unreachable webhook) without throwing", async () => {
+    const dir = projectWith({});
+    process.env.SETOKU_NOTIFY_WEBHOOK = "http://127.0.0.1:1/nope"; // refused
+    try {
+      await expect(
+        notifyActivity(dir, { kind: "deploy", version: "1.0.0", previous: "0.9.0" }),
+      ).resolves.toBeUndefined();
+    } finally {
+      delete process.env.SETOKU_NOTIFY_WEBHOOK;
+    }
+  });
+});


### PR DESCRIPTION
Closes #63.

Announce box activity to a Slack channel, and let an app edit carry a human "what changed" note that shows in version history.

## What's included

**1. Outbound activity notifications (`lib/notify.ts`)**
A best-effort, fire-and-forget notifier. A transport-agnostic `ActivityEvent` union (`app_published` / `app_updated` / `deploy`) rendered to a Slack incoming webhook (`{"text": …}`, the same shape `deploy/monitor/alert.sh` already speaks). It never throws into or blocks the action it reports, and is a silent no-op when no webhook is configured. The event model is deliberately transport-agnostic so a future channel/connector can render the same events differently (the issue's "different channels/connectors" note).

**2. Secret-safe config**
`resolveNotifyWebhook` reads the webhook from an env-var **name** (`notifications.slackWebhookEnv` in `.setoku/config.json`, default `SETOKU_NOTIFY_WEBHOOK`) — the URL never lives in config and never reaches the model, same discipline as the DB/lake URLs. Threaded through `docker-compose.yml` and documented in `deploy/README.md`.

**3. `update_app` `message`**
An optional one-line "what changed" note (≤500 chars). It lands in the existing `app_revisions.note` column, so the version-history drawer renders it with **no frontend change**, and it rides along in the update notification.

**4. Deploy notice**
Fires **once** on the first boot of a changed `VERSION` (tracked in a new store `kv` table), never on ordinary restarts, and stays silent on a box's first-ever boot (that's onboarding, not a deploy).

## What the messages look like
- `📊 *App published:* "Sales" by al@co — 3 live panels` + link
- `✏️ *App updated:* "Sales" by bo@co` / `> Added a weekly revenue panel` / `_changed: content, data_` + link
- `🚀 *Setoku (campsh) updated* to v0.21.0 (was v0.20.0)`

## Notes
- Notifications are **opt-in**: unset `SETOKU_NOTIFY_WEBHOOK` → off. A misconfigured webhook logs a URL-free warning to stderr so it isn't silently broken.
- No `web/` frontend files changed — the drawer already renders `note`.

## Testing
- `test/notify.test.ts` — event rendering, env-var-name resolution, best-effort POST, no-throw on failure.
- `test/app-history.test.ts` — kv round-trip + the message → history note.
- `test/apps-integration.test.ts` — `message` → version history end-to-end through the tool layer, and the over-length reject path.
- Full fast suite green, typecheck clean.

## Review substitution
Codex was rate-limited (usage cap) at review time, so an independent adversarial subagent review stood in — verified all three load-bearing constraints (never-blocks, secret-safe, once-per-deploy) and found no blocking issues.