### PR TITLE
apps: remove the legacy raw-served "html" publish format (#62)

### DIFF
--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -1112,7 +1112,8 @@ server.registerTool(
 // app splits presentation (a frozen, agent-authored template) from data
 // (named panels, each a saved read-only query the box RE-RUNS live through the
 // governed run_query path). The template reads results off window.__SETOKU__.
-// A zero-panel app is just a static report (back-compat).
+// A zero-panel app is a static / state-only fragment (a todo, a poll, a
+// presentational summary); it still renders through the runtime shell.
 //
 // v0 is TEAM-ONLY: the link (/admin/p/<id>) is session-gated, so only people who
 // hold a box login can view it — that's what keeps a (prompt-injectable) analyst
@@ -1308,8 +1309,10 @@ const APP_GUIDE = [
   "aren't intentionally changing. You never need a browser to read an app's current markup — get_app has it.",
   "",
   "## The template (`html`)",
-  "A self-contained HTML fragment: inline <style>/<script>, inline SVG. NO external/CDN assets and NO",
+  "A self-contained HTML FRAGMENT: inline <style>/<script>, inline SVG. NO external/CDN assets and NO",
   "network — data is injected, not fetched (the iframe runs under a no-network CSP).",
+  "Pass just the inner markup — NOT a full <!doctype>/<html>/<head>/<body> document (the runtime supplies",
+  "that skeleton and wraps your fragment; a whole document is REJECTED by publish_app / update_app).",
   "",
   "## Preloaded helpers — prefer these over hand-rolled SVG/CSS",
   "`Setoku.stat(elId, panelKey, {label, value, format})` — `value` is the COLUMN NAME to read from the",
@@ -1421,6 +1424,16 @@ server.registerTool(
         `Template is ${(bytes / 1e6).toFixed(1)} MB — over the ${MAX_REPORT_BYTES / 1e6} MB cap. Keep it a self-contained ` +
           "fragment; the live data arrives via panels, so don't embed bulk data in the template.",
       );
+    // Every published app is a FRAGMENT — the runtime nests the body inside its
+    // own document skeleton, so a full <!doctype>/<html> document renders wrong.
+    // Reject one up front with a clear steer (the legacy raw-served "html" format
+    // is gone; app_guide documents the fragment contract).
+    if (isFullDoc(html))
+      return errorText(
+        "Publish a fragment, not a full HTML document. The app runtime wraps your template in its own " +
+          "<!doctype>…<body> skeleton, so a whole <!doctype>/<html> document nests wrong. Drop the doctype/" +
+          "<html>/<head>/<body> wrapper and pass just the inner markup (styles in a <style> tag are fine). See app_guide.",
+      );
     const declaredParams = (params ?? []) as AppParam[];
     const prep = await prepPanels(panels ?? [], declaredParams);
     if (!prep.ok) return errorText(prep.error);
@@ -1428,11 +1441,6 @@ server.registerTool(
 
     const id = mintShareId();
     const refresh = clampRefresh(refreshSeconds, normalized.length > 0);
-    // An "app" renders via the runtime path (chart helpers + Setoku.state + the
-    // no-network app CSP). That's anything with panels OR a zero-panel FRAGMENT
-    // (e.g. a state-only app: a todo, a poll). Only a zero-panel full HTML
-    // DOCUMENT is a legacy frozen report (format "html"), served as-is.
-    const format = normalized.length > 0 || !isFullDoc(html) ? "app" : "html";
     store.createPublished({
       id,
       title: title.trim() || "Untitled app",
@@ -1440,21 +1448,19 @@ server.registerTool(
       panels: normalized,
       params: declaredParams.length ? declaredParams : null,
       refreshSeconds: refresh,
-      format,
       createdBy: user,
     });
     for (const s of seeds)
       store.putPanelCache(id, s.key, { columns: s.columns, rows: s.rows, rowCount: s.rowCount, truncated: s.truncated, error: null });
     store.audit(user, "publish_app", { id, title, bytes, panels: normalized.length });
 
-    const noun = format === "app" ? "app" : "report";
     return text(
       `Published "${title}" → ${publishUrl(id)}\n\n` +
         (normalized.length ? `${normalized.length} live panel(s); the box re-runs them every ${refresh}s. ` : "") +
         "This link is TEAM-ONLY: anyone you share it with must sign in to the box to view it. " +
         (publishBase ? "" : "(Prefix the path above with your box URL.) ") +
         `\n\nEdit it with update_app("${id}", …) — same link. Manage: get_app / unpublish_app("${id}"). ` +
-        `(An admin can make this ${noun} public from /admin.)` +
+        "(An admin can make this app public from /admin.)" +
         (await publishNotes(html, normalized)),
     );
   },
@@ -1496,6 +1502,13 @@ server.registerTool(
       const bytes = Buffer.byteLength(html, "utf8");
       if (bytes > MAX_REPORT_BYTES)
         return errorText(`Template is ${(bytes / 1e6).toFixed(1)} MB — over the ${MAX_REPORT_BYTES / 1e6} MB cap.`);
+      // Same one-model rule as publish_app: a published app is a FRAGMENT the
+      // runtime wraps, so a full <!doctype>/<html> document can't replace it.
+      if (isFullDoc(html))
+        return errorText(
+          "Update with a fragment, not a full HTML document. The app runtime wraps your template in its own " +
+            "<!doctype>…<body> skeleton. Drop the doctype/<html>/<head>/<body> wrapper and pass just the inner markup. See app_guide.",
+        );
     }
 
     // Panels AND params both determine what the panels compute (params bind into
@@ -1529,20 +1542,6 @@ server.registerTool(
     if (refreshSeconds !== undefined) refresh = clampRefresh(refreshSeconds, willHavePanels);
     else if (panelsChanged) refresh = willHavePanels ? (meta.refreshSeconds ?? DEFAULT_REFRESH_SECONDS) : null;
 
-    // Recompute format when the panel SET or the BODY changes: panels → app; zero
-    // panels → "app" for a fragment (state app), "html" only for a full document.
-    // The body matters for a panel-less app (a new full <!doctype> template must
-    // flip it to the legacy "html" path); a params-only edit touches neither, so
-    // format holds.
-    let format: "html" | "app" | undefined;
-    if (panelsChanged || html !== undefined) {
-      if (willHavePanels) format = "app";
-      else {
-        const bodyToCheck = html ?? store.getPublished(tid)?.body ?? "";
-        format = isFullDoc(bodyToCheck) ? "html" : "app";
-      }
-    }
-
     const ok = store.updatePublished(tid, {
       title: newTitle,
       body: html,
@@ -1553,7 +1552,6 @@ server.registerTool(
       // and untouched variants stay warm.
       panels: panelsChanged ? normalized : undefined,
       params: paramsChanged ? (params as AppParam[]) : undefined,
-      format,
       refreshSeconds: refresh,
     }, { editor: user });
     if (!ok) return errorText(`Update failed — no active app "${id}".`);

--- a/plugin/gateway/http.ts
+++ b/plugin/gateway/http.ts
@@ -39,7 +39,7 @@ import {
   type PublishedMeta,
   type PublishedReport,
 } from "./lib/store";
-import { newestComputedAt, renderApp, isFullDoc, type RenderedPanel } from "./lib/apps";
+import { newestComputedAt, renderApp, type RenderedPanel } from "./lib/apps";
 import { mirroredTables, mirrorAsOf, referencedBizTables } from "./lib/mirror";
 import { APP_RUNTIME } from "./lib/app-runtime";
 import { AppStore, defaultAppDbPath, AppStoreQuotaError, type StateScope } from "./lib/app-store";
@@ -679,17 +679,15 @@ function jsonForScript(value: unknown): string {
 }
 
 /** Assemble the sandboxed frame document: our skeleton + injected panel data +
- *  the agent's template fragment. Legacy zero-panel reports are full documents,
- *  served as-is. The payload is already byte-bounded by renderApp's
- *  capRenderBytes (shared with the provenance drawer so the two agree). `team`
- *  gates raw error text: a public frame must NOT inject a raw DB error (it can
- *  name tables/columns/env vars) — same scrub the public /data path applies. */
+ *  the agent's template fragment. Every published app is a fragment the runtime
+ *  wraps — even one with no panels (a state-only app: a todo, a poll) gets the
+ *  runtime + empty data injected, so its `Setoku.*` / `__SETOKU__` calls degrade
+ *  ("No data") instead of ReferenceError. The payload is already byte-bounded by
+ *  renderApp's capRenderBytes (shared with the provenance drawer so the two
+ *  agree). `team` gates raw error text: a public frame must NOT inject a raw DB
+ *  error (it can name tables/columns/env vars) — same scrub the public /data
+ *  path applies. */
 function frameDocument(dash: PublishedReport, panels: RenderedPanel[], opts: { team: boolean; params?: Record<string, string> }): string {
-  // A legacy full HTML document (pre-app report) is served as-is. But a
-  // FRAGMENT with no panels — e.g. an app the author turned static while
-  // keeping a Setoku.*/__SETOKU__ template — still gets the runtime + empty data
-  // injected, so those calls degrade ("No data") instead of ReferenceError.
-  if (!panels.length && isFullDoc(dash.body)) return dash.body;
   const scrub = (e: string | null | undefined): string | null =>
     e ? (opts.team ? e : "data temporarily unavailable") : null;
   const data = {
@@ -1054,17 +1052,13 @@ const httpServer = http.createServer(async (req, res) => {
       // the up-to-2MB body (this path is credential-free and cheap to hammer).
       const meta = store.getPublishedMeta(id);
       if (!meta || meta.archivedAt || meta.visibility !== "public") return notFound();
-      // An app renders via the runtime path whether or not it has data panels: a
-      // chart app has panels; a state-only app (todo/poll) has none but still
-      // wants the runtime + no-network frame. Only a legacy frozen report (format
-      // "html") is served whole at /p/<id>.
-      const isApp = meta.format === "app";
+      // Every app renders via the runtime path whether or not it has data panels:
+      // a chart app has panels; a state-only app (todo/poll) has none but still
+      // wants the runtime + no-network frame.
       const hasPanels = (meta.panels?.length ?? 0) > 0;
 
-      // The /frame and /data subpaths exist only for apps (the shell embeds
-      // /frame; /data is the freshness poll, meaningful only with panels).
-      if (sub === "frame" && !isApp) return notFound();
-      if (sub === "data" && !(isApp && hasPanels)) return notFound();
+      // /data is the freshness poll — meaningful only with panels.
+      if (sub === "data" && !hasPanels) return notFound();
 
       // /p/<id>/data — FRESHNESS ONLY for the public shell's "updated …" stamp.
       // The public surface exposes NO calculations (no SQL, descriptions, metrics).
@@ -1160,24 +1154,8 @@ const httpServer = http.createServer(async (req, res) => {
       if (sub) return notFound(); // unknown subpath
 
       store.audit("public", "published_viewed_public", { id });
-      if (!isApp) {
-        // Legacy static report: serve the self-contained body sandboxed, as before
-        // (opaque origin, no popups/top-navigation).
-        const rep = store.getPublished(id);
-        if (!rep) return notFound();
-        res.writeHead(200, {
-          "content-type": "text/html; charset=utf-8",
-          "content-security-policy": "sandbox allow-scripts",
-          "x-content-type-options": "nosniff",
-          "referrer-policy": "no-referrer",
-        });
-        // frameDocument serves a legacy full-doc as-is, but injects the runtime +
-        // empty data for a fragment template (so Setoku.* degrades, not throws).
-        res.end(frameDocument(rep, [], { team: false }));
-        return;
-      }
-      // Live app: serve the trusted outer shell (frames /p/<id>/frame, polls
-      // /p/<id>/data). The agent template never runs in this top-level origin.
+      // Serve the trusted outer shell (frames /p/<id>/frame, polls /p/<id>/data).
+      // The agent template never runs in this top-level origin.
       res.writeHead(200, {
         "content-type": "text/html; charset=utf-8",
         "content-security-policy": SHELL_CSP,
@@ -1244,9 +1222,6 @@ const httpServer = http.createServer(async (req, res) => {
           res.end("not found\n");
           return;
         }
-        // An app (with or without panels) renders via the runtime path; only a
-        // legacy frozen report (format "html") keeps the loose sandbox-only CSP.
-        const isApp = rep.format === "app";
         const raw = parseFrameParams(req.url);
         // ?force=1 bypasses the cache and re-runs the selected variant — author or
         // admin only, so a member (or a stale tab) can't hammer prod through the
@@ -1254,14 +1229,12 @@ const httpServer = http.createServer(async (req, res) => {
         const force =
           new URL(req.url ?? "", "http://x").searchParams.get("force") === "1" &&
           (rep.createdBy === session.identity || canApprove(session.role));
-        const panels = isApp && (rep.panels?.length ?? 0) > 0 ? await renderApp(store, projectDir, rep, { rawParams: raw, force }) : [];
+        const panels = (rep.panels?.length ?? 0) > 0 ? await renderApp(store, projectDir, rep, { rawParams: raw, force }) : [];
         store.audit(session.identity, force ? "app_frame_refreshed" : "app_frame_viewed", { id });
-        // A live app's template needs no network (data is injected) → strict
-        // CSP. A LEGACY report predates that contract and may inline a CDN script
-        // or remote image; keep its original sandbox-only CSP so it still renders.
+        // The app template needs no network (data is injected) → strict CSP.
         res.writeHead(200, {
           "content-type": "text/html; charset=utf-8",
-          "content-security-policy": isApp ? `${FRAME_CSP}; sandbox allow-scripts allow-forms` : "sandbox allow-scripts",
+          "content-security-policy": `${FRAME_CSP}; sandbox allow-scripts allow-forms`,
           "x-content-type-options": "nosniff",
           "referrer-policy": "no-referrer",
         });
@@ -1530,7 +1503,6 @@ const httpServer = http.createServer(async (req, res) => {
                 body: snap.body,
                 panels: snap.panels ?? [], // [] rewrites to no-panels + clears cache
                 params: snap.params ?? [],
-                format: snap.format,
                 refreshSeconds: snap.refreshSeconds,
               },
               { editor: session.identity, note: `Restored version ${seq}` },

--- a/plugin/gateway/lib/apps.ts
+++ b/plugin/gateway/lib/apps.ts
@@ -63,16 +63,19 @@ export const MAX_RENDER_ROW_BYTES = 3_500_000;
 export const RENDER_FETCH_CEILING = 25_000;
 
 /**
- * Whether a published body is a FULL HTML document (legacy "html" format, served
- * as-is) vs a fragment the app runtime wraps. A real document OPENS with the
- * doctype/`<html>` tag — possibly behind a leading banner comment or `<?xml ?>`
- * prolog. We skip that leading whitespace/comment/prolog and then require the tag
- * AT that position, so:
+ * Whether a published body is a FULL HTML document vs a fragment the app runtime
+ * wraps. Published apps are ALWAYS fragments — the runtime nests the body inside
+ * its own `<!doctype>…<body>…</body></html>` skeleton, so a whole document nested
+ * there renders wrong. publish_app / update_app use this to REJECT a full-doc body
+ * up front (the one supported model is a fragment; the legacy raw-served "html"
+ * format is gone). A real document OPENS with the doctype/`<html>` tag — possibly
+ * behind a leading banner comment or `<?xml ?>` prolog. We skip that leading
+ * whitespace/comment/prolog and then require the tag AT that position, so:
  *   - a fragment that merely CONTAINS `<html` elsewhere (a code snippet, a template
  *     string) is NOT misclassified as a document, and
  *   - a document that opens with `<!-- generated -->` or `<?xml ?>` before the
  *     doctype still IS one.
- * One definition shared by publish, update, and render so they always agree.
+ * One definition shared by publish and update so they always agree.
  */
 export function isFullDoc(body: string): boolean {
   let s = body.replace(/^\s+/, "");

--- a/plugin/gateway/lib/store.ts
+++ b/plugin/gateway/lib/store.ts
@@ -16,7 +16,6 @@ import os from "node:os";
 import path from "node:path";
 import { parseFrontmatter } from "./artifact";
 import { setokuDir } from "./config";
-import { isFullDoc } from "./apps";
 import type { AppParam } from "./params";
 
 export type DocType = "entity" | "metric" | "query" | "overview" | "gotcha";
@@ -146,11 +145,12 @@ export interface AppPanel {
 export interface PublishedReport {
   id: string;
   title: string;
-  /** "html" = a frozen, self-contained report (legacy / zero-panel). "app"
-   *  = a template whose panels the box re-runs live. */
+  /** Render model. Always "app" now (a fragment the runtime wraps); the legacy
+   *  raw-served "html" format is gone. Kept as a field for existing rows and the
+   *  version-history snapshot. */
   format: "html" | "app";
   body: string;
-  /** Live data bindings; null/[] for a frozen report. */
+  /** Live data bindings; null/[] for a static (state-only or presentational) app. */
   panels: AppPanel[] | null;
   /** Declared interactive inputs (date/int/text/bool/enum) a panel's SQL binds
    *  via `:name`. null/[] for a non-interactive app. See lib/params.ts. */
@@ -428,17 +428,19 @@ export class KnowledgeStore {
       archived_at TEXT
     )`);
     // Brought the table forward in-place for boxes created before visibility /
-    // the revoked→archived rename / live apps landed (idempotent). A
-    // pre-app row stays format='html' with panels NULL and keeps rendering.
+    // the revoked→archived rename / live apps landed (idempotent).
     this.ensureColumn("published", "visibility", "TEXT NOT NULL DEFAULT 'team'");
     this.ensureColumn("published", "archived_at", "TEXT");
     this.ensureColumn("published", "panels", "TEXT");
     this.ensureColumn("published", "params", "TEXT");
     this.ensureColumn("published", "refresh_seconds", "INTEGER");
-    // Dashboards→Apps rename: the live-render format value was 'dashboard'. Boxes
-    // that published before the rename hold rows with format='dashboard'; the new
-    // code gates the runtime path on format='app', so backfill them in place (a
-    // no-op on a fresh box). Legacy v0.11 frozen reports stay format='html'.
+    // Every app now renders through the runtime shell, so the format column is
+    // effectively always 'app'. Boxes that published before the Dashboards→Apps
+    // rename hold format='dashboard'; backfill those to 'app' (a no-op on a fresh
+    // box). The legacy raw-served 'html' value is retired: no new rows mint it, and
+    // it was already absent from every live box at removal (issue #62) — so a
+    // straggler is not migrated (a full-doc body can't render inside the shell) but
+    // simply falls through the runtime path like any other app.
     this.db.run("UPDATE published SET format = 'app' WHERE format = 'dashboard'");
     // Append-only version history for published apps (issue #58). One snapshot
     // per create / content edit / revert; the newest seq mirrors the live
@@ -1092,7 +1094,6 @@ export class KnowledgeStore {
   createPublished(rec: {
     id: string;
     title: string;
-    format?: "html" | "app";
     body: string;
     panels?: AppPanel[] | null;
     params?: AppParam[] | null;
@@ -1108,10 +1109,10 @@ export class KnowledgeStore {
       [
         rec.id,
         rec.title,
-        // Match the publish_app tool's rule so a direct caller can't mislabel a
-        // fragment: panels → app; else a full <!doctype> doc is a legacy frozen
-        // "html" report, but a bare fragment (state-only app) is still an "app".
-        rec.format ?? (panels ? "app" : isFullDoc(rec.body) ? "html" : "app"),
+        // Every published app is a fragment the runtime wraps — the legacy raw-served
+        // "html" format is gone, so the stored format is always "app". The column
+        // stays for existing rows / the version-history snapshot.
+        "app",
         rec.body,
         panels,
         params,
@@ -1348,9 +1349,9 @@ export class KnowledgeStore {
 
   /** Edit a published app/report in place (same id/link) — author-gated
    *  upstream. Only provided fields change; id/createdBy/createdAt/visibility are
-   *  preserved. Passing `panels` (incl. []) rewrites the panel set + format AND
-   *  clears the panel cache (the old rows no longer apply). Returns false if the
-   *  row is unknown or archived. */
+   *  preserved. Passing `panels` (incl. []) rewrites the panel set AND clears the
+   *  panel cache (the old rows no longer apply). Returns false if the row is
+   *  unknown or archived. */
   updatePublished(
     id: string,
     fields: {
@@ -1358,9 +1359,6 @@ export class KnowledgeStore {
       body?: string;
       panels?: AppPanel[];
       params?: AppParam[];
-      /** Explicit format — the caller (which has the body) decides app vs legacy
-       *  html; falls back to panels-based derivation when omitted. */
-      format?: "html" | "app";
       refreshSeconds?: number | null;
     },
     // Who is editing (for the version-history attribution), and an optional note
@@ -1380,13 +1378,8 @@ export class KnowledgeStore {
     }
     if (fields.panels !== undefined) {
       const json = fields.panels.length ? JSON.stringify(fields.panels) : null;
-      sets.push("panels = ?", "format = ?");
-      vals.push(json, fields.format ?? (json ? "app" : "html"));
-    } else if (fields.format !== undefined) {
-      // Format can change without the panel set — e.g. a panel-less app whose body
-      // flips between a fragment ("app") and a full legacy document ("html").
-      sets.push("format = ?");
-      vals.push(fields.format);
+      sets.push("panels = ?");
+      vals.push(json);
     }
     if (fields.params !== undefined) {
       sets.push("params = ?");

--- a/plugin/gateway/lib/store.ts
+++ b/plugin/gateway/lib/store.ts
@@ -420,7 +420,7 @@ export class KnowledgeStore {
     this.db.run(`CREATE TABLE IF NOT EXISTS published (
       id TEXT PRIMARY KEY,
       title TEXT NOT NULL,
-      format TEXT NOT NULL DEFAULT 'html',
+      format TEXT NOT NULL DEFAULT 'app',
       body TEXT NOT NULL,
       visibility TEXT NOT NULL DEFAULT 'team',
       created_by TEXT NOT NULL,

--- a/plugin/gateway/web/app/pages/AppView.tsx
+++ b/plugin/gateway/web/app/pages/AppView.tsx
@@ -289,8 +289,8 @@ export function AppView() {
   // (401/404/500 — no __SETOKU__): surface it instead of leaving the drawer stuck on
   // "updating…". Armed unconditionally on load (metadata may not have resolved yet
   // during navigation); the FIRE-TIME check reads formatRef — by then the current
-  // app's metadata has resolved, so a legacy "html" report (which never echoes) and
-  // a not-yet-known format don't trip a false error.
+  // app's metadata has resolved, so a not-yet-known format (still loading) doesn't
+  // trip a false error.
   const onFrameLoad = useCallback(() => {
     setFrameLoading(false);
     clearEchoTimer();

--- a/plugin/gateway/web/app/types.ts
+++ b/plugin/gateway/web/app/types.ts
@@ -146,8 +146,9 @@ export interface AppPanel {
   metricId?: string | null;
 }
 
-/** A app/report published to the box (list metadata; no body). A "app"
- *  has live `panels`; a legacy "html" report has none. Mirrors lib/store.ts. */
+/** An app published to the box (list metadata; no body). `format` is always
+ *  "app" now (the legacy raw-served "html" format is gone); a data app has live
+ *  `panels`, a static one has none. Mirrors lib/store.ts. */
 export interface PublishedMeta {
   id: string;
   title: string;

--- a/test/app-history.test.ts
+++ b/test/app-history.test.ts
@@ -66,7 +66,7 @@ describe("app version history", () => {
     // Simulate the http revert handler: feed v1 back through updatePublished.
     store.updatePublished(
       "app1",
-      { title: v1!.title, body: v1!.body, panels: v1!.panels ?? [], params: v1!.params ?? [], format: v1!.format, refreshSeconds: v1!.refreshSeconds },
+      { title: v1!.title, body: v1!.body, panels: v1!.panels ?? [], params: v1!.params ?? [], refreshSeconds: v1!.refreshSeconds },
       { editor: "alice", note: "Restored version 1" },
     );
     const live = store.getPublished("app1");

--- a/test/apps.test.ts
+++ b/test/apps.test.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Pure helpers in lib/apps.ts. isFullDoc decides "legacy full HTML document"
-// (served as-is) vs "fragment the runtime wraps" — it must be anchored so a
-// fragment that merely CONTAINS the literal `<html` (a code snippet, a template
-// string) isn't misclassified and served down the wrong path.
+// Pure helpers in lib/apps.ts. isFullDoc decides "full HTML document" (which
+// publish_app / update_app REJECT — apps are fragments the runtime wraps) vs
+// "fragment" — it must be anchored so a fragment that merely CONTAINS the literal
+// `<html` (a code snippet, a template string) isn't misclassified and rejected.
 import { describe, it, expect } from "bun:test";
 import { isFullDoc } from "../plugin/gateway/lib/apps";
 

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -442,18 +442,27 @@ describe("app surface", () => {
     expect(r.text.toLowerCase()).toContain("membrane");
   });
 
-  it("still publishes a static (zero-panel) report for back-compat", async () => {
+  it("publishes a zero-panel fragment app (state-only / presentational)", async () => {
     const pub = await call("publish_app", {
       title: "Q2 revenue",
-      html: "<!doctype html><h1>Q2 revenue</h1><p>$225</p>",
+      html: "<h1>Q2 revenue</h1><p>$225</p>",
     });
     expect(pub.isError).toBeFalsy();
     const id = (pub.text.match(/\/admin\/p\/([0-9a-f]+)/) ?? [])[1];
     expect(id).toBeTruthy();
     const listed = await call("list_apps");
     expect(listed.text).toContain("Q2 revenue");
-    expect(listed.text).toContain("static");
+    expect(listed.text).toContain("static"); // no live panels
     await call("unpublish_app", { id });
+  });
+
+  it("rejects a full HTML document — apps are fragments the runtime wraps", async () => {
+    const r = await call("publish_app", {
+      title: "full doc",
+      html: "<!doctype html><html><body><h1>hi</h1></body></html>",
+    });
+    expect(r.isError).toBe(true);
+    expect(r.text.toLowerCase()).toContain("fragment");
   });
 
   it("rejects an oversized template", async () => {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -932,7 +932,7 @@ describe("live apps (end-to-end render path)", () => {
     expect((await fetch(`${BASE}/p/${id}`)).status).toBe(200);
   }, 20_000);
 
-  it("clamps an absurd refresh, strips SQL from the list, and 404s subpaths for legacy reports", async () => {
+  it("clamps an absurd refresh, strips SQL from the list, and 404s /data for a panel-less app", async () => {
     const alice = await connect("tok-alice");
     // huge refreshSeconds must be clamped (a 'live' link that never refreshes isn't)
     const big = await call(alice, "publish_app", {
@@ -942,9 +942,9 @@ describe("live apps (end-to-end render path)", () => {
       panels: [{ key: "p", sql: "SELECT count(*) AS n FROM orders", dialect: "postgres" }],
     });
     const bigId = (big.text.match(/\/admin\/p\/([0-9a-f]+)/) ?? [])[1];
-    // a legacy zero-panel report (static)
-    const legacy = await call(alice, "publish_app", { title: "legacy", html: "<!doctype html><h1>hi</h1>" });
-    const legId = (legacy.text.match(/\/admin\/p\/([0-9a-f]+)/) ?? [])[1];
+    // a zero-panel fragment app (state-only / presentational — no live data)
+    const stateOnly = await call(alice, "publish_app", { title: "state-only", html: "<div id=todo></div>" });
+    const soId = (stateOnly.text.match(/\/admin\/p\/([0-9a-f]+)/) ?? [])[1];
     await alice.close();
 
     const boss = await session("boss", "s3cret-pass");
@@ -963,15 +963,16 @@ describe("live apps (end-to-end render path)", () => {
     expect(row.panels?.length).toBe(1); // count still available for the UI
     expect(row.panels?.[0].sql).toBe(""); // but SQL stripped
 
-    // #7: legacy report is served only at /p/<id>; the app subpaths 404
+    // #7: a panel-less app renders via the runtime shell (/p + /frame both serve);
+    // only /data 404s, since the freshness poll is meaningless with no panels.
     await fetch(`${BASE}/admin/api/set_visibility`, {
       method: "POST",
       headers: { "content-type": "application/json", cookie: boss.cookie, "x-csrf-token": boss.csrf },
-      body: JSON.stringify({ id: legId, visibility: "public" }),
+      body: JSON.stringify({ id: soId, visibility: "public" }),
     });
-    expect((await fetch(`${BASE}/p/${legId}`)).status).toBe(200);
-    expect((await fetch(`${BASE}/p/${legId}/frame`)).status).toBe(404);
-    expect((await fetch(`${BASE}/p/${legId}/data`)).status).toBe(404);
+    expect((await fetch(`${BASE}/p/${soId}`)).status).toBe(200);
+    expect((await fetch(`${BASE}/p/${soId}/frame`)).status).toBe(200);
+    expect((await fetch(`${BASE}/p/${soId}/data`)).status).toBe(404);
   }, 20_000);
 
   it("update_app is author-gated, edits in place, injects the chart runtime, and reverts public on panel change", async () => {


### PR DESCRIPTION
Closes #62.

Collapses published apps to a single model — **a fragment the runtime wraps** — and drops the legacy `format="html"` path, where a zero-panel full `<!doctype>` document was served **raw** at `/p/<id>` with no Setoku shell (and so bypassed the branded public header + "Made with Setoku" attribution). Now every public app flows through the branded shell.

### Audit first (issue catch #2)
Checked every live box before deleting the raw-serve branch:

| box | published rows |
|---|---|
| Hedgy (`setoku`) | 9 × `app`, **0 × `html`** |
| demo (`bulldogs_demo`) | 5 × `app`, **0 × `html`** |
| personal | 0 rows |

**Zero `format='html'` rows anywhere** → no data-migration debt, so this is a clean collapse rather than a serve-existing shim.

### Changes
- **`publish_app` / `update_app`** now **reject** a full `<!doctype>`/`<html>` document body with a clear "publish a fragment" steer. A full doc can't be auto-wrapped (the runtime nests the body inside its own `<!doctype>…<body>` skeleton, so a whole document renders wrong — issue catch #1). A bare fragment, with or without panels, stays an app.
- **`createPublished` / `updatePublished`** always store `format='app'` (reverted the panels/`isFullDoc` derivation from #59). The column + type are kept for existing rows and the version-history snapshot; the schema default is updated `'html'` → `'app'`.
- **`http.ts`**: removed the raw-serve branches in the public `/p/<id>` path and the team `/admin/frame/<id>` path. Every app now renders through `frameDocument` (the runtime shell) under the strict `FRAME_CSP; sandbox allow-scripts allow-forms` CSP — a **tightening** vs the old loose `sandbox allow-scripts` a raw body got.
- **`isFullDoc`** is retained solely to reject full docs at publish/update.
- **`app_guide`** spells out the fragment contract (no `<!doctype>`/`<html>`/`<head>`/`<body>` wrapper).

### Testing
- `bun run typecheck` + `bun test` (360 pass) green; pre-push hook green.
- Updated tests: full-doc publish is now asserted **rejected** (e2e); the panel-less-app public paths now assert `/p` 200, `/frame` 200, `/data` 404 (the "legacy report 404s subpaths" test flipped to the new shape); `isFullDoc` unit tests retained (now load-bearing for reject correctness).
- Admin SPA bundle **byte-unchanged** (comment-only `.tsx`/`.ts` edits) — no `build:admin` artifact drift.
- Independent adversarial review found no bugs; confirmed CSP is strictly tightened and no code path still expects `format === "html"`.

### Follow-up (not in this PR)
The web Apps list badges a zero-panel app "interactive" while the `list_apps` MCP tool labels the same app "static" — a pre-existing divergence, now universal for zero-panel apps. Worth reconciling separately (it's a user-facing label choice + a bundle rebuild).