### PR TITLE
site: design riffs + hero phrase rotator, Man/Mac footer links

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -735,11 +735,11 @@
         <span class="eyebrow">Open source · MCP server · Apache-2.0</span>
         <h1>Make any AI fluent in your <span
             class="rotator"
-            data-words="company,family,personal"
-          ><span class="rotator-word">company</span><span
+            data-words="company data,family data,personal data"
+          ><span class="rotator-word">company data</span><span
               class="rotator-measure"
               aria-hidden="true"
-            ></span></span> data.</h1>
+            ></span></span></h1>
         <p class="lede">
           Setoku is a small self-hosted MCP knowledge server + Claude Code
           skills for hooking up your data. It does two things: it gives your AI
@@ -1397,8 +1397,9 @@ SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
             >GitHub</a
           >
           <a href="#demo">Demo</a>
+          <a href="/man" title="this page, as a man page">Man</a>
+          <a href="/mac" title="this page, on System 7">Mac</a>
           <a href="mailto:hello@setoku.com">Contact</a>
-          <span>Apache-2.0</span>
         </div>
         <span class="jp">設 × 奥 · set (math) × oku (innermost)</span>
       </div>

--- a/site/riffs/1-manpage.html
+++ b/site/riffs/1-manpage.html
@@ -1,0 +1,855 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SETOKU(7) · open-source MCP server for company data</title>
+    <meta
+      name="description"
+      content="Setoku is an open-source MCP server that gives your AI a read-only view of your company’s data, plus the context to use it correctly."
+    />
+    <style>
+      :root {
+        --paper: #ffffff;
+        --paper-2: #f5f4f1;
+        --ink: #201f1a;
+        --ink-soft: #423f36;
+        --ink-faint: #6a675c;
+        --line: rgba(32, 31, 26, 0.16);
+        --line-soft: rgba(32, 31, 26, 0.08);
+        --sage: #4d7357;
+        --sage-d: #33543d;
+        --mono: ui-monospace, "SF Mono", "SFMono-Regular", Menlo, Consolas,
+          "Liberation Mono", monospace;
+        --w: 74ch;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+        scroll-behavior: smooth;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family: var(--mono);
+        font-size: 14.5px;
+        line-height: 1.75;
+        padding: 0 20px 80px;
+      }
+      a {
+        color: var(--sage-d);
+        text-decoration: none;
+        border-bottom: 1px solid rgba(51, 84, 61, 0.35);
+      }
+      a:hover {
+        background: var(--paper-2);
+        border-bottom-color: var(--sage-d);
+      }
+      ::selection {
+        background: var(--sage);
+        color: var(--paper);
+      }
+
+      /* running man header/footer */
+      .runline {
+        /* font-size stays at the body size here so 74ch matches main's
+           column exactly; the smaller text is set on the children */
+        max-width: var(--w);
+        margin: 0 auto;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        letter-spacing: 0.02em;
+        color: var(--ink-faint);
+        white-space: nowrap;
+        overflow: hidden;
+      }
+      .runline > span {
+        font-size: 12.5px;
+      }
+      .runline .mid {
+        flex: 1;
+        text-align: center;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .runline.top {
+        padding: 16px 0 8px;
+        border-bottom: 1px solid var(--line-soft);
+      }
+      .runline.bot {
+        padding: 14px 0;
+        margin-top: 40px;
+        border-top: 1px solid var(--line-soft);
+      }
+      @media (max-width: 620px) {
+        .runline .mid {
+          display: none;
+        }
+      }
+
+      main {
+        max-width: var(--w);
+        margin: 0 auto;
+        position: relative;
+      }
+
+      /* section headers, man-page style */
+      h2.man {
+        font-size: 14.5px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        color: var(--ink);
+        margin: 46px 0 6px;
+        scroll-margin-top: 60px;
+      }
+      section {
+        padding-left: 0;
+      }
+      .body {
+        padding-left: 5ch;
+      }
+      @media (max-width: 560px) {
+        .body {
+          padding-left: 2.5ch;
+        }
+      }
+      p {
+        color: var(--ink-soft);
+        margin: 12px 0;
+        max-width: 66ch;
+      }
+      b,
+      strong {
+        color: var(--ink);
+        font-weight: 700;
+      }
+      .dim {
+        color: var(--ink-faint);
+      }
+      .cmd {
+        color: var(--sage-d);
+        font-weight: 600;
+      }
+
+      /* NAME line + rotator */
+      .nameline {
+        color: var(--ink);
+        margin-top: 8px;
+      }
+      .rotator {
+        display: inline-block;
+        color: var(--sage-d);
+        border-bottom: 1px solid rgba(51, 84, 61, 0.4);
+      }
+
+      pre.block {
+        background: var(--paper-2);
+        border: 1px solid var(--line);
+        border-radius: 4px;
+        padding: 14px 16px;
+        overflow-x: auto;
+        margin: 14px 0;
+        line-height: 1.7;
+        color: var(--ink);
+      }
+      pre.block .c {
+        color: var(--ink-faint);
+      }
+      pre.block .cmd {
+        color: var(--sage-d);
+      }
+
+      .kv {
+        margin: 16px 0;
+      }
+      .kv dt {
+        color: var(--ink);
+        font-weight: 700;
+      }
+      .kv dt .t {
+        color: var(--ink-faint);
+        font-weight: 400;
+        margin-left: 1ch;
+      }
+      .kv dd {
+        color: var(--ink-soft);
+        margin: 2px 0 14px 4ch;
+        max-width: 62ch;
+      }
+
+      ul.man {
+        list-style: none;
+        margin: 12px 0;
+      }
+      ul.man li {
+        color: var(--ink-soft);
+        padding-left: 3ch;
+        position: relative;
+        margin: 6px 0;
+        max-width: 64ch;
+      }
+      ul.man li::before {
+        content: "•";
+        position: absolute;
+        left: 0.6ch;
+        color: var(--ink-faint);
+      }
+
+      /* clover: centered above NAME, a title plate */
+      pre.fig {
+        width: max-content;
+        margin: 38px auto -8px;
+        color: var(--sage-d);
+        font-size: 11px;
+        line-height: 1.15;
+        white-space: pre;
+        user-select: none;
+      }
+
+      /* ascii art wrapper */
+      .ascii-wrap {
+        overflow-x: auto;
+        margin: 16px 0;
+      }
+      pre.ascii {
+        line-height: 1.2; /* box-drawing verticals must touch; >1.2 leaves gaps */
+        font-size: 13px;
+        color: var(--ink);
+        white-space: pre;
+        min-width: min-content;
+        letter-spacing: 0;
+      }
+      pre.ascii .lbl {
+        color: var(--sage-d);
+      }
+      pre.ascii .an {
+        color: var(--ink-faint);
+      }
+
+      /* examples */
+      .ex {
+        margin: 18px 0;
+      }
+      .ex .q {
+        color: var(--ink);
+      }
+      .ex .q::before {
+        content: "Q  ";
+        color: var(--sage-d);
+        font-weight: 600;
+      }
+      .ex .a {
+        color: var(--ink-soft);
+        padding-left: 0;
+        margin-top: 2px;
+        max-width: 64ch;
+      }
+      .ex .a::before {
+        content: "A  ";
+        color: var(--sage-d);
+        font-weight: 600;
+      }
+      .ex .a .big {
+        color: var(--ink);
+        font-weight: 700;
+      }
+
+      /* ascii chart */
+      pre.chart {
+        line-height: 1.5;
+        font-size: 12.5px;
+        color: var(--ink);
+        white-space: pre;
+        margin: 8px 0 4px 3ch;
+        overflow-x: auto;
+      }
+      pre.chart .bar {
+        color: var(--sage);
+      }
+      pre.chart .num {
+        color: var(--ink);
+      }
+
+      details {
+        margin: 14px 0;
+        max-width: 66ch;
+      }
+      summary {
+        cursor: pointer;
+        color: var(--sage-d);
+      }
+      details p {
+        margin-top: 8px;
+      }
+
+      .mark {
+        width: 15px;
+        height: 15px;
+        display: inline-block;
+        vertical-align: -2px;
+        color: var(--ink);
+        margin-right: 2px;
+      }
+      .foot-etym {
+        color: var(--ink-faint);
+        font-size: 12.5px;
+        text-align: center;
+        margin-top: 26px;
+      }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path
+          d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z"
+          fill="currentColor"
+        />
+      </symbol>
+    </svg>
+
+    <div class="runline top">
+      <span
+        ><svg class="mark"><use href="#clover" /></svg>SETOKU(7)</span
+      >
+      <span class="mid">Miscellaneous Information Manual</span>
+      <span>SETOKU(7)</span>
+    </div>
+
+    <main id="top">
+      <!-- masthead clover: the actual mark, rasterized from its SVG paths -->
+<pre class="fig" aria-hidden="true">
+ .*%@@@%*.
+:@@@@@@@@@*
+@@@@@@@@@@@:     :*%%*.
+@@@@@@@@@@@@:   %@@@@@@*
+.%@@@@@@@@@@@. %@@@@@@@@
+  :**%%@@@@@@*.@@@@@@@%:
+        .:*@@%%@@%**:.
+            :%%:.
+            .@@.
+            :@@:
+            %@@:
+           .@@@.
+           %@@@.
+          .@@@@
+</pre>
+      <section>
+        <h2 class="man">NAME</h2>
+        <div class="body">
+          <p class="nameline">
+            <b>setoku</b> &mdash; make any AI fluent in your
+            <span
+              class="rotator"
+              data-words="company data,family data,personal data"
+              >company data</span
+            >
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="man">SYNOPSIS</h2>
+        <div class="body">
+<p>
+            Setoku is a small self-hosted MCP knowledge server + Claude Code
+            skills for hooking up your data. It does two things: it gives your
+            AI a read-only way to query your data, and it remembers what that
+            data means (the metric definitions, the gotchas), getting better the
+            more you use it. The MCP works with whatever AI you already have, and
+            no model runs on the server, so no added inference cost.
+          </p>
+          <p class="dim">
+            Open source &middot; MCP server &middot; Apache-2.0 &middot;
+            <a
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >github.com/Hedgy-Labs/setoku ↗</a
+            >
+            &middot; <a href="#demo">jump to DEMO</a>
+          </p>
+        </div>
+      </section>
+
+      <section id="quickstart">
+        <h2 class="man">QUICKSTART</h2>
+        <div class="body">
+          <p>
+            Setoku installs as a Claude Code plugin. Add the plugin, then run
+            onboarding from your main project directory, the codebase you want
+            Setoku to learn from:
+          </p>
+<pre class="block"><span class="c"># 1 · add the plugin (skills only)</span>
+<span class="cmd">/plugin</span> marketplace add Hedgy-Labs/setoku
+<span class="cmd">/plugin</span> install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+<span class="cmd">/setoku:onboard</span></pre>
+          <p>
+            Onboarding stands up the server, auths your Claude, wires your
+            database read-only, and generates the first knowledge from your
+            code. You stay in the loop for anything that touches your data. To
+            start onboarding, run <span class="cmd">/setoku:onboard</span>.
+          </p>
+          <p>
+            You’ll need somewhere to host it. Something like OVH’s
+            <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener"
+              >VPS-2</a
+            >
+            is plenty.
+          </p>
+          <details>
+            <summary>Or stand up the server by hand</summary>
+<pre class="block"><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</pre>
+            <p>
+              Installs Docker, generates secrets, gets an HTTPS certificate, and
+              prints the connect command. Then add the plugin and run
+              /setoku:onboard from your project; it’ll detect the box you just
+              made.
+            </p>
+          </details>
+        </div>
+      </section>
+
+      <section id="how">
+        <h2 class="man">DESCRIPTION</h2>
+        <div class="body">
+          <p>
+            Setoku gives the AI two kinds of MCP tools, and one rule: look up
+            what the data means before you touch it.
+          </p>
+          <dl class="kv">
+            <dt>Context tools<span class="t">find_context · get_metric</span></dt>
+            <dd>
+              The AI reads what your data means first: canonical metric
+              definitions, entity docs, and the gotchas that make a naive query
+              wrong.
+            </dd>
+            <dt>Read-only query<span class="t">get_schema · run_query</span></dt>
+            <dd>
+              Read-only, with a row cap, a statement timeout, a table allow-list,
+              and an append-only audit log. Enforced by the database role, not by
+              parsing SQL.
+            </dd>
+            <dt>Human-approved<span class="t">report_correction</span></dt>
+            <dd>
+              The AI can only propose changes to what Setoku knows. A person
+              accepts them on the admin page, outside the agent loop, so an
+              injected session can’t rewrite the brain.
+            </dd>
+          </dl>
+          <p>You set it up with <b>Claude Code</b> skills:</p>
+          <ul class="man">
+            <li>
+              <span class="cmd">/setoku:onboard</span> sets Setoku up in a repo
+              for the first time.
+            </li>
+            <li>
+              <span class="cmd">/setoku:connect</span> adds a data source or
+              custom integration.
+            </li>
+            <li>
+              <span class="cmd">/setoku:generate</span> writes business context
+              from your code.
+            </li>
+            <li>
+              <span class="cmd">/setoku:curate</span> reviews and approves
+              pending knowledge.
+            </li>
+          </ul>
+          <p>
+            Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex, or
+            whatever you run. Just ask in plain language, and the tools do the
+            rest.
+          </p>
+        </div>
+      </section>
+
+      <section id="apps">
+        <h2 class="man">APPS</h2>
+        <div class="body">
+          <p>
+            Ask Claude to build a dashboard on your data. Then publish it to a
+            link as a Setoku App, the data stays live, and your whole team can
+            view it. Nothing to deploy, no frontend to maintain.
+          </p>
+          <dl class="kv">
+            <dt>Built by asking<span class="t">publish_app</span></dt>
+            <dd>
+              Describe it in plain language; the agent writes the app and
+              publishes it to a URL. Edit it the same way, just ask for the
+              change.
+            </dd>
+            <dt>Backed by live data<span class="t">read-only</span></dt>
+            <dd>
+              Apps read through the same governed path: row caps, audit, a
+              SELECT-only database role. They never get write access to your
+              sources.
+            </dd>
+            <dt>App-private state<span class="t">no writes to your data</span></dt>
+            <dd>
+              Each app keeps its own state (todos, votes, annotations) in a
+              sandbox that belongs to the app, not your database. Worst case, an
+              app messes up its own notes.
+            </dd>
+            <dt>Share by link<span class="t">team or public</span></dt>
+            <dd>
+              A team link is login-gated; an admin can flip one public for a
+              credential-free URL. The page runs in a locked-down sandbox with no
+              network, so a published app can’t phone home.
+            </dd>
+          </dl>
+        </div>
+      </section>
+
+      <section id="architecture">
+        <h2 class="man">ARCHITECTURE</h2>
+        <div class="body">
+          <p>
+            You can host this on whatever infra you like. We put it all on one
+            small box (a ~$12/mo VPS). The
+            <span class="cmd">/setoku:connect</span> skill helps you add custom
+            integrations. Only the proxy is public, so your databases aren’t
+            exposed. Queries are read-only, and knowledge changes pass through a
+            person.
+          </p>
+          <div class="ascii-wrap">
+<pre class="ascii" role="img" aria-label="Setoku architecture: you and your AI connect over MCP to the Setoku gateway on your box. A person approves changes into the gateway. The gateway reads a ClickHouse lake and a knowledge store. Below the box, your sources are ingested into the lake and your Postgres database feeds it read-only, mirrored on a cron.">
+                        <span class="lbl">┌───────────────────┐</span>
+                        <span class="lbl">│</span>   <span class="lbl">You</span> <span class="lbl">+</span> <span class="lbl">your</span> <span class="lbl">AI</span>   <span class="lbl">│</span>
+                        <span class="lbl">└─────────┬─────────┘</span>
+                                  <span class="lbl">│</span>  <span class="an">MCP · read · propose</span>
+  <span class="an">your box</span>                        <span class="lbl">│</span>
+ <span class="lbl">┌────────────────────────────────┬─────────────────────────────────┐</span>
+ <span class="lbl">│</span>                                <span class="lbl">│</span>                                 <span class="lbl">│</span>
+ <span class="lbl">│</span>                  <span class="lbl">┌─────────────┴──────┐</span>          <span class="lbl">┌───────────┐</span>   <span class="lbl">│</span>
+ <span class="lbl">│</span>                  <span class="lbl">│</span>   <span class="lbl">Setoku</span> <span class="lbl">gateway</span>   <span class="lbl">│</span> <span class="an">approves</span> <span class="lbl">│</span>  <span class="lbl">a</span> <span class="lbl">person</span> <span class="lbl">│</span>   <span class="lbl">│</span>
+ <span class="lbl">│</span>                  <span class="lbl">│</span> <span class="lbl">context</span> <span class="lbl">·</span> <span class="lbl">queries</span>  <span class="lbl">│◀─────────┤</span>           <span class="lbl">│</span>   <span class="lbl">│</span>
+ <span class="lbl">│</span>                  <span class="lbl">└───┬─────────────┬──┘</span>          <span class="lbl">└───────────┘</span>   <span class="lbl">│</span>
+ <span class="lbl">│</span>               <span class="an">reads</span>  <span class="lbl">│</span>             <span class="lbl">│</span> <span class="an">reads · proposes</span>            <span class="lbl">│</span>
+ <span class="lbl">│</span>                      <span class="lbl">│</span>             <span class="lbl">│</span>                             <span class="lbl">│</span>
+ <span class="lbl">│</span> <span class="lbl">┌────────────────────┴───────┐</span>  <span class="lbl">┌──┴────────────────┐</span>            <span class="lbl">│</span>
+ <span class="lbl">│</span> <span class="lbl">│</span>     <span class="lbl">Lake</span> <span class="lbl">(ClickHouse)</span>      <span class="lbl">│</span>  <span class="lbl">│</span>  <span class="lbl">Knowledge</span> <span class="lbl">store</span>  <span class="lbl">│</span>            <span class="lbl">│</span>
+ <span class="lbl">│</span> <span class="lbl">│</span> <span class="lbl">logs</span> <span class="lbl">·</span> <span class="lbl">events</span> <span class="lbl">·</span> <span class="lbl">DB</span> <span class="lbl">mirror</span>  <span class="lbl">│</span>  <span class="lbl">└───────────────────┘</span>            <span class="lbl">│</span>
+ <span class="lbl">│</span> <span class="lbl">└─────▲─────────────────▲────┘</span>                                   <span class="lbl">│</span>
+ <span class="lbl">│</span>       <span class="lbl">│</span>                 <span class="lbl">│</span>                                        <span class="lbl">│</span>
+ <span class="lbl">└───────┼─────────────────┼────────────────────────────────────────┘</span>
+  <span class="an">ingest</span> <span class="lbl">│</span>       <span class="an">read-only</span> <span class="lbl">│</span>   <span class="an">(mirrored on a cron)</span>
+  <span class="lbl">┌──────┴──────────┐</span>   <span class="lbl">┌──┴──────────────────┐</span>
+  <span class="lbl">│</span>   <span class="lbl">Your</span> <span class="lbl">sources</span>  <span class="lbl">│</span>   <span class="lbl">│</span>    <span class="lbl">Your</span> <span class="lbl">database</span>    <span class="lbl">│</span>
+  <span class="lbl">│</span> <span class="lbl">GH·Vercel·Slack…│</span>   <span class="lbl">│</span> <span class="lbl">Postgres</span> <span class="lbl">·</span> <span class="lbl">read-only│</span>
+  <span class="lbl">└─────────────────┘</span>   <span class="lbl">└─────────────────────┘</span>
+</pre>
+          </div>
+        </div>
+      </section>
+
+      <section id="connectors">
+        <h2 class="man">CONNECTORS</h2>
+        <div class="body">
+          <p>
+            Point Setoku at the data you already have. Every source lands in a
+            local
+            <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+              >ClickHouse</a
+            >
+            data lake, on purpose: agents write arbitrary queries (scans, GROUP
+            BYs, whole-table aggregations), and a columnar engine answers those
+            in about a second, so the apps and dashboards they build stay quick.
+            Your app database connects read-only and is mirrored in on a cron;
+            the rest is ingested as it happens.
+          </p>
+          <div class="ascii-wrap">
+<pre class="ascii">
+  <span class="an">ClickHouse · one lake, every source</span>
+  <span class="lbl">┌────────────┬──────────────────────────────────┐</span>
+  <span class="lbl">│</span> <span class="cmd">PostgreSQL</span> <span class="lbl">│</span> app database, mirrored read-only <span class="lbl">│</span>
+  <span class="lbl">│</span> <span class="cmd">GitHub</span>     <span class="lbl">│</span> issues, PRs &amp; commits            <span class="lbl">│</span>
+  <span class="lbl">│</span> <span class="cmd">Vercel</span>     <span class="lbl">│</span> deploys &amp; logs                   <span class="lbl">│</span>
+  <span class="lbl">│</span> <span class="cmd">Render</span>     <span class="lbl">│</span> deploys &amp; logs                   <span class="lbl">│</span>
+  <span class="lbl">│</span> <span class="cmd">Slack</span>      <span class="lbl">│</span> messages                         <span class="lbl">│</span>
+  <span class="lbl">│</span> <span class="cmd">Mercury</span>    <span class="lbl">│</span> banking &amp; finance                <span class="lbl">│</span>
+  <span class="lbl">└────────────┴──────────────────────────────────┘</span>
+</pre>
+          </div>
+          <p>
+            No connector for your source yet? The included setup skills give your
+            coding agent the patterns to wire one up itself. See
+            <a
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >the repo</a
+            >, or open an issue.
+          </p>
+        </div>
+      </section>
+
+      <section id="demo">
+        <h2 class="man">DEMO</h2>
+        <div class="body">
+          <p>
+            There’s a live demo wired to a fictional pro sports club, the Bonita
+            Bulldogs (ticketing, sponsorship, concessions, payroll, broadcast
+            rights).
+          </p>
+          <p class="dim">
+            <b class="dim" style="color: var(--ink)">1.</b> Connect to the demo
+            MCP server. In Claude (or any MCP client) open Settings → Connectors
+            → Add custom connector, and paste this URL. The token rides in the
+            URL, so there’s no separate key to enter.
+          </p>
+<pre class="block">https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</pre>
+          <p class="dim" style="color: var(--ink)">
+            <b>2.</b> Ask a question.
+          </p>
+
+          <div class="ex">
+            <div class="q">“How many unique fans do we have?”</div>
+            <div class="a">
+              <span class="big">71,204</span>. Deduped by normalized email,
+              internal accounts excluded. Not the raw 92,118.
+            </div>
+          </div>
+          <div class="ex">
+            <div class="q">
+              “What’s our total annual revenue, and how much is media rights?”
+            </div>
+            <div class="a">
+              <span class="big">$192M</span>. Five systems reconciled to the
+              same units. Media rights is the biggest line, ~$90M.
+            </div>
+          </div>
+          <div class="ex">
+            <div class="q">“What was ticket revenue this season?”</div>
+            <div class="a">
+              <span class="big">$46.8M</span>. Cents reconciled to dollars;
+              refunds, exchanges, and comps excluded.
+            </div>
+          </div>
+          <div class="ex">
+            <div class="q">“What’s our total merchandise revenue?”</div>
+            <div class="a">
+              <span class="big">It flags it</span>. Most merch is sold via
+              Fanatics, not in this data, so it says so instead of returning a
+              wrong total.
+            </div>
+          </div>
+          <div class="ex">
+            <div class="q">“Chart revenue by line.”</div>
+            <div class="a">Annual revenue by line · ~$192M total</div>
+<pre class="chart" role="img" aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M.">Media rights  <span class="bar">████████████████████████████</span>  <span class="num">$90M</span>
+Ticketing     <span class="bar">██████████████▋</span>            <span class="num">$47M</span>
+Sponsorship   <span class="bar">████████▋</span>                  <span class="num">$28M</span>
+Concessions   <span class="bar">████▍</span>                      <span class="num">$14M</span>
+Merch         <span class="bar">██▌</span>                        <span class="num">$8M</span>
+Other         <span class="bar">█▌</span>                         <span class="num">$5M</span></pre>
+          </div>
+
+          <p class="dim" style="color: var(--ink); margin-top: 22px">
+            <b>3.</b> Try an app.
+          </p>
+          <p>
+            Ask Claude to build a dashboard on the same data, then publish it to
+            a link. Two live examples, running on the demo data right now:
+          </p>
+          <ul class="man">
+            <li>
+              <a
+                href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+                target="_blank"
+                rel="noopener"
+                >Sponsorship pricing table ↗</a
+              >
+              — inventory and rates for sponsorship placements.
+            </li>
+            <li>
+              <a
+                href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+                target="_blank"
+                rel="noopener"
+                >Fan lifetime value ↗</a
+              >
+              — segment fans by spend across tickets, merch, and concessions.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section id="why">
+        <h2 class="man">RATIONALE</h2>
+        <div class="body">
+          <p><b>We’re curious.</b></p>
+          <p>
+            There are plenty of AI memory stores, and plenty of data gateways.
+            Stapling the two together, and nudging the agent to gather knowledge
+            about the data as it goes, seemed useful and fun to tinker with.
+          </p>
+          <p><b>We’re cheap.</b></p>
+          <p>
+            We wanted something that runs on one small box, works on a Pro/Max
+            subscription or a cheap model with no added inference cost, mostly
+            sets itself up (no field engineer to pay for), stays portable between
+            providers, and is open source.
+          </p>
+          <p><b>We’re paranoid.</b></p>
+          <p>
+            HR platforms, CRMs, and clouds are all announcing “context layers.”
+            They’d like the meaning of your business to accumulate on their
+            servers, where it can never leave. Context is deeper lock-in than
+            data, and a hosted context layer has no export button. Setoku exists
+            so that understanding accumulates on a box you own instead. If we
+            disappear tomorrow, your context doesn’t.
+          </p>
+          <p><b>We and some friends wanted the same thing.</b></p>
+          <ul class="man">
+            <li>
+              <b
+                ><a href="https://www.hedgy.works" target="_blank" rel="noopener"
+                  >Hedgy</a
+                ></b
+              >: keep scaling without hiring. Debug from live logs and data, find
+              growth levers, and match candidates and companies better with more
+              data.
+            </li>
+            <li>
+              <b
+                ><a href="https://baggu.com" target="_blank" rel="noopener"
+                  >Baggu</a
+                ></b
+              >: give employees state-of-the-art tools. Faster onboarding, and a
+              safe way to vibecode against real data.
+            </li>
+            <li>
+              <b
+                ><a href="https://tlon.io" target="_blank" rel="noopener"
+                  >Tlon</a
+                ></b
+              >: experimenting with giving agents curated data to work from.
+            </li>
+            <li>
+              <b>Sports analysts</b>: query across data that doesn’t usually sit
+              together.
+            </li>
+            <li>
+              <b>Academic labs</b>: think through hypotheses against real papers,
+              data, and drafts.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section id="bugs">
+        <h2 class="man">BUGS</h2>
+        <div class="body">
+          <p>
+            Your AI can still be confidently wrong. Setoku just makes that
+            harder to do quietly.
+          </p>
+          <p class="dim">
+            Everything else:
+            <a
+              href="https://github.com/Hedgy-Labs/setoku/issues"
+              target="_blank"
+              rel="noopener"
+              >github.com/Hedgy-Labs/setoku/issues ↗</a
+            >
+          </p>
+        </div>
+      </section>
+
+      <section id="help">
+        <h2 class="man">SEE ALSO</h2>
+        <div class="body">
+          <p>
+            It’s open source, so you can self-host it today. If you like, we’re
+            happy to help set it up. Just email
+            <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+          </p>
+          <ul class="man">
+            <li>
+              <a
+                href="https://github.com/Hedgy-Labs/setoku"
+                target="_blank"
+                rel="noopener"
+                >github.com/Hedgy-Labs/setoku ↗</a
+              >
+            </li>
+            <li><a href="#demo">DEMO</a> — try it on real-ish data</li>
+            <li>
+              <a href="mailto:hello@setoku.com">hello@setoku.com</a> — setup help
+            </li>
+          </ul>
+          <p class="foot-etym">
+            設 × 奥 · set (math) × oku (innermost) · Apache-2.0
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <div class="runline bot">
+      <span>Hedgy Labs</span>
+      <span class="mid">2026</span>
+      <span>SETOKU(7)</span>
+    </div>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) {
+            return w.trim();
+          })
+          .filter(Boolean);
+        if (words.length < 2) return;
+        var reduce = window.matchMedia(
+          "(prefers-reduced-motion: reduce)"
+        ).matches;
+        var i = 0;
+        function swap() {
+          i = (i + 1) % words.length;
+          if (reduce || !box.animate) {
+            box.textContent = words[i];
+            return;
+          }
+          box
+            .animate([{ opacity: 1 }, { opacity: 0 }], {
+              duration: 220,
+              easing: "ease-in",
+              fill: "forwards",
+            })
+            .finished.then(function () {
+              box.textContent = words[i];
+              box.animate([{ opacity: 0 }, { opacity: 1 }], {
+                duration: 220,
+                easing: "ease-out",
+                fill: "forwards",
+              });
+            })
+            .catch(function () {});
+        }
+        setInterval(swap, 2600);
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/10-classicmac.html
+++ b/site/riffs/10-classicmac.html
@@ -1,0 +1,1660 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · System 7</title>
+    <style>
+      /* Embedded System-OS bitmap fonts (self-contained, base64 woff2).
+   Chicago/ChicagoPixel: Chicago clones · Geneva: FindersKeepers · Monaco clone.
+   Free/OFL-style faces from the system.css project; verify licensing before production ship. */
+@font-face{font-family:'Chicago';src:url(data:font/woff2;base64,d09GMgABAAAAACsAAA8AAAAAanQAACqhAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGhgGVgCEJAgYCYFpCoG1aIGNPguDfAABNgIkA4d0BCAFg34HhDMMOxtGUxXjWAseB4EWqyWianTm7P/L5I3RD00aDHsyRCbDlLRkFRpqNOiSU0i08cIw6RGRzk3GJx+W9E6eka58DR2jZ4PqMOutB2nQ/SM09kmuH63V+wq6uqemp6dndu9u9wj2w34gUkEVY+KBhIqSEY4skEIV+VUSBzg8ze0fxpdJrYja7m63WxASFia1DdgG272DUfpBpawCu/CXQY+6Q8RojPplgYo2adVmDGMDhIfnD3/n3temqE8t/Qu4sQdJwglGY1mUQAJr/d9aOt/Of3EFBFX2VeF7USWSkVXV1bkspbg4e4SLx7hb/v/+p2r5PwA6vEdIravGnZviAkBIwu5RYXe5YzrkC2qAFqgvt04Qps2ajUzyoS5AVOVh+vy9zqr0/6bqKfcSRezlA8qXKNsJsr0kkN5/kvy/rHHLLLuBhtQDbnnQPSRb6prGBYKoj9jtIV5izwGR+wAzzDbaunyD5CAJLwspurro9vfTSlRoOqGpj7FUjPTG333eMOa+f/Yuvfrfxq3aagpoAoIMRYa2lOdyI0pmZQrv8ROOAUA2flrlfzsd+9FD/T8o5BlopWzoairKM9FtMOBL0wmoL4pl5+uMFd5OqmeAOBz8cBLs6p7BzxVp/x+NlNLuRusQGbIJb2ZmUJ9O8Zd3UDCAfYhBWOddDfrtYGRGQfyR/2f7wAIJQsagGOb5pPJ/EMxVOhhkZJTTSX1YnVeD/z8fv3n5uVNH2PR9Aj9fPGFd9U60mQA7+w4HIvQJhOrazqYBfhElje88LJv/yGOtctNt2nUAoFOXJ/FrxFOvvDbAc2+9894HJmYfffLZFxbdvvrmux+sbHr0AnZtYAcAAEQR2GJqcFjG29yV3nSrXtx/o3v8MREuJiRSmdzPPyBwWFBwSOjwESNHjQ4bM3bc+AkTwyMio6IVSlVMbJxao41P0OlJSCUmGZJTUtPSJ03+NSNzytRpWdk5uXnTZ8ycNXsO+OPPXXsqauoPHTx89MixE6dONp4+e+bc+YuXL/397z9Xr1y73rly3vzFT9YfWF7wcm0++IsGqwBYuA4AAMCSzeD4/zvmLgN3AVi65Sko/L365q0HD9vaHz3+DzTfAeD5CwC6NrR2PPtt786i3SWlZcWVVcBYt48B9+6vAABsBACAmL6KAdGpMiB/MTT/ZgfQS+DUbCNYS1tHyO6D7Ubq33Bpfe9pLHJ4ENDIrj6AKPKiD1NGYg6oF2Z10IcGLpVTHhbxBJksSkG2mtbpaThIieRmTjus4o28OEXW1teGIYfBrbx5eWoLPTyU4n0tyEpJGRPQaFAT9SoxJUgg05Hrp8sj79uRHlyfhTKFWErWJx9+f8z7YJnoFG8URRSHP10tyKcWmpLCiPxCpGzbV+R5kEuH9PxSbYDDjH+Z9IXkcZJZDwCbp5KZKMMJJ0O5kToFZbMAR1ckFEX4hKkhoOxBQ2NR6RSP55WwzN2cFvlBLEVEvYysTeAKSoR2k4HhkagbWTu5y0eiwuGESkR78BCdk6wvl9Ic04g1nlKycFBuWOgCKSrMrRasARVooSvUQ1I9mHLsuWpgxYcYGw3AEDdZJuaMIncYAYHnEEa/Ybgvvy3QuFGaJBrRopoe2E9v38RindXjBWZU7CtWtKxKoE3UeUh1tPZtZs1fakd36POq+7NtB/BVMDuvQETMBgGr0NGSRTTUMUQEl2DkSCwZDeEXETnCel6jdE+SZUgEHqB7t+ybWDG9XqPgGBJlkmPvfgZbImQMl1xTeD9XwFZE1qnvoXDI4zXc4MCXH4JjVPJNNI8F9OHxlv1mmb6MIRyOVjOA71WySsQr+VuW2fGpsMF9gCATrXRZ/ae6tsasdYs/wldnQVvw/Im7xB6+mAFybR0nRUra7WLv+1moGa+3WUVTw64YPCmcLtM2+47AhEBCSrq8RG0WrAlhAge4iCuzoaVCqWg5XSIC+XWAmxWyOg5jjkGQATlIEu/6kwaLhxhtXPnlKF7uxOuoy9R8qYx8aFuSLExWCBXyEkvsd0AYYGpW8HHIz1GaB6AxK9SNUyftLiG1vVQhPMjfx+LQw9T17rn6uInpT0RlQqQKJ/CR68itUXeY54Lbmbfb+/MQUFKDBTXgUExYKUGBuIqhQJVjKVILroEya3YR+UDWZZiAukf9+5SmoJApxBCTUOOiEMhPORH60xmE2evIl9mRVzS2vm1PmFY2G8FAPyBIcit3Q7qjaaSTCzWuQWjQRgDCFNLnJx1l7WLtrgR7lwyyyutiPPCHcoFlUgTTTFSTAkWT7ev8mYKpxHnSosc0wA+UsFSomp0EBtZ8D+VMgyBMVKpwpgRISP4d2XPIjpwS+MQFnClNiMFLbAkWMNDq689QNFnniJQp+q6ZImgNZgEd22KyIKYsp0v0OrYAtGb9ftvquunbaWNvKWhsK99aZ5AijpbmLXaTbePwJrFTiVm+e3WsyTTH2w1+oPCKj4t1OqSsAwNVWanBsEi9A92il9bovFVvD6VdKAij0EbzFauBBZ61c/AD3AoHhZRba9DzaTTyYUkZrzOoeb9M3bjL97NpHgbP8vfQrBRRAiDrXrf4zwZdiBRO4PodSRAxVdBgP5S5VKfLqUtE/lprM532QNPhQ4prXUeh48AZrmr3AIdK+C7ND1gdbHh7lxzmAUt1lYQmC7ScSbLsHxYmCzFf8esXw3mJE9/g9GXy6113TJEqW70icqFI7izPgcIFYbW3BEqQS2+6jKWRNnvZOOhS00zbirmMvBOSnqMvUe87czCwyau26FXwujHl7hUJatz50jfpLVqBCRy+WwjD2K5OxijEdyhoEWTit1HrH2yt41uwikR51cUgTrZxtOvoMppAiw30gRFYRmqjqW6O+45rOBGv462BZSU7DFHboqODThNufHBbVEP0eRqbXw6MPCLjScb7QeA6FJQpjByNoD3h7Z2w33XxGbEF2gA9UFzqL4RAX9bAVsOEsSgMlxSlkxRR2DzQZ8+11vF/YURC/BJfZK1Uukvk6RMpDpUegqbVjHWNsZe1Om50ObRZYi9fCTUY2tm0AvsFWn+b2o7liLgstQW1kXU0K4u7vrSembAeRitLJfS9aP6GJJ8ULkehvOjpCs93a/szijYhBkJBrknTls+ycVJieok2iyUiaF969lTP2T/7+OozqFhQ++rTF6RoRSc7sfFcp/Y+SR2b+PXYkCn5yfdkn2qCsXGSmO/cg1ZR1PDd64sNCd0ri+PkpSVUQQCI8Bjxmz6Uv5JOp/rvfxKvYklf20IfTMryYOzhwVAD8331JvbaJKVh0iYexZa+E0Rk57lDBPWzwNS3dp82Zbggxr0aerssl9KO0V8Naljx2D0jalqyoZ3XMd/zYcHur8hT68SMmIDSH20QYdSjLSMpsYi891DRv43iXT4+kfwdR0wcVzyL/lmC0FsTtTa0gEuymjgHmdbyUXhDQU6ISgWeDoLnmKbvC0SUNvWuvOpWxqdwRZdlkB5+Q17jfxA+7g0HOi0VuS96IKWkxJXsLGSL77zgZK296n/+9QH3d8x/Q99mcdzBJE7BTXJAQxIUjmlHV/hcnZUXgRnPC4o/0CrURynpoYWGoQEvPFv/+3xA5H7mM4J5CP8iPlK7VU7xcz9L2oF9fhYfvNvbfiSqQij64LlcvJgUcDhtpM+h/mKFzWpKXJY2ZuGF8T7qKTaCgkZG9y5M8Slf63uXIyNmS+l+PIcAnHCnxgsqwJMBO4unhgCALDXeAOiZzLs7TMafuomBuDVjuvLSs79znydElkGo5R0V8PRROvQ4KV32OUlpDVQQopCmUBmzaqKV30Z4mqpR7r4Klrtk4FABz0sWnGsAKkulmnBcLpa5gFnMk4wieRP2RdjDDPrU8MIIKIeA6j03UCDROF0iq5rPCuc3QJf8pn/8WsmJHcPPJvZHZezhRXzQabOuRAtwqr769CS9zl+5I+d/Eqgflppa6VDUQrqmPtbp0mBDvcl1/dH6mjHwLTVd7vsN+h8UeKb+vVAwjv4rgQj8R2gu/afGA0MNjh2NRBnlN9n6XMFM9+7TN7EP2aQOGhgdp0lRxf2jL+8NFa92bNsC9+zvAlM8l810RkAW+EiHnCSNX5tfRvEBQguhBxWC4Ui9YxCtIV4I/wEjSZCD0qUGZhd7OqfA8Henihj8edW3+AZhxtANxa3yh6QJ+p4G3mwnNwbDd3Nx99EDdMetBLZ9dK+M7Snyj8MGB8oEl4JYkdxj3wGMBuY2nUbuROQU5olJTNgn7HPGju0qfhDtwt83sp0dqXbMdolFjvhz1po/8rF82KUiZpo0ReuDprJetQUvff3sIo/gFtfNrVmw0lZ//318xhvPu1KoGb328O+OJ8N6o8KfwwRDjUk+uEjZgjaDOh8Zb0kEdV5Veaco4ToRAl5FEGHEL5X4HV6JaWznNtnz8ywxiVf9BWdKkfTSWyuuvNQ/Jon5fnnIs4nW6VAMtk/ua0d/Kofd0OLZnayWVzvxKawn4R07woIrfzcu/Z+jTb2itiire96VvaPLM1KHI0r/7jipz2fxJQVoyhBnhnfhUmPOINhSQ7PVh2586228Oh3Ou3CWNqgzGOiHosz75JackMBsF+N5PbnVRl4CatIfB3Z5UiROpuEJLAeLeMn7PgamSZOyIdgFuV4IJWT6vEjhjXxEq2gWkaY4dJb7O9kqZFwevFBXOg7UjdDx5aY5RFix1zHZP2Zv/0ocnvE3w6AgjpHetVs4Wcc4Is/QR+7lQOwZU9A4TRVUVRUeY9LUgFUpx4lfqXg8hJj2F+8khjK5ytM1+pGnbXx73P6U97+HKd0sD3d/GhxkQW5a2K+P2+qP6/Xs0R+FUQA19E0lLOUQ174DbF8EecO9pltVv3TYcx0O4lAJEYdwFvcvgcNHZA8zO/bup2ma5Wj5F8nfmy9E8osKEKSgKB8Rpt9xi/dwO7P7uFxTdieX25Vj4uIi4MRL0449Ft9xLCHsmNbtXMZ4OXtr5JAghagaZ7F2NzflZE5LTp7JsqloFXu9MhOPys5g0V+/0d8oSCUxhs9cwaYnXAjhyq8qRkUXQwaKLMUljHkv13fzItF2w266m7d1KggKwiNmhIcfM0Lb+9mzZ77mRdPe0LeAzTx6QkzMLKhSFO0Rb+qBiaXU6P97qEQjNcryqKaajNcplUn28coeMtGV0hduLkKphO47mJWz1zI0U2vtpru932kbtOkVKRurenKu5LdYRcr3Kkb62yI4Cd+6jpohK471Ky6RFsdg7lwqldi6Krv1vbW11AGerN3QQVyQUXh58xkRpKC49eBK0d7ajS1B46QkVtp0RpREJYkar/7uaV0II/0bpfCsfoJzscLEB0XpaAeCdCIuZ6Ob2Owb0WefurgX/rlHTU+d+blUYNiUJRRkFSQJhUkFWS/4wsdDhVmbxebLd8Imw+y/sE4M/Ymxm6Y1sVEziNSxjx73+zUe+gduzOZAHZ2kh/pyurxWJSlveo2XEW3nV2LyShsDwCHLfv/lopUXWoky/E1TBeFAW3pgDxsuU9UyFEWZKZJy0g7HQ2ooUtLzAP/KruQpV6rclXiIPISyg/uc2F2Gg+RB+E8OKCNN0kwiw5AMk2hvTfpJM/qxEeEBkQCqjYlGYGNoxgEOhPznYmj/swK7bj6HlSLnzE1YBdbeeQ4pxc51tv4LGRXDrjQzpD6RpEodjCV3NdRCC1TL4/QL0SaXdrQYbeu7geo5P3f3cRzWFrfs032Mr5G6EBBp+tmOViJN5iakAbn6/ioS9Ighv5Bso0mjrtPaaBtFUlUVK61WXxvb+qUuFn7UauMrpcMIPVJ9+aOpEDZ/bEYERpKJZwxWeOD7t3icwhiuUoOc/4rHqkUb1/Ms3j40v+GQ3AK1La7W4hpbTa1K1PBjHwD7bIfEEFtx8T1Rgv/oOEhA/ILDGQBO258TpRMH277jJcS788tFsZ9qrDUe1hImgSGtsP7rjzh81vnrkirJ2LUCr5Dvct4XVaOb1rNZNq/WSNP0E/6mar/zNMcjLP+dlXnIaiALGi3QYqPs0CcrMrD618qqZBgmzkuKtru0I3uR9v52VM/p3/sfp7KAPj6TmerQaI23feX0bjRzjARGLOL253a4PJSIVSfViESPq4QbsTj5AH9UzWiE8gWpadGUSnlXEKUU+wb7ipOgYL3H5dHM6rrVvNGcZEIMTL43nEyogtbWaOe6u3t5AwcF2uvcJihT22ps/Ew10XZ+BZqIHezdD8C+HwfwFOLAjYeYurbIxtho7ekrx6nBVE703CzEdhE7m38Q5fjV9jIxyeta1MupiamR9EpJoqztigcVi7aZzmPF2HlzKxpbW6RiVGyjJpGx2qDRbKRsVn52KMXY5tFaT40WnjWjahSOk5HIuZ/taIWovasUKRaVdVzHjURb8w7MalMPi9HQe6vBaGmzl9ZMm9kWE1NCf2FKsXPmVlEZ1mo+hzlbTNae3j1V7bP2Mks3Ls32spIltNkIeUtNEjO84y/zlN2hzUTBPDf6xI0TUjN19MaRxYibop+qobNdVCGqa2gxX/+sWCt6mB4oOnezRAjxcx8ahVozrRWo1v75NiyOKMW3N78lqiRNB2cipdLy6w/E1Qa6tr5nEN9aaWNsmkqMX6Pf+J0E5wA47XjcL0Y86+wVQsuH9t4xeeGjp8Zzl2qkLgQlajC9w5XEu5vbsfGC+JnWKbEuiyODNFISa/jQKlLhb00NON9i6oZMCV3CeFlNtIJUrqgpZ7+YkTu3fWkVSVJso6mYKabNeQ8eutGKJEpX7AFNNonRVqf+WaPUhlXGRhxW/K02Dj0ssdEaRiOwJugYXa3sosWQ1Pckpq3uI/YT5A+OEuyyQvgRQpfrMM3NsjCNpVmcWXGo65+D7jmTa2kzJWRRVAkFHJ8jcHuyf+wsFVQtcurtFTRFcqj9CqYuRVbc6pUWJ0MyXI/svENbGSsf+6rGSHsvzES60e2dH8RVFiNj9LTCSh0PbH3CgWgX6EASkHP9zcgntPljU3yUnaALhdzbW4Q8ltJEM5VI+892tPtvBlHVwr56ulqt6irkQFcvXoI1fTyAfBIeuN0sKkFandtQktu3y4dbUv2jpq6GN+m9nIixewOzgc6r4Pjs6uXo8YbWN3ix+NU7z3B5lor4cKsUfYzOan4vq3SiRGXmK10mKut4h1cxtLs9ddYWQxr6VtvM/UVfmsWc1+JLZBRyo68NVfu2+tjYVcq6fXraTDP76qtQCYrxbUqdY7R0090M7agMbehsx/ao6G5xkVKpyn7BS5EDHz94/Cwn3jUX4p+wHTffE+V4W2cZ9gkvbG69Chkjw4Y0zVRJTJdWCD+hpV0f8JjaL0bGyDfStFnFmZdT2NbfgVR+rWKq2BRdBMZFoGk+o8mJ6Z6mt4CkObDgx7MojdSJoET7K0Ud0xO/393+RBHtBInt/9AqUuLPX9GYT7WJ0UHdXu6TLQJuGQWNEEJGDFRkpstFZZ3SsNdKWiW493AOvTt9UpybUWlhLLQqq7VtRksWxHIq5Qb/hu5DzkPfvVSjZtEjTeVZo7xVQy4CcHHQOf8NUrFdgVJJtzAt9DK0wdSGV+7tC9L3E0Pa+tqQYqTDpQPhOw9V4NMfnzM0DNQS382mbiI8kErUpSV0kuRQK1kAC1jWP7cI+aaSbyZztyQhMJHoPgV6DlBKXrdux6EkDPUd7ZwrJK7unyGiiK1yN4/Aza4HDJ7IdyHHOjDT28lH7ZvvnSbon5WR6TvYLpYPJezYJV8CKUj5daznxfivmQRnkDqoCwlHY5xjpdBd+gQTUG95zktaeFDnxuE89EH3WSmK4uS5bjsxngu1YoX0hd9IYiikoBVyDs3xlPdXzTyr+uWe/ujKuUflZ3rRPWSBY1an4u5IFFPcz+7cNC4YwUJWbPm47xWKIpyXRebNTruAWqOltb1UL+yFG6roC1XlxvKztXQl/GEKKD/r1SFwCLl5Nh6WgfxNN9cCsOnyDvd9GlcfbsB/21xXum77L4CQpxMteS0bLp7tue7BVgA2/r3ak1HzZFwneobr+m36v5Q+40+NE1y7eILNt3lkrTvYW+R9dq8zpoOeroMX2EMSHqHybl7QXrd9XG7uuO16PUlWiteg0z+WW7MhfNgcPTln2MRwaoUk8HCgsDl8ItV/j7xwPw2Qv91nuP3NBkE6Hbhl+MmrJgYNGEzgaB3CJ9J1QYD9t9sM978Rl1eXt2i2CkbnQe8Eb5gcI3Cf7z0tL1aw0Sdy7U4fhcu9ySf3/P5ix4uNDyph5dCgsNDgLUHBOLZdiIVcfmmj2CYW1GhpaDMCrB/D7sK4+k28tfx1cdtEPxDEVRy4eRm6HzE7E3dyvNguQ51O9qdSqcCl2l7U2nlAJDrQ0SrCWzuA4o9yaT23K9/E5fbld3HFIrGYx7JAI+VnfBYZiqEhTVM07dp9Pbd2/xirX61rTd0YtinfxNZyTIvb2VLOFQ548jmXkhYwJH8jX8buzDdxdM2dd7KT2G2LPrA9ZkKZVWbvBsfo8n1yz7s/QgGIKuAFGEwGqWO09StdKaj48BtISo1PYGuKbWr5XLlWtFIep9VSJbAEmmOxa6ZzuIbY2fRG7AstDM249GZMwP8UKYIihyxly0F7VT61Wb4lHqQlV8LKzb/+JlDlT/V57j01P0bwm29MPNj7uc8+q44qi/KLXII4gcEhG/xDZOgGORoUstFPbmQ9ayqUDBTD3StqeVyMH11LMSvgCrlM3nLrwvLlO1d4lF5H9A4XEjiFA1a75sh9NVy/r2o2dfkMMDA6rHbZGlBCHrG5sMcBvKz3xOzrypQ0pUOF843mUt/WrouaGK7HE13pFWRTC35HMSLc28Hx4flsNsFNDCN9HRzqX97fB5X+dDUOeAWOgw3yqLVh/MD6Z3z+s/phfNlmGf9LfaAyw7XddUs7dQc/6POdqK2keqxMImPtgUrBmZ9tqIrW8tcKRI/ay8SQ17XoA4eOoYleGSTK2x6KjIStebuolNjR9J3AJuDVikS2Dvd2JKOjhFwabp89t9+Tgep9kaLETF/6hJNLmR0EZ8HB7azOnYNhESwDSf4zA2baVvWoxFE2RsXUftd4vXfXhiR6+Ji3jTVwoQi8u5+xkhYsvJefXyJJ9VHgA+Q6rX1Eog+UxKdbDJkAjkV/mXvrcJvpHFo6mOtjF2+IGBUWDkD3E0GdqONSmfDP3IW2aC1wHz+qJfTI1aCjR8y9XZt81MnnzdpVe3W7VP5lcwrtGCxScqLkq45B1R6UFHeH4wX5NY7UExR01YFqGv+83udrhFSaGibqy7HK/oMADT+rJc7hibrYE5JTm4b7sCD1o6SOSSDjgdbBJY4OvTMuj9u+2gX0OTfBXLSXUij1+Kmqr+isM/zLmTfH6k9WOQtG8OTDEyZeIK/95czJ8PwRB53IPOMI+AfcKpni6xpN+vjqFa6+PuJE/buApMR5W5AOJKadFseo4XyDdTN1TJkeuXz16hGfmoRUrUKPe0tqqBrR47YiJE3U0HZV9FnQ0HcD0XNNG3vYNbS2CmnqP7A9wgqrEjig+BOHRLs+NyMJvuddTOi8gFmtPyVGRDrP7kTH/zOnogQluZ+KXDisICL2p5z/QwF4wWmTUNljQwKcAFyWC85sJGvHQ94FtwB7wRynoXBcjaaiao29SA5e57dFnYwzivdzrL7/8ePc5OpAwyACkDLcJ5sE3E1g9SyweQuLDeww5TpeuKQwY3cIYWL1flh6Lz+/cckkFWU+QK7jHh6RPpCSA3lS3WUxGqm8mSS5kV5uLijHr3WUiT56pACdMiYuPAzouGg5/s5UhvdlUNGaqHHg6WA7nzr6jzcMPU/d/DLDnzfFB/zZU+6cS+MMTP3yvP+K5HYMtNhj5i98ygxaMK7RkWRzR5jJmrVF9/H5Ird7VeMtfW0BI1kXU1dVHA17epgk5nsPjMY7usqEe7ADXW2EScMwjKaCMTKGEXteYEasves8YsFXND2WGPFXu3af8C0VdbYcwvTcy1uFrhXD9aP8/JNmrBShxR9MUo8vLjEPTVibevR88bn42J9IW2QVely1qrfh7kAd3OsXKqkIfyA/w8QSvxEO7Kmply7mGZINydNZjqH2SvVxA0ajltLam4zFVDGAp3/SdeSYyImBUaw+3sD6emp8dESgAlg9+j4nSmvpSKBpUwZu167VV32ndXBgQ30ikjOe7GMYOHZbAOh/4DpIwYM0z/W1amx30lk5lBuJ/xqgw85iCQEBGDoLwwMeBGtB3upmGPpHohnvBfKOo8cF5ccJhNkFiw5ZlJ9zjBnFzBbVzn7/C24CQWEhwVuDggnsN5ZLQEjI1uAQEVrIatgPHSFpJaFBv7pwVaF+sr591brVGzrhZNZvF7YVbhv9b06gdVjoxWCvKRXX3CsKp2O1jVvF+LaGRlx6evsYbPq26Zh85jUZXnduGS4ubqxF8wrzUPp0iRhfepbBJY3bxmIzts3Axm67KhOd2r8UF287TWNNI3Ny3a9VTPEK+hjq7va+cHlPjlvhOzf3UHOQV2bFNfcp2Tk5rR++TK/gC6HDfniG8l2vSKV3795sPG2vHuvvJw+UyllRq8TuSRLDCP3Fl75ucz8vKbjttGXJL6MC1GFjNIRmPhiyMWKMxit8pAW4SvdURfBuf4p3zhzP5Vxc9WuDb1ACUiJMXNpov+Pohs64eTJ72dA1/qW7lvX/Of2pweEzeFlEJuJkEHQh4Bt4RUwacFIO0Y8LwIkyV7cVbttOBHATuQEnt7nlCvZ0XcnyAvNrB/D5zfyAzS28t0S0rJl/qHjCBwA0K8d8RI/IhhNveS2bffkv3KIHnJhvnuSlaD4BwJ5DBt8c120nA7gaLtJY6Oq3Hxoog1v1zds3W3Jutdy6bW8ktVArUd7WrS25SsL/0biHzdjNZ17hInaAtzZZgwS1UAcDQ9Llyhj55NDTnP6iMhl2s/u3FE68uyvgA2iKC3QPHG5QMRT0wUZ5OfMpinHQFDMlTAmExRCW0NiVNMS/X6pP5k4Y4i9gxaWnN9AsTWp6g0zzsJKvS/GM4Nk7qGNfJsISv1DJawj3uk7Y3MJWqvnH5Ar/Ro/7DEVtxqqOrRddFAsVSUpUai+PQZMECnEjVvf4JLoWUsb7bqe8RnqdcPuC1nyuARXgOHocZe9Kfk8bXo8pXJtmnCqeHI4XzrNXW++ERYWPlVOQbAmLmjhORspPEafvXJMUmf3LlKwRrDmVdupaHOw8+/YsWLy1u/vL++5eO/hrxqTUSVNZWfVyzwz/jLGpkQqlDPU4wlt6xhkVp40WdSScsc+YBFbZSxQjgoRRaRYQb7ZewgRzg/6Yw+dfujznEBqaKoyaKMmo/Z9VeOcEupPxHypzqNzZ0gYOjyK8nR0Eroazy3Pn7ylE9LxNZ45ACBQVy/rt2Tu8OqxltpmBs5mDkziDyODu3dwWoX2fhFB7VF11cjZUk6rL+m2dcMLLhl7MRsWYMQLSO7nYqK6Tvim9lD0covWftcydqhjUO4tZuqv2GvJXzsFbCy4taP8DLjeLjlNuIYKbpQ+FqkR4oLuBF2g0Ntg8zTjveNWfQGSv8dFhTQhCyFB3gLVOscxkcoDy+uvINpdJp5o3fGSAvL6ieOJmjRTcrTCzdMoaMRBkcLHcIUKbAmxhcWGjCEDnoVZ8bm4jZymYPABiHNoUsLSLKOch57/Ulk8OLjIVOXLHStHlBor9HBhnVaPfEBTrgAQXOx7byq1bWOCQcQ7o9NDP6UneIUwsqUCJ2IQXzz6LUax7wOfgfHtbZit268AM2bECBGBngYLX75Gtl67ABcHYPVZj3tUicSSR0h64gp1vLta0kinuyrRYjM04DRGT9rNanjFaJ6YDyvzk6i4fRiGIRp0OJEpFkim3w6SXWZKTGyePdZ81nJKSMrTzgdADEx29N4yjDO0AF+E/vs3MdFtbCeSx7Fs3rh6IZKPu7lsnjN5hV6AMsEFgIDgMf8YeTDIV8V1AKaoMtyTViIL2lM4Sv2QpssrBminuzgbPvmdbttshd5L3GrWCh227cVQoBWINZ8DIGilgb7MFrFqvImERUrnG2BKgFdfowIrO064kFah5QCErilqFv8D01U9raSuYjHWUZuis4nuA7gOmibVlDGPciBwrPxzWbrNs56CBcsKLUdcha51853tFEA8GCRl+2ohRAYr9s+yvq7ooVml13N6qIAO59+DkWU1phEWhCtLqFFM/O1SExwoVJTur1uADitIwSM87mgxnC3tcSE6llDJ6trOCHUb2HY1HUzn60rT0SU0LqqCOVpV06BA6Cd3VCKMp41FNqqopBL2mUFXDAkjfHk0qevm6pdP0oNCpiZgedJlTeJwl9KlCZEqbGJZOscU48gQDUpIbQllDUeRBgMAB4A3ZEEzCjur60WyRF8Z7iqMFM0MeIIGqb3hwfNL3cvx3djaiRlT23lqr2igbpibTKRHNcYOenWvxF27s3cw3bvBNfcs0nMiAGGEWfbX0jB7qcb47oGbrMSw0qblNTIGDJ+7f5ztRndIJDQ1y9T6pssiV5O6SGhmWa6UVrTqR1WmMdJsFhuqtD1a4kztMFguxsnZ3pU2ElODqWJJSoZ3NJl03TkaxsOt0YuUyDNmsze3a3TY2ZVksdFKB9/u91qVH3uYtXebX4B16w9qarKrIzvqCWcahw2fWyU5n8IfJqafUiRjrNuYQKbkihjIFq2llxYqlNYjIWi8LtRWKp0PI84mk2HybJoD0pyMOO1gsZD3rlQqSejGd8iSDuQ0sqskdMPXRhukmEbVZpl59O5ga6Sb30u+JpMVFhBfb57M1A1aRQgBUcVGLJj0f1lAQbNm6nqakQLq00R3qpNNSJ5LsOTMvoYv2BBtfMefcmrUSo1GS6uaR6BKK39NKjSMpop7VafxtFxj0aHdXZn4bKJx3WFdGVhMX3lu3Ud4RLXyHHoJp02+in6AMVnSsVKsMViezkuFth3gmWMuLxZxFjDg7gp3ZtqFltMBpbXXJQcYTjTgBKgOgcdLQre3sTY++ZycfXeFANMWCgyEJCKM5gPNhrfjm+wRTmMU2MJtiAwPuxWx13di2kwlGjQiCYN5brxW1jlRaVcU4QIuNPq80lMKL0EJXhw/k4dXN1c5RFVpBO2t5tj+8oW8A2+c3modqNzfHvGjEAbeRlIgnPXsRwx8/DltbdwdcCrirl/SYtnzdUcZKiE08qtI4APZGeaUGM+0twMvwhFGDAWud3YyBwzCvuoqOI9+yCa0SxNtwpMtYswMHRukZw2kJmPak2IAdmNxP9PpK5M+5H/eaHOT5Facq/r8/QlNLO4A0QjReK8ps2dkgX9Stdjj23+i2Te42JrQMUWlEnBMTeXpN4wZSeRdexJabwVLhgc3LahS3QoQD9IJZk4VlorEWVWIFUTeztURVQeZSZJb0qMCbSSQ2liWczsBhxXQuEEXAsMisbmMESqQoVv4CaqCZ+lS8ruK04Ao1AagzIG9AK56MrsAZwIgY1DCfvFJk10iXLNr6tcWAnizzjmjoQhRM02jb3wE+B1eUbnqY9Mx+RgGnM6CX4jsPpqpObEOJlODFrHxQXikWlhRYJgoGBhbbpJ46nRm7uLkVYuKRDX2uMpbXLIUMoNQiZUFIOHmgk0c1ANYDo+Fmx0Q3mjJ0CU9rG1jZe2HX6f+9s9cgUFY6LP/hRRzkxeDmKeQA1/G/N0m1zVznf4s35JHVi6Hg1LrLsCn6EGhQlgeG1lUWWh2CNj+mZSeGjqdymOClYHkg1WEKuaApf1Gn2XasF13PMheS4omklQewvtJEkyyjxuPto2EKFxHTAOnCovTJZtfr+6z3y4IJelqSK+zQWXx4mWi/aq4WJO7jIIt+DAr3O9EDYhYMJJbc1vhj1mmppQHwOrIgmaoLsuIzLtD4NKimMSAYWBxQ29YwwwUKhpCaSuZ5mLGCBMynDYGYYolFymsMzJVpvmm5FSEQdANkswTO+UyDKJqTXWiBgWdZnsXgixWfpgrApWYwIp0qu4nmUgFhIciUJQ+r6IoIRAw2kRX4O6nwoYPq/8KwAXgol4AsN5VjDiUNJXD1RFOpiRBTf45FZqbJAC9B5u8sv64/p+cFCgLON4N8xtjhCv8vFUL/txUYfG2+HXd54qmHzrnksmeezxcPpMJ1/f4v6VpZp+hVHFw8fK7cuPPgyYs3H74EhBAojAhOjCAhJSPnx1+AQMMECRYi1HAjjDTKaGHGGGuc8SaYKFyESFGiKSipxIgVR01DK14CHT0SREmUxCBZilRp0k0y2a8yZKq23gbn7fbGRoW2KbNPja1arfOnLyx22GOzf3T6rFy9r7p9U+WAa644aIqpfjPNDVmuuu6WJs1ueivbXbe1OCTHJ7974J77cr1nssV0eWaYZabZjOaYZ675FlhkocXyvVNgqSWWWWG5RpVWWWm1NT4wO+OwI1546SzaI48ddcxJp/zruBP+s9bfNtnvfxdctD0GkJBSIKOIX+30h7/ssleRYiVKVajFqNPgtDslfl0zIGZtYPRoMNEQGhobfrbPb4NhWTtrgAmhwf7EgVyNAOvxdhq9dW2QicYaAA==) format('woff2');font-weight:normal;font-style:normal;font-display:swap;}
+@font-face{font-family:'ChicagoPixel';src:url(data:font/woff2;base64,d09GMgABAAAAAA+IAA4AAAAAUzwAAA8rAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGiYGVgCDIggEEQgKgY9IgYtGC4JsAAE2AiQDhVQEIAWDOQeDQRvTTkUHYtg4AMTv6klUvSRodFgdH9gEaqrQ6vY1oiIhhBCrVvzYDvW7M874pr3mf/b9TP0GnnBS/aYnnFyPIPqu+shq7c4B+ITwRLAMWOc9UoBGMORVIs0luY0H+lPfv5AkPBbGdHVPbkFbszI0w97Aoc/f+zr77rdTKqCxeBp2dI54aFhjAdB0l6E0VvFecQMYQM0SFmmPXR4VEOWBTttUP8aEfx0s7a1pfjhjxllPx4wwFahP37mP0NxK47omfRlEdKw8zgCFBVSnMfTS2F9LXydMe/L9ktYqdmuAZMIcANv33u6+sU6rc1daKffuaVfava+bsfx9bkqvNLx11lhga4B0GhwUBMM8ISQMBMDcjzW+h5l2Kr0Wj5+IE5JNOCJrZu51fCcR8PYq3x/hyT3TILw2cIO/QEf0NlgSwq1CiYRAIOI+4lcV6SzyWZyQvHx8Y2JoJ6kL/CCNkHziCcfjaB6mUsisG8GDCEAR6IGl7Nw4otNLB4pfUleFjvb3dL3b3YMXvOsHf/onVo6f4+SMoS50vRvd6QG85AM/kfhzz5/kh/ND+cH8QL4335Pvynfm2/OGNy/eKvADRU3YNBJvSm9KUVZYhH2q8q5qnvUflGx5QayyQqlSa7Q6vcFoMlusNrvD6XJ7vD5/IBgKR6KxeCKZSmeyuXyhWCpXqrV6o9lqd7q9/mComFA6xDwrqrJu+24Y52lZt2M/7wvgA6A9mbn6FLTDwq5zB5+CndjiBNj25oLvPt0atrvb+Dk73YwN34CNb8GPaf/X5L0+6njM/vgTcNz9cSpgDxh+7BE5A24DYmvSqQw5n2E/QF+MwSlOxyMWOklCEUd+91BJggkZqRBG3FYSFKAIF8GkSoaMrq5CXbAgZA5BhMESN0qXp1VLDLg8qaWO3LmzWkspXbnMpbOx6JubFcozG3XEhaCAOK6kqlVne3TrUKu1aRhr9PdQ1nGizC8Az2BHtzgAH7s3tgpYeCvZpzkXxLcrcIaS33q1yIXWWKfGPm230Yjw2bojj+Ew8Fki5JCq1hJbIrc9vV/sXxf/35FD23wj9kTvz2fPtUfDNfhQprYAe+/MiOEaj8rwLtsM6xe/dTaM4+vOWLOoF+O7sWTSs+KpY8TiIrxfDBt7ICp36V3CC8XN3BWSpRc2UNvDq8NIakFJUYTCqUisIi7+e28eBWeWEew6w2/E00rl6VyxZpWvU9Vl77eG6LV+e1471JvN5l6ZLfw2pZGgRsC3sTFtZZKfub4AZmTDrPb+GhaBoLaBRXefe+T7ip36LG6eu4V1ICK55bJ8U89WnZeLRoJavfumsyE8EVtmETAvqCSh8IF7pkNCt/2Wt3mpFJbwLZSh6UqBJlbGy8VIlTQ6S9ieRbDFyzVqpzCo4cQvAZenjFxMfFjJljgFYG1s6wUHjEqy6agNbHEJ/kV6Ua8iv82j/djRplVW4myJ1JEtr+wMFANRVMv5QmEdXHkie6i4Ig0/5raEktpR5E2yexwqS7Y19RyuHKTJpDG9kBiofEGXMSd8OOUP+q0qIdVxp6KI75kt15axhvKVsAq5cl1yNuBClReu3AFYJ5CIb6rKas2yekUWUU/avdZ1I3gw4ArJMFbeIWvDlQE6Zk2fG8BBJrxyZSiUgIADPGKq5fLcJ0AnEnLxPHeVkU8jJy/FF1Xklr2UDnDjjJHLOLeQVE0+7ca1uaNEH9QUhDhJJqyOjOAJCnkodMiwHluqIcVvAkKMiOjSlXQXuY2ufpJPoJoR4MBC9+CzuFyx0lPxJqWOkCxpMnIv6de8T4bIFmFT0KsGIydKoy45pqfYQs6oojLWaHdxVeqnGEOkBWog5/Yq5ULyF6OAHkFXdKEOmI4Qn4mQkNTbtLhSyBoPNNqApVrxOOjlIuVxoxDIYhlY95N0j9NxeDj2/wp4jjFhP7JnYweIJ0XUhCzuCX5OPrbyhinj0+NxPiwA9xYJwOsYh8hX2FHLoykKoT6s0HuVzHiUkfTGbeHnt4GM53boCbhAuzF2lfTKa/ZmL3D1QePEIcKev6uVjHgkh4heLK9PQOlzYbD2qvQz7PueIky7yTqI7M0w58zj3AP3rLMA74groFeYBegMf4tMVZN2s5wzKqI6mbDhSSenGUAWpNIPhHeGEZI+UDQ6nsYaMeSr3Q9x9qPIKjTGDznhF4mdQ7iVSftf/5uxdBl4hs4yv5sun+3sfVrSIPfkhcDfIYz5uVWrZEEPKB+hTqPYo8kQQhVCmKSnRCAbSoqaGNseWgakzKqKwy2zTzLtQuWlXZq0nFi6QFXldRyJbWy+QsL9nJXzytstxMMY1sjSJT3zalTBEOvVoII0X61EOhOIl6qF2hK5b9YjNC6z1SikPgPPRSKxgfTI5mgNC8hxRqmsCcdTy2JMQI2gmZFeQBZz5GBsfguUUHgXbigZmYHmZClE9CUniPuA62RfTwXtQS3yIEiMzoRLS/RESzcx+fXDwsxYoKS3Qy19m8eKt6CXXipr59nJCJt/8cGmKQfZmeUayMDG6fSpi98nU1QyWczTFyjtLxntJ2ZqfUAfuyz7YcOCuzNY1j6R4wDAvHOdQWJcn4g/n7CQkqTlVJc96wU9ICKTJi33E6Xk0zyNPeCPz7Iuu0XG+iT1hiBtSyygnurP5Kr/7YfYU76V5Nbfqbx+oc83nf/5deXzViuEas1duhlulp5lNZwWg3BQ8MMtLq9ZkXEyZ5stKM+xRCXhS5UlfWO4Lu8cYMO2Rd7AfHNyih+Ix02wCddaR9AKKG0Gj5RnalWv49eBOmJqFv+TP5EHuUrfA86QoEivRfRREuu7pUnF41KitLJ+0LOo2/qHd2sVewARHvQMunKP6DKKjQQymJYSphmcba834MVEROw0Me9N2axDVB6R6hS9AQa21cEV7Z6yWFuMyPtcIl9VJZlniDK5xOlfgkcy6fdJPfEpbrMWktytYU8RTnaVo1Mbzqt3dV5yvgml1rM5NsVt1hr08ChceQqepVcJfi0DZEwals9Zp8FZJGBFdt30fAA8MkztAJf9C1jbSXS0KevC5EMHn0DYDN+JCCIpXdRqzcaZFrel6l2fLOqFE7aVNSCBC7HigyYRFUEUTv9Zwrs1h5QDZaN1Gv+djveGbNZusFVsqHm3FrGjD7udNWUDhzOFEZRlS7ATKdNglSvL+3c7LYud0Wzu5mmTF/FrTjpjA3bESJTRm6MlPr749vjbzZPrj9dPzY/Fap9FZ05t7qVJB9Doo0TKbGGmOtMRKdv2SBQkW4AfVmlNPjBWWQmY64Rwq2sTH0ZLuqCLuakOz6/KxHJ6ak2MtAduQkIKKwQPTN+bZpVdiOlh0Q5gO7PdSuzRMYiNJ7NibFYiNFuSBL+6rU4TQ28UpdA/o40L9ANtZbAR0yodNsqeiZr2DIZddncO7jDcytMgMKNMQYqWm3ryMa3oMqlffA250tDY2Q0pMnqw7YPbr7PCoF5qmWNK29dtdrDP7VvdICpPokfJna+THCDJ0MZc8T5gG5n21+HtsMlLLtPeKlnsO7b5G9QyMFK7I5hDNKctqH6SO2jCjKTrwclpr2l/UJxgjGzn5JYZdGzuLQB2o+4SKPRMmOjKykhTbHSMBnk4uc8vtP2juHUg+w3MFGiCjF25KU9dZ0KNA7JvToosjYfUzppXK6JkzdUJBl5/EHeT3yofy2gEHHvmzjsfRuaLLD9FdGO6PxkhCiE/ZE16nSefU6DZVxZX7z8rx7nYoes6mu6DCTUp5WeGQaO20YzL9LeJZmK1nJHLJ+ALlNElJ1Vsf20wT4YpzVZQxl8ZthsUYOalp7S7CPBs/Vk6daSqZFKqh+RgvbNXU3qktMNwQq8B+RAaBwekiLpLKTsbjmr2Fw5kv8nb16ijeXlMICDB/klYzaUXrdsq6I/Mvkk5ImRMB3IO7oLjldX5IbVSpAba93Vjox4N8fE6ZqmTkMoCEGlgqhTbjSbkrLcHLGeZ95gZ7+yNO2WrP+agTptq95r0nuY8t6w12cJv0GNV4pGUrhZkInKMEqA+t121/SsyvHlY4rq6L7TfxtuCMrFJYmO7AXihxWYjLBXyBXeCB3I729MHym8IUgurgvnGjnkJ0y+LgHQ6sahsKQGGad82iPIx75OZhF6ZwQuKmBwUWYEYVKBntWwPTNB4iiqclGXWYbyxClk6xoOeoVifqlzGyI621UCX0E3HmAaMRlCnQJeVXm1p2Ru/+0VxnfZoJehl2m3RamjslPkLsU+FbW7Ds/MDAExWkzERG5GZ9IGYwkGbfhmjh2MpObVzsJmdlHZfcwjzgWvlQWC0Z4PUyoDnCKzLsb99t/bD4P3TGj9eZZtX+x48u/xvnbh5+Ts/+5MdXsfIj4IVnI1UOOU8/h+r8UcOIODTa2X58Ojy3+17J/5eoL8IxsdeALc5AAhYjHl7AuDYBPyj/o4rLgDiDcIQQBQcBbHVojxjSfgabg9icASWjHki9ArUwq2CSSQJeKEarImUL+DGX9AVKcouu4ag89h0DI1U5LWLMiFElQG8z9izLYMlyzIBkR7CFvWS0+saR5kJvt1se+mCmrTKMYyB7jIWekNIOys5id2SEw3c9Dd/eYXqUfnu5umkge10dj1zJS298yzCqXsltRX3KvRyyF6llhv2qnTx9nm1VpC+S5Tt6ImxCIftlXS0YK/CCPW9Sj2dtVdlsLs/dK2nry1hK9vazC4W2MEOdrUlS8yWw+jfuVzvU15oS1tZxkZ2tpkl7GACC6eztP0Qr4HlbGZTW9nNdvxPo/I1nTsDDt3RaQMz3Wz1D7azXWxlB9sbapxxxhvDcNH+xtVLDJVRZwhNG12UsDnmg03UuO3vTVR/geL/INq0a+mgo04666Krbrrroadeeuujr376G2CgQQYbYqhhOHgCkURGQUlFTUNLR89gvAkmmmSyKaaaZroZ3Dy8fPwCghZYaJHFLG4JS1rK0paxrOUsbwUrWsnKVrGq1axuDWtay9rW0dHV0zcwDMklONRhuA+n+9LhjncMzsNVuNTRDsEpRBGl44jKkd6P2vmudrHr8JQnXG9jmzjRpp6xmSc97QXPes7zNveKF73kBmzhRyfhda96zZaOwta2so3tbGt7F9rBTna0s13sZle728Oe9raXfUyM/V2EA90YTbQ1u61nBkPQIG4UMoXm0LrQSf9jrbzgPLPBYAAAAA==) format('woff2');font-weight:normal;font-style:normal;font-display:swap;}
+@font-face{font-family:'Geneva';src:url(data:font/woff2;base64,d09GMgABAAAAAAvoAA4AAAAAM6gAAAuPAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGiYGVgCDNggEEQgK0wjKGQuCDAABNgIkA4QUBCAFg2kHgkkbMi1FRa2cnCqR/H9YboqILj+A2kIJjjCjQKIRYjOzUnF0V7yBcBDywCYPz3D68G/z919Jx34hVkLEFcJ0Z/qb+3h4fn/UuW+ENTIY9dNSadpazmYSEhiafP7v3f1b926sIZoGOsk6Wfws8TzrA4XxgyDm9gsFOmnHdW9LYybYENfSIDSuKxQ1mXsDmFte+EoLJP+dRLTT+MKrfz22jq3LR714l2Pp0DW/Grzy4iv3M5hotMFaOA3W/wDjAhtIxAW+NpFl2yyL8TiOMkaR8QwRkP+/ZbWH65q5vpwUqSErTphdNAqLwyHU9lT/X2+nOjx6iRdy/vO79qqmenm9l7I85BlDzi4JxUNosFiEtBxj7v8XjtebvIELCU8kvIhONP5af0oEvA0eBx7cmhPgRWRZFihFTSFWCEuFXCQEAhHtmD8P0q49ARvE946faBsiSX4O/qwCIflWbaaeJsjEVgTnP1Qk0kLYXZDDsvqt4qKO4tfmbUVtMk6h+d6uu89rPvFV+OT2de5BGxp7Ou+udOFn4f1fcfrD/88R++zUQsvPb0eA6vjkCZZOtLfMZEcnZ9OnW3YGIp/wSiIhOS3Iyc3LL4izGHEx9fqL6IZp2Y7r+UEYxQAinKRZXpRV3bRdP4yzvaJqumFatuN6fjaXLxSDUrlSrdUbzVa70+31YeZs+IvMW8AfPnHoeM5p7nbJYTT3OewxYgpgLOa7DtkA46YzgIWL4EsXW+IFTHNq03SK+I+1ln1uFBNvoXJXUGUFYF20wEmD++tzByRpbFkLu20ANOlDGx2sGOx1MYZ78Qh50qWO1NZNQTfZqaABOnsR7TzZ5jRG0SH00EnsQd0WQCXrEOkwIS3SjyK2XyoKf8KLgWkY0FBY3rAbUnUVoJB1tz7wgTuCvPAPgqQ5anERHyQfYoJBwIeg1h6gi5jtqwhNZM/J0tdxLkk4xQLFFLnfiKLA5EAiYPhYNqesD9BFfyGEat3vSuC9vqUkDvsD5/uca7xXP/Hhbfzw8JaovMy0I+YTCAN3/SHIMlaHWHHD9mmf0H3CaRbnthJ9dM5m4jiUXXS58oR7isn4iA2YZWgcA/lWTidyIX0Ie8EIXKy7HB2utuH7oG3tMATZaz1MA5X2DnmZluvzELD7N8fv8iUdY3aAyyvAur9BJiM26Fb6oZye5NS3ulJ6Yn1cofjVsSSdj3GfPprITJIIwJkITYSV0jS+T5NpdPKM3mXxQ1Atk8VBKQjQa0VjY+NqOTCypNodNVE5RpjlZSo8qE2WQpPwku4PLCPyBzR5dGRLdXnk0ApIrM8TuKDf8PpmXu/srtjOwoZbpATRDj7poV66QBMDErDzjGYSFZCtjJQZkCsjCIAKtlMBFTFTNthPW9OlkJTgozfAiXQ3A+fOeruzSZjaZxvRwjddWvgifa7TpM5UCYeA+5qU2tsQuNVNYGLuxWxHKaRJwkPmChWrU/IAU4iIL+0IukWSvvcVYOYJGeYIj9wim7XCRCopO4mBs0HwHfWE2dw5ux82RUchn/JeS3sExGcFDBEJde9q/LU8VpjXFkgFggzZxGLoV/rSS7hwF0Ll2FRyOq9Q9ht2G5Yxn9MyjtfQmtwiNOi4MKLmoVakvSzpRmAoABhAXmBqDXA5SB4G2yi9IMfAuXdEnjoY12QpA6JXIFB4jU2TE7KwJRyBFegUSIfnL5CoThZ8eIeICnVznmVlNXuofisQQIIJD6oQUp7jI8vVWsKpqZ4VacZQ/5Am21gJwCr6JBVFGxDtpZ5vWoV+T+oJ5ZnNg0Yb182CKtCw2CM4AwZPvEOXMCKwC0iA2tN+C7FO6CONAnhntVVfhtGMPvUxqiR54EPA9JAWWDVK34Vgvry5IuYj4HNVIzQ+94SXj0k/QSnPoH/WigUzoE+NbDeH3gebqWmFPqGoCh5XlOYdMfuGptdpL5JjRu7oUU2GcVqzEryey06qQre2XqhaUGweIqIcbO6ZHS5vBeYVM0UllfZMbntIwB8rI2UhoPIBMJZ0WoK7I2WkRKOKsXgRkWCg1iMMqLtIZCaxIakKpnRIJhwI9shnydURNarfIXhgp/SRDMpooKhA43oqhRJP2qR8PRGPa+JoNAjFXC22S6EWIJkbCm5T8ryhkp2qAfBUHDVFCD4+5zHCx2uMN/nljPKbIscIc29tQZOAJC6qtAVyyzTY+qQ+CRS4TYOm84AiylAkC2x1K7sFUdfaGprZK2p597K2o3lWRCVfriAyblI/LuEXNxJ4awS5TCpJgpe2UAtrYQZBpIKJRnXhBQomFbDDEEBG0lWjNFKi0aChSBNuxF36Li3IBWLCF8zNhT06E+AqqYxrQnBkKaWMJFjFoYd9aNxVSTf9Iqj6Jom+Tz5qC+fyO1nhVExvX3oT0Nn2dn3IZoqQMBUoGfTSujavrdINQvAmNilXRkbasiharMFX0afliIrHLwHIVwHOijjoqb9HG5HJL3kvXoMZGV+KNVPPSyGBR+NRxrxhj9kibdFe3xWmI0xhC6mumQhOIMi3y2oj7Ir2Vu4MVgeRcjL6cuKMgxBbb9GaxS4kXT3w4fozm2scUm3cJC8ytdylV3s89S47WgaavOZFcb73Z0hV+sx485Tbd0Hl2446BOp5q0bw0+E4OAfO+Wr1LpNxUlxIDamQ69HMN+/FSaP6vuHUqP54QMaAo5IOXD+dDGE8GV0CwIjjGcjdv95eqmCi/hRohQG/PDAlE/pcIvjFQuhSmTHspaqne5HsGR4tVAyJd07nCAHPOai5P3GRosHu1dyZe41FHgW6RoXMgPAu4BxDNz6X2fB5s8Le1A2+D8WciTDh1OP6cu7IokLlx6a19tlsxdm0gbT2be8XjyOLSkam2c7OsuPpm5qxeKKDDD4Xr2wHFxdPw4sT/A2U6zCh/iB6nG388sMuah6WGZMpU6c5vMe2xG+bIjZYPJwtZFgWramugtzg9uPSIuq2yDhJLBi6QjEOwHma+rlgaEmTEv6yZ5PRpnxXLTRoh/+G8O3GQHry3qXPY7uNuN/SKl8kaU8aGEbG6YnMYGjiv4baNL8iKP06t0LIXb9byBjL4HQcq5F0DOUXrq6JWl2kXABaybfinDsePFB52rwXuCMKp4R+YgEW0OxlUBqNSIWnw6V3blEuTjkMGDpTWOFRVR4/v7SmmCfD7KUZ3mWBz17pTYLFTf6AVE+W+FuXil+o8pGXD2JsMFu9+2hVdjYgee7e0eiEpqlQSsev9Lz3DW+F2WmZ0MH/NLpVnTph/rmOXz6PLP+gS6Fl+6eU63fqIea9r07h0lBXK6clDPV4Kz/+PLSZfyODYGyn7eEnvPrLXD9/9+Uc3Umno1ACoe0fW1hFLv4fJAL+S5bFdKJADILIwEICsfAwJWUFGZU33dCzs/Y6C9+HWCvLqYYEaYrTSzOmzNIdMsN3qmpn9qMtxY326u9KR2QIXWmHcmJDlokOvBGS4hVSOnmCnnDjYlOGvX3DvJW1U+zyzMeo9m3c4EFgmf5C6C/bH8nEYE6588IuitWsR6FcpyjJVxHlqOMe5Sr3PMpTyb9Pz1cezcCJ3CJUh09RqC+JklK9oxxtHKNc9b2iPA19f3K++qHpYm5l7EixtXUyQ5dRq/Hx7zE+8OGdzW2MjB0cucZFtnvq8lfxlo8Px7/QFz9/EvQyNjJ3tsZ/x/QzTm0Jmkyij7QfTZuywZ0fN7e1Ierp6euIq3rw20NbEcIA8dEcYSThL/v/1Va+7PcB8M8C/gcqVKRYiVJlylVSmUKl0RlMFpvD5fEFQpFYIpXJFSqqauoamlraOrp6+gaGRsYmpmbmFpZW1ja2djIUKo3OYLLYHC6PLysnr6AoUFJWUVVT19DU0tbR1dMP1hFLLXPVdt9Ybr019jnlqNWW2GJd5FjpNqcdNsTDUE+rjPcywd8llyM38gqm/c8TaOqx5fMx869AOw3r0wgh) format('woff2');font-weight:normal;font-style:normal;font-display:swap;}
+@font-face{font-family:'Monaco';src:url(data:font/woff2;base64,d09GMgABAAAAAAloAA0AAAAAI0QAAAkOAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGhgGYACCXhEICqwEn20LgUoAATYCJAODDgQgBY0WB4F4G3wbRUdzjwOZbDrB/3UCN4ZIfaivUnAoimLBgoXaRCNqPGpsHMqazN+mD/bauxcsH1gRavT89pRJ25cx/73oFRAnOMTRlvZ9HkH9Wvg9b/eIQoQbdEDk4lJRqVMhhUJFxXH5kwH6XxIKRwD998ejmx8HJZO7MwFL6iV8B7Ba0Iq8MyX8jBfsZsOCwuC8K5R70EHk8pDzTX6/7Xb7NsEytXzsId4ioRT0YCiVacHviahg4JydnlEnTAEHDljt/4VKsqxNgZKh1z94bqi/wCoe1Xr1+r9pzWYotY+DLhTOgLC782fy3+6/Sa7t9dDaHmrvVP8JZTZ33UGXWBy+FdmqETi6qkaBUB6hNJtMs5hk/wCM3hgjjCIE6KjbTb5jPhECvvj6+R/e//r9z97yAU10ZUJ+nRSr4q4Xecpr/2/WPrHUO1oIV/YhFP7B27++fYqgwqRJVO6GRB8BUaAwiYwMGcaRwWGZwDiadSRVVQnTfZPwL0ySTAL/7t/9AwFynHYGnHWOKBOASEgAgCDLS+VKVa3eaLbanbeN/gdJ/715fhBGcZJmeVFWddN2/TBO87Ju+3Fe9/OuRc3hEGFCGRdSaeO4nh+EUZykWV6UoLDDmnNVDSIF4/8VYOz5h79CbKZ8hMpBmPtXo0RAonqdJSAyKIluS+gNlBVpYGHUlam3iQedCwgaRPA2MAB2wlZlyyBSY2msEgHbwH60jBGTKvkonh7PzQYrlG2ryVl99nXV4/jITH7jBONacw5y0+SWXRv/qeluIrh9b8KZjUOIJQPXit5lR5i8vbbHJj4N8x4M/QR0OD7nnzlqmlC4vEVSvvsvfSwiBUJOXGnLiBCo5t6hBmGmhkzlkzzSbmH0DV24nKc7fAMh48tgI0SnnLvQiDI0kfIYZA1dM8QA220UCEA/Ucbg2gMDDQOIUBsZpNG0v0VYeIzObe6Tb5DCRXSIxDkvI0nAJhmcFzDnTFS8eJdz5IB0dcYRuBBUVBDmUZKZH5IZhDtDWxyWIAtRSnE5Q9GbtMAZB+qXaxD4eikHmzLEqdwEl/uRxwVVIOMsNL4Yc3sW2d5URHUwCgjSrHPXOPgadEN7yA4FYp6pJUHyTI5vioKSgcWLDRsTRn5UrEeBk1JJIqaALYmY4mqQCZAmQpoARdikDXTVlMBxemx2lKTj3uAXVMLA+KEoyfcSsTthHQIKRE4/xllXDM0gpQUhBuJc7EFaoxkSDFDfGU5HHFUTLn7m+we2tglTBvFwHSMvTGoaLXHWsYzKOCWm7BgjlWkMFMdogcSrpdQwWPAR1wIjJSHkhoPC2vz/jirbqcnsMoWXaDeS1bCrelpbKHSOitk/EhRada71HDVHUQWMiWokRlSQ2a+OmTv5zu57RPALCBbAgUi8lvZiZzdlhpkA2iHtE9Aj5v8DcwE5HtYaaqEC8HRjE4ztvTVqBhbQjSqoLQUb/LUfHT6tMXsCqBxhzLLe6fEE6u1m00gG4rjponvt3CrIBUsOjvsrAfz2pov9Me0vHtQNS2/tPebmBkH28SfvJBdV8mwqWJiMumGAi7dA1GSBSla8V5ymmJZlGWsL7aJtExbMouswW2xadlhU+/XuQbeDp5binIsBtHWp1YLNNsbhVDMgQFpnhcHoDoNb5mxppghGmEQrCXK2FzNgvxr7smivHqEWWZUv/5riV78TwOmnThAiM13A6sUFQHlMC9tcKpPPITsw0tRw5jT18AohhJrImsK5IBIehbzsdz+JPrFgehe2RgODaMYfyHHAsnBHFj0GpA/TYbW319o7IftFSOSmUhEyJSiOd3hEAi3pwe6ObbqN1WAdiHuB9MPWGsRoG1Bgry4JmaJFf91NAOqLu5VJmhV4oigoUBQRkFAaKJh17st7aK+94egWPtU4xOk3+8veyAwPe0DFgZwecPQTZyGVeB4FYZMHashfWqHTX09RSlxCpsIzHN95yFkxyZhqkIZQO1BJxkWJcxkmic+AZcm1lU6hIsrf/Pcvth/fX9f9Op77ss8fgv/zaIKqBILk/0Dq47+Bogdm9znyhPmxQLJF3yuEWoNsakAIwsAY1wD6WcB/vPFONtvZ+hDDDeyB4LBdkRh2UuFJuYS+O6Cld9/+PG86IFFYb1Lc8CAaYwUkQ9kpmVRclZmeRzLX9rksafhTlpVjqKxYFw9l1fD4V9Y00lxZNzPdlA0j07eyaVF2RLbMyr6SbQvycw8fanb+iyeR17CMNzI07ZFJ20WZmeK6zI3zUpaM8L0sa0ZJVlx7GCOr5sRnsmZEGirrdj6ulA0L0hPZdPrxd9my++mObDv+XHp3Q+19vu/jM+kNPiZGoeTQhdAyNLpqjqSya8VCkRi+bFu8iNboX+aoNj9KgR16Xdtcf73PlU6oHthLKzwwowl+Nn0zsL3V9Zw/zuRB0eBdedtr3N/P8Ck4onK/VMbQjUP21fEgbWKZ1l0p4gvhDvi5Iz+k3h9QXG1YJD6UCjdaS+D7a9S7o4M/Z0SiUuwmOsNqYNCvdYP7eqFBRy3pxHy/sRSvu1ffU7f/8Hdmw7OV/fDF90c7tvIEXOY4g5VA4D4U194M+XyjFu6BqnsTZOOqbYT+YBm4mPKrgWPwz197cJT+iV7EWHWUHoyGc+WMfe4SR7fNjB9y45+pqX/+tZe9xiV1xpJeJddnCyMez1Rt6iijNkrgcIrESvTCCYysIPbv8hKYyyRSiUxirIcNPGv/8+eHBPMsSZMM2GKi1UHPSaDtQGzbZ5HW3COZUfYfiTojgaJ8c82jqAO8ctNsLPb+ubdw3zu/3oqJFSVNDahcHTr6epNC0KNQyklakutLHx5LCCTrLQwe/G2kCjUouG9m7ldlLreXH8+KIPHDANguA8nUVKTRY7EVa0bnKP3SBmX6am9RpV9yUeuzGMe+j2k3eD3sLmmK/x8CvkHh7/jVQ/mZLKu+cWw/fIk3pb4BCXBRotD9/GyIFJls2/o9U1XX0NTS1tGlM5gsNocLgBCMoBhO8PgCoUgskcrkCqVKrUm0ajl9IJPZYrXZHU6X2+O1yWZbbLWNCoRgBMVwgqRohsPl8QVCkVgilckVSpXP7/GWx+2+JquatwEAAAA=) format('woff2');font-weight:normal;font-style:normal;font-display:swap;}
+
+      :root {
+        --chicago: "Chicago", "ChicagoFLF", Geneva, Tahoma, sans-serif;
+        --geneva: Verdana, "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --mono: ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono",
+          monospace;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: auto;
+      }
+      /* Pixel chrome stays crisp; body prose is smooth + legible. */
+      .menubar,
+      .titlebar,
+      .win .eyebrow,
+      .btn,
+      h1,
+      h2,
+      h3 {
+        -webkit-font-smoothing: none;
+        font-smooth: never;
+      }
+      body {
+        font-family: var(--geneva);
+        font-size: 14.5px;
+        line-height: 1.6;
+        color: #000;
+        /* light classic stipple desktop */
+        background-color: #cfcfcf;
+        background-image: radial-gradient(#000 0.5px, transparent 0.6px);
+        background-size: 3px 3px;
+        min-height: 100vh;
+        padding-bottom: 60px;
+      }
+      a {
+        color: #000;
+        text-decoration: underline;
+      }
+      b {
+        font-weight: 400;
+      }
+
+      /* ---------- menu bar ---------- */
+      .menubar {
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        background: #fff;
+        border-bottom: 2px solid #000;
+        height: 34px;
+        display: flex;
+        align-items: stretch;
+        gap: 0;
+        padding: 0 13px;
+        font-family: var(--chicago);
+        font-size: 22px;
+      }
+      .menubar .apple {
+        display: flex;
+        align-items: center;
+        padding: 0 15px;
+      }
+      .menubar .apple svg {
+        width: 23px;
+        height: 23px;
+      }
+      .menubar .m {
+        display: flex;
+        align-items: center;
+        padding: 0 17px;
+        cursor: default;
+        user-select: none;
+      }
+      .menubar .apple,
+      .menubar .m {
+        margin: 1px 0;
+      }
+      .menubar .apple:hover,
+      .menubar .m:hover {
+        background: #000;
+        color: #fff;
+      }
+      .menubar .apple:hover svg {
+        color: #fff;
+      }
+      .menubar .clock {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        padding: 0 12px;
+        font-family: var(--chicago);
+        font-size: 22px;
+      }
+      @media (max-width: 560px) {
+        .menubar .m.opt {
+          display: none;
+        }
+      }
+
+      /* ---------- desktop icons ---------- */
+      .deskicons {
+        position: absolute;
+        top: 52px;
+        right: 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        align-items: center;
+        z-index: 1;
+        zoom: 1.6;
+      }
+      @media (max-width: 900px) {
+        .deskicons {
+          display: none;
+        }
+      }
+      .icon {
+        width: 74px;
+        text-align: center;
+        font-family: var(--geneva);
+        font-size: 11px;
+        color: #000;
+      }
+      .icon svg {
+        display: block;
+        margin: 0 auto 4px;
+      }
+      .icon .lbl {
+        background: #fff;
+        display: inline-block;
+        padding: 0 3px;
+        border: 1px solid #000;
+      }
+
+      /* ---------- windows ---------- */
+      .screen {
+        max-width: 640px;
+        margin: 0 auto;
+        padding: 34px 14px 0;
+        position: relative;
+        z-index: 2;
+        /* scale the whole desktop up ~1.6x, uniformly */
+        zoom: 1.6;
+      }
+      .win {
+        background: #fff;
+        border: 2px solid #000;
+        margin-bottom: 30px;
+        /* era-accurate thin hard shadow */
+        box-shadow: 1px 1px 0 #000, 2px 2px 0 #000;
+      }
+      .titlebar {
+        height: 20px;
+        border-bottom: 2px solid #000;
+        display: flex;
+        align-items: center;
+        position: relative;
+        background: #fff;
+        cursor: default;
+        user-select: none;
+      }
+      .win.active .titlebar {
+        /* racing stripes */
+        background: repeating-linear-gradient(
+          to bottom,
+          #000 0 1px,
+          #fff 1px 3px
+        );
+      }
+      .titlebar .box {
+        width: 11px;
+        height: 11px;
+        background: #fff;
+        border: 2px solid #000;
+        margin-left: 7px;
+        flex: 0 0 auto;
+        visibility: hidden;
+      }
+      .win.active .titlebar .box {
+        visibility: visible;
+      }
+      .titlebar .zoom {
+        margin-left: auto;
+        margin-right: 7px;
+      }
+      .titlebar .name {
+        position: absolute;
+        left: 50%;
+        transform: translateX(-50%);
+        background: #fff;
+        padding: 0 10px;
+        font-family: var(--chicago);
+        font-size: 14px;
+        white-space: nowrap;
+        max-width: 68%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: rgba(0, 0, 0, 0.42);
+      }
+      .win.active .titlebar .name {
+        color: #000;
+      }
+
+      /* window body + scrollbar furniture */
+      .win-main {
+        display: flex;
+        align-items: stretch;
+        overflow: hidden;
+        transition: max-height 180ms steps(6, end);
+      }
+      .win-body {
+        flex: 1 1 auto;
+        min-width: 0;
+        padding: 20px 22px 22px;
+      }
+      .win-body p {
+        margin: 0 0 12px;
+        max-width: 62ch;
+      }
+      .win-body p:last-child {
+        margin-bottom: 0;
+      }
+      .sb {
+        flex: 0 0 15px;
+        width: 15px;
+        border-left: 2px solid #000;
+        display: flex;
+        flex-direction: column;
+      }
+      .sb .ar {
+        height: 15px;
+        flex: 0 0 15px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 8px;
+        line-height: 1;
+        background: #fff;
+      }
+      .sb .up {
+        border-bottom: 2px solid #000;
+      }
+      .sb .dn {
+        border-top: 2px solid #000;
+      }
+      .sb .track {
+        flex: 1 1 auto;
+        position: relative;
+        background-color: #fff;
+        background-image: linear-gradient(
+            45deg,
+            #000 25%,
+            transparent 25%,
+            transparent 75%,
+            #000 75%,
+            #000
+          ),
+          linear-gradient(
+            45deg,
+            #000 25%,
+            transparent 25%,
+            transparent 75%,
+            #000 75%,
+            #000
+          );
+        background-size: 2px 2px;
+        background-position: 0 0, 1px 1px;
+      }
+      .sb .thumb {
+        position: absolute;
+        left: 1px;
+        right: 1px;
+        top: 8px;
+        height: 40px;
+        background: #fff;
+        border: 2px solid #000;
+      }
+      .win-foot {
+        height: 15px;
+        border-top: 2px solid #000;
+        display: flex;
+        align-items: stretch;
+      }
+      .win-foot .htrack {
+        flex: 1 1 auto;
+        background-color: #fff;
+        background-image: linear-gradient(
+            45deg,
+            #000 25%,
+            transparent 25%,
+            transparent 75%,
+            #000 75%,
+            #000
+          ),
+          linear-gradient(
+            45deg,
+            #000 25%,
+            transparent 25%,
+            transparent 75%,
+            #000 75%,
+            #000
+          );
+        background-size: 2px 2px;
+        background-position: 0 0, 1px 1px;
+        position: relative;
+      }
+      .win-foot .hthumb {
+        position: absolute;
+        top: 1px;
+        bottom: 1px;
+        left: 6px;
+        width: 46px;
+        background: #fff;
+        border: 2px solid #000;
+      }
+      .win-foot .grow {
+        flex: 0 0 15px;
+        width: 15px;
+        border-left: 2px solid #000;
+        background: #fff;
+      }
+      .win.rolled .win-main,
+      .win.rolled .win-foot {
+        display: none;
+      }
+      @media (max-width: 560px) {
+        .sb,
+        .win-foot {
+          display: none;
+        }
+      }
+
+      h1,
+      h2,
+      h3 {
+        font-family: var(--chicago);
+        font-weight: 400;
+        letter-spacing: 0;
+      }
+
+      /* ---------- hero ---------- */
+      .eyebrow {
+        font-family: var(--chicago);
+        font-size: 12px;
+        display: inline-block;
+        border: 2px solid #000;
+        padding: 2px 8px;
+        margin-bottom: 18px;
+      }
+      h1 {
+        font-size: clamp(24px, 5.4vw, 38px);
+        line-height: 1.1;
+        margin: 0 0 16px;
+      }
+      .rotator-end {
+        white-space: nowrap;
+      }
+      .rotator {
+        display: inline-block;
+        border-bottom: 4px solid #000;
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+      }
+      .caret {
+        display: inline-block;
+        width: 0.5ch;
+        margin-left: 1px;
+        background: #000;
+        color: transparent;
+        animation: blink 1s steps(1, end) infinite;
+        vertical-align: baseline;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .rotator {
+          transition: none;
+        }
+        .caret {
+          animation: none;
+        }
+      }
+      .lede {
+        font-size: 14px;
+      }
+      .actions {
+        margin-top: 20px;
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      .btn {
+        font-family: var(--chicago);
+        font-size: 14px;
+        background: #fff;
+        color: #000;
+        border: 2px solid #000;
+        border-radius: 10px;
+        padding: 5px 18px;
+        text-decoration: none;
+        cursor: default;
+        display: inline-block;
+      }
+      .btn:active {
+        background: #000;
+        color: #fff;
+      }
+      .btn.default {
+        box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000;
+        margin: 2px;
+      }
+
+      /* ---------- generic list rows ---------- */
+      .rows {
+        margin: 6px 0 4px;
+        border-top: 2px solid #000;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 200px 1fr;
+        gap: 16px;
+        padding: 12px 0;
+        border-bottom: 1px dotted #000;
+      }
+      @media (max-width: 560px) {
+        .row {
+          grid-template-columns: 1fr;
+          gap: 4px;
+        }
+      }
+      .row .k {
+        font-family: var(--chicago);
+        font-size: 14px;
+      }
+      .row .k .t {
+        display: block;
+        font-family: var(--mono);
+        font-size: 12px;
+        margin-top: 4px;
+        color: #000;
+      }
+      .row .v {
+        font-size: 13px;
+      }
+
+      ul.list {
+        list-style: none;
+        margin: 10px 0 0;
+        display: grid;
+        gap: 8px;
+      }
+      ul.list li {
+        position: relative;
+        padding-left: 24px;
+        font-size: 13px;
+      }
+      ul.list li::before {
+        content: "";
+        position: absolute;
+        left: 2px;
+        top: 3px;
+        width: 11px;
+        height: 11px;
+        border: 2px solid #000;
+        background: #fff;
+      }
+      ul.list.checked li::after {
+        content: "✔";
+        position: absolute;
+        left: 3px;
+        top: -1px;
+        font-size: 13px;
+        font-family: var(--chicago);
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        background: #fff;
+        border: 1px solid #000;
+        padding: 0 4px;
+      }
+
+      /* ---------- terminal / code ---------- */
+      pre {
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.55;
+        background: #fff;
+        border: 2px solid #000;
+        padding: 12px 14px;
+        margin: 14px 0;
+        overflow-x: auto;
+        white-space: pre;
+      }
+      pre .c {
+        color: #000;
+        opacity: 0.5;
+      }
+      details {
+        border: 2px solid #000;
+        padding: 8px 12px;
+        margin-top: 14px;
+      }
+      summary {
+        font-family: var(--chicago);
+        font-size: 13px;
+        cursor: default;
+      }
+
+      /* progress bar */
+      .prog {
+        margin: 16px 0 4px;
+      }
+      .prog .lab {
+        font-family: var(--chicago);
+        font-size: 13px;
+        margin-bottom: 6px;
+      }
+      .prog .track {
+        height: 16px;
+        border: 2px solid #000;
+        background: #fff;
+      }
+      .prog .fill {
+        height: 100%;
+        width: 78%;
+        background-color: #fff;
+        background-image: linear-gradient(
+            45deg,
+            #000 25%,
+            transparent 25%,
+            transparent 75%,
+            #000 75%,
+            #000
+          ),
+          linear-gradient(
+            45deg,
+            #000 25%,
+            transparent 25%,
+            transparent 75%,
+            #000 75%,
+            #000
+          );
+        background-size: 2px 2px;
+        background-position: 0 0, 1px 1px;
+        border-right: 2px solid #000;
+      }
+
+      /* ---------- diagram ---------- */
+      .diagram {
+        margin-top: 16px;
+        overflow-x: auto;
+      }
+      .diagram svg {
+        width: 100%;
+        min-width: 460px;
+        height: auto;
+        display: block;
+      }
+      .diagram .node {
+        fill: #fff;
+        stroke: #000;
+        stroke-width: 2;
+      }
+      .diagram .box {
+        fill: none;
+        stroke: #000;
+        stroke-width: 2;
+        stroke-dasharray: 5 4;
+      }
+      .diagram .t {
+        font-family: var(--chicago);
+        font-size: 13px;
+        fill: #000;
+      }
+      .diagram .s {
+        font-family: var(--geneva);
+        font-size: 10.5px;
+        fill: #000;
+      }
+      .diagram .e {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        fill: #000;
+      }
+      .diagram .arr {
+        stroke: #000;
+        stroke-width: 2;
+        fill: none;
+      }
+
+      /* ---------- demo ---------- */
+      .alert {
+        border: 2px solid #000;
+        padding: 16px 16px 14px;
+        margin: 14px 0;
+        display: grid;
+        grid-template-columns: 44px 1fr;
+        gap: 14px;
+        align-items: start;
+        box-shadow: 1px 1px 0 #000, 2px 2px 0 #000;
+      }
+      .alert .ico {
+        width: 40px;
+        height: 40px;
+        border: 2px solid #000;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--chicago);
+        font-size: 22px;
+      }
+      .qa {
+        display: grid;
+        gap: 12px;
+        margin-top: 8px;
+      }
+      .qa .card {
+        border: 2px solid #000;
+        padding: 12px 14px;
+      }
+      .qa .q {
+        font-family: var(--chicago);
+        font-size: 13px;
+        margin-bottom: 8px;
+      }
+      .qa .ans {
+        font-family: var(--chicago);
+        font-size: 22px;
+        line-height: 1;
+      }
+      .qa .note {
+        font-size: 12px;
+        margin-top: 7px;
+        display: block;
+      }
+      .field {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        border: 2px solid #000;
+        padding: 8px 10px;
+        margin: 10px 0;
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+      .step-h {
+        font-family: var(--chicago);
+        font-size: 15px;
+        margin: 22px 0 6px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .step-h .n {
+        width: 22px;
+        height: 22px;
+        border: 2px solid #000;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 13px;
+        flex: 0 0 auto;
+      }
+
+      /* 1-bit bar chart */
+      .barchart {
+        border: 2px solid #000;
+        padding: 14px;
+        margin-top: 10px;
+      }
+      .barchart .cl {
+        font-family: var(--chicago);
+        font-size: 12px;
+        margin-bottom: 12px;
+      }
+      .bar {
+        display: grid;
+        grid-template-columns: 96px 1fr 52px;
+        align-items: center;
+        gap: 10px;
+        margin-bottom: 8px;
+        font-size: 12px;
+      }
+      .bar .name {
+        text-align: right;
+        font-family: var(--geneva);
+      }
+      .bar .track {
+        height: 15px;
+        border: 2px solid #000;
+        background: #fff;
+      }
+      .bar .fill {
+        height: 100%;
+        border-right: 2px solid #000;
+      }
+      .bar .val {
+        font-family: var(--mono);
+      }
+      .d100 {
+        background: #000;
+      }
+      .d75 {
+        background-color: #fff;
+        background-image: linear-gradient(
+            45deg,
+            #000 40%,
+            transparent 40%,
+            transparent 90%,
+            #000 90%,
+            #000
+          ),
+          linear-gradient(
+            45deg,
+            #000 40%,
+            transparent 40%,
+            transparent 90%,
+            #000 90%,
+            #000
+          );
+        background-size: 3px 3px;
+        background-position: 0 0, 1.5px 1.5px;
+      }
+      .d50 {
+        background-color: #fff;
+        background-image: linear-gradient(
+            45deg,
+            #000 25%,
+            transparent 25%,
+            transparent 75%,
+            #000 75%,
+            #000
+          ),
+          linear-gradient(
+            45deg,
+            #000 25%,
+            transparent 25%,
+            transparent 75%,
+            #000 75%,
+            #000
+          );
+        background-size: 3px 3px;
+        background-position: 0 0, 1.5px 1.5px;
+      }
+      .d25 {
+        background-color: #fff;
+        background-image: radial-gradient(#000 34%, transparent 36%);
+        background-size: 3px 3px;
+      }
+
+      .why-h {
+        font-size: 16px;
+        margin: 20px 0 4px;
+      }
+      .why-h:first-child {
+        margin-top: 0;
+      }
+
+      /* ---------- footer / about box ---------- */
+      .aboutbox {
+        max-width: 470px;
+        margin: 0 auto 40px;
+      }
+      .aboutbox .win-body {
+        text-align: center;
+        padding: 26px 22px;
+      }
+      .aboutbox .mark {
+        width: 44px;
+        height: 44px;
+        margin: 0 auto 10px;
+      }
+      .aboutbox .wm {
+        font-family: var(--chicago);
+        font-size: 24px;
+      }
+      .aboutbox .jp {
+        font-size: 12px;
+        margin-top: 8px;
+      }
+      .aboutbox .links {
+        margin-top: 14px;
+        font-size: 12px;
+        display: flex;
+        gap: 14px;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path
+          d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z"
+          fill="currentColor"
+        />
+      </symbol>
+    </svg>
+
+    <!-- MENU BAR -->
+    <div class="menubar">
+      <span class="apple" title="About Setoku">
+        <svg viewBox="0 0 64 64" aria-label="Setoku menu"><use href="#clover" /></svg>
+      </span>
+      <span class="m">File</span>
+      <span class="m">Edit</span>
+      <span class="m opt">View</span>
+      <span class="m opt">Special</span>
+      <span class="clock" id="clock">Setoku 7</span>
+    </div>
+
+    <!-- DESKTOP ICONS -->
+    <div class="deskicons" aria-hidden="true">
+      <div class="icon">
+        <svg width="42" height="34" viewBox="0 0 42 34">
+          <rect x="1" y="1" width="40" height="32" fill="#fff" stroke="#000" stroke-width="2" />
+          <rect x="6" y="7" width="30" height="4" fill="#000" />
+          <rect x="6" y="15" width="22" height="3" fill="#000" />
+          <rect x="6" y="21" width="26" height="3" fill="#000" />
+        </svg>
+        <span class="lbl">Read&nbsp;Me</span>
+      </div>
+      <div class="icon">
+        <svg width="34" height="34" viewBox="0 0 34 34">
+          <rect x="2" y="2" width="30" height="30" rx="4" fill="#fff" stroke="#000" stroke-width="2" />
+          <rect x="8" y="24" width="18" height="4" fill="#000" />
+          <circle cx="24" cy="9" r="3" fill="#000" />
+        </svg>
+        <span class="lbl">The&nbsp;box</span>
+      </div>
+      <div class="icon">
+        <svg width="28" height="34" viewBox="0 0 28 34">
+          <path
+            d="M4 8 h20 l-2 24 h-16 z"
+            fill="#fff"
+            stroke="#000"
+            stroke-width="2"
+            stroke-linejoin="round"
+          />
+          <rect x="2" y="5" width="24" height="4" fill="#fff" stroke="#000" stroke-width="2" />
+          <path d="M11 3 h6" stroke="#000" stroke-width="2" />
+          <path d="M11 13 l1 15 M17 13 l-1 15" stroke="#000" stroke-width="1.5" />
+        </svg>
+        <span class="lbl">Trash</span>
+      </div>
+    </div>
+
+    <main class="screen" id="top">
+      <!-- HERO WINDOW -->
+      <section class="win active">
+        <div class="titlebar">
+          <span class="box close"></span>
+          <span class="name">Setoku</span>
+          <span class="box zoom"></span>
+        </div>
+        <div class="win-main">
+          <div class="win-body">
+            <span class="eyebrow">Open source · MCP server · Apache-2.0</span>
+            <h1>
+              Make any AI fluent in your
+              <span class="rotator-end"
+                ><span
+                  class="rotator"
+                  data-words="company data,family data,personal data"
+                  ><span class="rotator-word">company data</span></span
+                >.<span class="caret" aria-hidden="true">.</span></span
+              >
+            </h1>
+            <p class="lede">
+              Setoku is a small self-hosted MCP knowledge server + Claude Code
+              skills for hooking up your data. It does two things: it gives your
+              AI a read-only way to query your data, and it remembers what that
+              data means (the metric definitions, the gotchas), getting better the
+              more you use it. The MCP works with whatever AI you already have, and
+              no model runs on the server, so no added inference cost.
+            </p>
+            <div class="actions">
+              <a
+                class="btn default"
+                href="https://github.com/Hedgy-Labs/setoku"
+                target="_blank"
+                rel="noopener"
+                >View on GitHub</a
+              >
+              <a class="btn" href="#demo">Try the demo</a>
+            </div>
+          </div>
+          <div class="sb" aria-hidden="true">
+            <div class="ar up">▲</div>
+            <div class="track"><div class="thumb"></div></div>
+            <div class="ar dn">▼</div>
+          </div>
+        </div>
+        <div class="win-foot" aria-hidden="true">
+          <div class="htrack"><div class="hthumb"></div></div>
+          <div class="grow"></div>
+        </div>
+      </section>
+
+      <!-- QUICKSTART WINDOW -->
+      <section class="win">
+        <div class="titlebar">
+          <span class="box close"></span>
+          <span class="name">Quickstart</span>
+          <span class="box zoom"></span>
+        </div>
+        <div class="win-main">
+          <div class="win-body">
+            <p>
+              Setoku installs as a Claude Code plugin. Add the plugin, then run
+              onboarding from your main project directory, the codebase you want
+              Setoku to learn from:
+            </p>
+<pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+            <div class="prog">
+              <div class="lab">Standing up the server…</div>
+              <div class="track"><div class="fill"></div></div>
+            </div>
+            <p>
+              Onboarding stands up the server, auths your Claude, wires your
+              database read-only, and generates the first knowledge from your
+              code. You stay in the loop for anything that touches your data. To
+              start onboarding, run <code>/setoku:onboard</code>.
+            </p>
+            <p>
+              You’ll need somewhere to host it. Something like OVH’s
+              <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener"
+                >VPS-2</a
+              >
+              is plenty.
+            </p>
+            <details>
+              <summary>Or stand up the server by hand</summary>
+<pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+              <p style="margin-top: 8px">
+                Installs Docker, generates secrets, gets an HTTPS certificate, and
+                prints the connect command. Then add the plugin and run
+                /setoku:onboard from your project; it’ll detect the box you just
+                made.
+              </p>
+            </details>
+          </div>
+          <div class="sb" aria-hidden="true">
+            <div class="ar up">▲</div>
+            <div class="track"><div class="thumb"></div></div>
+            <div class="ar dn">▼</div>
+          </div>
+        </div>
+        <div class="win-foot" aria-hidden="true">
+          <div class="htrack"><div class="hthumb"></div></div>
+          <div class="grow"></div>
+        </div>
+      </section>
+
+      <!-- HOW IT WORKS WINDOW -->
+      <section class="win">
+        <div class="titlebar">
+          <span class="box close"></span>
+          <span class="name">How it works</span>
+          <span class="box zoom"></span>
+        </div>
+        <div class="win-main">
+          <div class="win-body">
+            <p>
+              Setoku gives the AI two kinds of MCP tools, and one rule: look up
+              what the data means before you touch it.
+            </p>
+            <div class="rows">
+              <div class="row">
+                <div class="k">
+                  Context tools<span class="t">find_context · get_metric</span>
+                </div>
+                <div class="v">
+                  The AI reads what your data means first: canonical metric
+                  definitions, entity docs, and the gotchas that make a naive
+                  query wrong.
+                </div>
+              </div>
+              <div class="row">
+                <div class="k">
+                  Read-only query<span class="t">get_schema · run_query</span>
+                </div>
+                <div class="v">
+                  Read-only, with a row cap, a statement timeout, a table
+                  allow-list, and an append-only audit log. Enforced by the
+                  database role, not by parsing SQL.
+                </div>
+              </div>
+              <div class="row">
+                <div class="k">
+                  Human-approved<span class="t">report_correction</span>
+                </div>
+                <div class="v">
+                  The AI can only propose changes to what Setoku knows. A person
+                  accepts them on the admin page, outside the agent loop, so an
+                  injected session can’t rewrite the brain.
+                </div>
+              </div>
+            </div>
+            <p style="margin-top: 16px">
+              You set it up with <b>Claude Code</b> skills:
+            </p>
+            <ul class="list">
+              <li>
+                <code>/setoku:onboard</code> sets Setoku up in a repo for the first
+                time.
+              </li>
+              <li>
+                <code>/setoku:connect</code> adds a data source or custom
+                integration.
+              </li>
+              <li>
+                <code>/setoku:generate</code> writes business context from your
+                code.
+              </li>
+              <li>
+                <code>/setoku:curate</code> reviews and approves pending knowledge.
+              </li>
+            </ul>
+            <p style="margin-top: 12px">
+              Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex, or
+              whatever you run. Just ask in plain language, and the tools do the
+              rest.
+            </p>
+          </div>
+          <div class="sb" aria-hidden="true">
+            <div class="ar up">▲</div>
+            <div class="track"><div class="thumb"></div></div>
+            <div class="ar dn">▼</div>
+          </div>
+        </div>
+        <div class="win-foot" aria-hidden="true">
+          <div class="htrack"><div class="hthumb"></div></div>
+          <div class="grow"></div>
+        </div>
+      </section>
+
+      <!-- APPS WINDOW -->
+      <section class="win">
+        <div class="titlebar">
+          <span class="box close"></span>
+          <span class="name">Apps</span>
+          <span class="box zoom"></span>
+        </div>
+        <div class="win-main">
+          <div class="win-body">
+            <h2 style="font-size: 17px; margin-bottom: 8px">
+              Save and share the tools Claude builds you
+            </h2>
+            <p>
+              Ask Claude to build a dashboard on your data. Then publish it to a
+              link as a Setoku App, the data stays live, and your whole team can
+              view it. Nothing to deploy, no frontend to maintain.
+            </p>
+            <div class="rows">
+              <div class="row">
+                <div class="k">Built by asking<span class="t">publish_app</span></div>
+                <div class="v">
+                  Describe it in plain language; the agent writes the app and
+                  publishes it to a URL. Edit it the same way, just ask for the
+                  change.
+                </div>
+              </div>
+              <div class="row">
+                <div class="k">
+                  Backed by live data<span class="t">read-only</span>
+                </div>
+                <div class="v">
+                  Apps read through the same governed path: row caps, audit, a
+                  SELECT-only database role. They never get write access to your
+                  sources.
+                </div>
+              </div>
+              <div class="row">
+                <div class="k">
+                  App-private state<span class="t">no writes to your data</span>
+                </div>
+                <div class="v">
+                  Each app keeps its own state (todos, votes, annotations) in a
+                  sandbox that belongs to the app, not your database. Worst case,
+                  an app messes up its own notes.
+                </div>
+              </div>
+              <div class="row">
+                <div class="k">
+                  Share by link<span class="t">team or public</span>
+                </div>
+                <div class="v">
+                  A team link is login-gated; an admin can flip one public for a
+                  credential-free URL. The page runs in a locked-down sandbox with
+                  no network, so a published app can’t phone home.
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="sb" aria-hidden="true">
+            <div class="ar up">▲</div>
+            <div class="track"><div class="thumb"></div></div>
+            <div class="ar dn">▼</div>
+          </div>
+        </div>
+        <div class="win-foot" aria-hidden="true">
+          <div class="htrack"><div class="hthumb"></div></div>
+          <div class="grow"></div>
+        </div>
+      </section>
+
+      <!-- ARCHITECTURE WINDOW -->
+      <section class="win">
+        <div class="titlebar">
+          <span class="box close"></span>
+          <span class="name">Architecture</span>
+          <span class="box zoom"></span>
+        </div>
+        <div class="win-main">
+          <div class="win-body">
+            <p>
+              You can host this on whatever infra you like. We put it all on one
+              small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+              helps you add custom integrations. Only the proxy is public, so your
+              databases aren’t exposed. Queries are read-only, and knowledge
+              changes pass through a person.
+            </p>
+            <div class="diagram">
+              <svg
+                viewBox="0 0 680 520"
+                role="img"
+                aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake for analytics, and your sources (GitHub, Vercel, Render, Slack, Mercury) are ingested into the lake."
+              >
+                <defs>
+                  <marker
+                    id="ah"
+                    markerWidth="9"
+                    markerHeight="9"
+                    refX="6"
+                    refY="3"
+                    orient="auto-start-reverse"
+                  >
+                    <path d="M0 0 L6 3 L0 6 Z" fill="#000" />
+                  </marker>
+                </defs>
+                <rect class="node" x="250" y="14" width="180" height="44" rx="0" />
+                <text class="t" x="340" y="41" text-anchor="middle">
+                  You + your AI
+                </text>
+                <path
+                  class="arr"
+                  d="M340 58 L340 142"
+                  marker-start="url(#ah)"
+                  marker-end="url(#ah)"
+                />
+                <text class="e" x="348" y="86">MCP</text>
+                <rect class="box" x="60" y="110" width="560" height="300" rx="0" />
+                <text class="e" x="76" y="130">your box</text>
+                <rect class="node" x="250" y="146" width="180" height="58" rx="0" />
+                <text class="t" x="340" y="171" text-anchor="middle">
+                  Setoku gateway
+                </text>
+                <text class="s" x="340" y="189" text-anchor="middle">
+                  context · query tools
+                </text>
+                <rect class="node" x="452" y="150" width="150" height="50" rx="0" />
+                <text class="t" x="527" y="179" text-anchor="middle">a person</text>
+                <rect class="node" x="92" y="322" width="180" height="66" rx="0" />
+                <text class="t" x="182" y="350" text-anchor="middle">
+                  Lake (ClickHouse)
+                </text>
+                <text class="s" x="182" y="368" text-anchor="middle">
+                  logs · events · DB mirror
+                </text>
+                <rect class="node" x="408" y="322" width="190" height="66" rx="0" />
+                <text class="t" x="503" y="359" text-anchor="middle">
+                  Knowledge store
+                </text>
+                <rect class="node" x="92" y="440" width="180" height="64" rx="0" />
+                <text class="t" x="182" y="468" text-anchor="middle">
+                  Your sources
+                </text>
+                <text class="s" x="182" y="486" text-anchor="middle">
+                  GitHub · Vercel · Slack…
+                </text>
+                <rect class="node" x="300" y="440" width="180" height="64" rx="0" />
+                <text class="t" x="390" y="468" text-anchor="middle">
+                  Your database
+                </text>
+                <text class="s" x="390" y="486" text-anchor="middle">
+                  Postgres · read-only
+                </text>
+                <path
+                  class="arr"
+                  d="M412 204 L508 322"
+                  marker-start="url(#ah)"
+                  marker-end="url(#ah)"
+                />
+                <text class="e" x="424" y="266" text-anchor="middle">reads ·</text>
+                <text class="e" x="424" y="282" text-anchor="middle">proposes</text>
+                <path class="arr" d="M527 200 L513 322" marker-end="url(#ah)" />
+                <text class="e" x="534" y="262">approves</text>
+                <path class="arr" d="M210 322 L300 204" marker-end="url(#ah)" />
+                <path class="arr" d="M182 440 L182 388" marker-end="url(#ah)" />
+                <text class="e" x="190" y="420">ingest</text>
+                <path class="arr" d="M388 440 L366 206" marker-end="url(#ah)" />
+                <text class="e" x="300" y="300">read-only</text>
+              </svg>
+            </div>
+          </div>
+          <div class="sb" aria-hidden="true">
+            <div class="ar up">▲</div>
+            <div class="track"><div class="thumb"></div></div>
+            <div class="ar dn">▼</div>
+          </div>
+        </div>
+        <div class="win-foot" aria-hidden="true">
+          <div class="htrack"><div class="hthumb"></div></div>
+          <div class="grow"></div>
+        </div>
+      </section>
+
+      <!-- CONNECTORS WINDOW -->
+      <section class="win">
+        <div class="titlebar">
+          <span class="box close"></span>
+          <span class="name">Connectors</span>
+          <span class="box zoom"></span>
+        </div>
+        <div class="win-main">
+          <div class="win-body">
+            <p>
+              Point Setoku at the data you already have. Every source lands in a
+              local
+              <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+                >ClickHouse</a
+              >
+              data lake, on purpose: agents write arbitrary queries (scans, GROUP
+              BYs, whole-table aggregations), and a columnar engine answers those
+              in about a second, so the apps and dashboards they build stay quick.
+              Your app database connects read-only and is mirrored in on a cron;
+              the rest is ingested as it happens.
+            </p>
+            <p style="font-family: var(--chicago); margin: 4px 0 2px">
+              ClickHouse · one lake, every source
+            </p>
+            <ul class="list checked">
+              <li><b>PostgreSQL</b> — app database, mirrored read-only</li>
+              <li><b>GitHub</b> — issues, PRs &amp; commits</li>
+              <li><b>Vercel</b> — deploys &amp; logs</li>
+              <li><b>Render</b> — deploys &amp; logs</li>
+              <li><b>Slack</b> — messages</li>
+              <li><b>Mercury</b> — banking &amp; finance</li>
+            </ul>
+            <p style="margin-top: 14px">
+              No connector for your source yet? The included setup skills give your
+              coding agent the patterns to wire one up itself. See
+              <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener"
+                >the repo</a
+              >, or open an issue.
+            </p>
+          </div>
+          <div class="sb" aria-hidden="true">
+            <div class="ar up">▲</div>
+            <div class="track"><div class="thumb"></div></div>
+            <div class="ar dn">▼</div>
+          </div>
+        </div>
+        <div class="win-foot" aria-hidden="true">
+          <div class="htrack"><div class="hthumb"></div></div>
+          <div class="grow"></div>
+        </div>
+      </section>
+
+      <!-- DEMO WINDOW -->
+      <section class="win" id="demo">
+        <div class="titlebar">
+          <span class="box close"></span>
+          <span class="name">Try it on real-ish data</span>
+          <span class="box zoom"></span>
+        </div>
+        <div class="win-main">
+          <div class="win-body">
+            <p>
+              There’s a live demo wired to a fictional pro sports club, the Bonita
+              Bulldogs (ticketing, sponsorship, concessions, payroll, broadcast
+              rights).
+            </p>
+
+            <div class="step-h"><span class="n">1</span>Connect to the demo MCP server</div>
+            <p style="font-size: 13px">
+              In Claude (or any MCP client) open Settings → Connectors → Add custom
+              connector, and paste this URL. The token rides in the URL, so there’s
+              no separate key to enter.
+            </p>
+            <div class="field">
+              https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9
+            </div>
+
+            <div class="step-h"><span class="n">2</span>Ask a question</div>
+            <div class="qa">
+              <div class="card">
+                <div class="q">“How many unique fans do we have?”</div>
+                <div class="ans">71,204</div>
+                <span class="note"
+                  >deduped by normalized email, internal accounts excluded. Not the
+                  raw 92,118.</span
+                >
+              </div>
+              <div class="card">
+                <div class="q">
+                  “What’s our total annual revenue, and how much is media rights?”
+                </div>
+                <div class="ans">$192M</div>
+                <span class="note"
+                  >five systems reconciled to the same units. Media rights is the
+                  biggest line, ~$90M.</span
+                >
+              </div>
+              <div class="card">
+                <div class="q">“What was ticket revenue this season?”</div>
+                <div class="ans">$46.8M</div>
+                <span class="note"
+                  >cents reconciled to dollars; refunds, exchanges, and comps
+                  excluded.</span
+                >
+              </div>
+            </div>
+
+            <div class="alert">
+              <div class="ico">!</div>
+              <div>
+                <div class="q" style="font-family: var(--chicago); margin-bottom: 4px">
+                  “What’s our total merchandise revenue?”
+                </div>
+                <b>It flags it.</b>
+                <span class="note"
+                  >most merch is sold via Fanatics, not in this data, so it says so
+                  instead of returning a wrong total.</span
+                >
+              </div>
+            </div>
+
+            <div class="barchart">
+              <div class="cl">“Chart revenue by line.” · Annual revenue · ~$192M total</div>
+              <div class="bar">
+                <span class="name">Media rights</span>
+                <span class="track"><span class="fill d100" style="width: 100%"></span></span>
+                <span class="val">$90M</span>
+              </div>
+              <div class="bar">
+                <span class="name">Ticketing</span>
+                <span class="track"><span class="fill d75" style="width: 52%"></span></span>
+                <span class="val">$47M</span>
+              </div>
+              <div class="bar">
+                <span class="name">Sponsorship</span>
+                <span class="track"><span class="fill d50" style="width: 31%"></span></span>
+                <span class="val">$28M</span>
+              </div>
+              <div class="bar">
+                <span class="name">Concessions</span>
+                <span class="track"><span class="fill d50" style="width: 16%"></span></span>
+                <span class="val">$14M</span>
+              </div>
+              <div class="bar">
+                <span class="name">Merch</span>
+                <span class="track"><span class="fill d25" style="width: 9%"></span></span>
+                <span class="val">$8M</span>
+              </div>
+              <div class="bar">
+                <span class="name">Other</span>
+                <span class="track"><span class="fill d25" style="width: 6%"></span></span>
+                <span class="val">$5M</span>
+              </div>
+            </div>
+
+            <div class="step-h"><span class="n">3</span>Try an app</div>
+            <p style="font-size: 13px">
+              Ask Claude to build a dashboard on the same data, then publish it to
+              a link. Two live examples, running on the demo data right now:
+            </p>
+            <ul class="list">
+              <li>
+                <a
+                  href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+                  target="_blank"
+                  rel="noopener"
+                  >Sponsorship pricing table ↗</a
+                >
+                — inventory and rates for sponsorship placements.
+              </li>
+              <li>
+                <a
+                  href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+                  target="_blank"
+                  rel="noopener"
+                  >Fan lifetime value ↗</a
+                >
+                — segment fans by spend across tickets, merch, and concessions.
+              </li>
+            </ul>
+          </div>
+          <div class="sb" aria-hidden="true">
+            <div class="ar up">▲</div>
+            <div class="track"><div class="thumb"></div></div>
+            <div class="ar dn">▼</div>
+          </div>
+        </div>
+        <div class="win-foot" aria-hidden="true">
+          <div class="htrack"><div class="hthumb"></div></div>
+          <div class="grow"></div>
+        </div>
+      </section>
+
+      <!-- WHY WINDOW -->
+      <section class="win">
+        <div class="titlebar">
+          <span class="box close"></span>
+          <span class="name">Why we built it</span>
+          <span class="box zoom"></span>
+        </div>
+        <div class="win-main">
+          <div class="win-body">
+            <h3 class="why-h">We’re curious.</h3>
+            <p>
+              There are plenty of AI memory stores, and plenty of data gateways.
+              Stapling the two together, and nudging the agent to gather knowledge
+              about the data as it goes, seemed useful and fun to tinker with.
+            </p>
+            <h3 class="why-h">We’re cheap.</h3>
+            <p>
+              We wanted something that runs on one small box, works on a Pro/Max
+              subscription or a cheap model with no added inference cost, mostly
+              sets itself up (no field engineer to pay for), stays portable between
+              providers, and is open source.
+            </p>
+            <h3 class="why-h">We’re paranoid.</h3>
+            <p>
+              HR platforms, CRMs, and clouds are all announcing “context layers.”
+              They’d like the meaning of your business to accumulate on their
+              servers, where it can never leave. Context is deeper lock-in than
+              data, and a hosted context layer has no export button. Setoku exists
+              so that understanding accumulates on a box you own instead. If we
+              disappear tomorrow, your context doesn’t.
+            </p>
+            <h3 class="why-h">We and some friends wanted the same thing.</h3>
+            <ul class="list">
+              <li>
+                <b><a href="https://www.hedgy.works" target="_blank" rel="noopener">Hedgy</a></b>: keep scaling without hiring. Debug from live logs and
+                data, find growth levers, and match candidates and companies better
+                with more data.
+              </li>
+              <li>
+                <b><a href="https://baggu.com" target="_blank" rel="noopener">Baggu</a></b>: give employees state-of-the-art tools. Faster
+                onboarding, and a safe way to vibecode against real data.
+              </li>
+              <li>
+                <b><a href="https://tlon.io" target="_blank" rel="noopener">Tlon</a></b>: experimenting with giving agents curated data to work
+                from.
+              </li>
+              <li>
+                <b>Sports analysts</b>: query across data that doesn’t usually sit
+                together.
+              </li>
+              <li>
+                <b>Academic labs</b>: think through hypotheses against real papers,
+                data, and drafts.
+              </li>
+            </ul>
+          </div>
+          <div class="sb" aria-hidden="true">
+            <div class="ar up">▲</div>
+            <div class="track"><div class="thumb"></div></div>
+            <div class="ar dn">▼</div>
+          </div>
+        </div>
+        <div class="win-foot" aria-hidden="true">
+          <div class="htrack"><div class="hthumb"></div></div>
+          <div class="grow"></div>
+        </div>
+      </section>
+
+      <!-- SETUP HELP WINDOW -->
+      <section class="win">
+        <div class="titlebar">
+          <span class="box close"></span>
+          <span class="name">Setup help</span>
+          <span class="box zoom"></span>
+        </div>
+        <div class="win-main">
+          <div class="win-body">
+            <p>
+              It’s open source, so you can self-host it today. If you like, we’re
+              happy to help set it up. Just email
+              <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+            </p>
+          </div>
+          <div class="sb" aria-hidden="true">
+            <div class="ar up">▲</div>
+            <div class="track"><div class="thumb"></div></div>
+            <div class="ar dn">▼</div>
+          </div>
+        </div>
+        <div class="win-foot" aria-hidden="true">
+          <div class="htrack"><div class="hthumb"></div></div>
+          <div class="grow"></div>
+        </div>
+      </section>
+
+      <!-- ABOUT / FOOTER -->
+      <section class="win aboutbox">
+        <div class="titlebar">
+          <span class="box close"></span>
+          <span class="name">About Setoku</span>
+          <span class="box zoom"></span>
+        </div>
+        <div class="win-main">
+          <div class="win-body">
+            <svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+            <div class="wm">Setoku</div>
+            <div class="jp">設 × 奥 · set (math) × oku (innermost)</div>
+            <div class="links">
+              <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener"
+                >GitHub</a
+              >
+              <a href="#demo">Demo</a>
+              <a href="mailto:hello@setoku.com">Contact</a>
+              <span>Apache-2.0</span>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      // --- hero word rotator: crisp 1-bit swap, no fade ---
+      // Natural width: the span sizes to its text, so the underline always
+      // hugs the phrase (no measured-width drift when the bitmap font loads).
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) {
+            return w.trim();
+          })
+          .filter(Boolean);
+        if (words.length < 2) return;
+        var i = 0;
+        setInterval(function () {
+          i = (i + 1) % words.length;
+          word.textContent = words[i];
+        }, 2000);
+      })();
+
+      // --- live menu-bar clock ---
+      (function () {
+        var el = document.getElementById("clock");
+        if (!el) return;
+        function tick() {
+          var d = new Date();
+          var h = d.getHours();
+          var m = d.getMinutes();
+          var ap = h < 12 ? "AM" : "PM";
+          h = h % 12;
+          if (h === 0) h = 12;
+          el.textContent = h + ":" + (m < 10 ? "0" + m : m) + " " + ap;
+        }
+        tick();
+        setInterval(tick, 15000);
+      })();
+
+      // --- active vs inactive window (frontmost = nearest viewport center) ---
+      (function () {
+        var wins = Array.prototype.slice.call(document.querySelectorAll(".win"));
+        if (!wins.length) return;
+        var ticking = false;
+        function update() {
+          ticking = false;
+          var mid = window.innerHeight / 2;
+          var best = null;
+          var bestDist = Infinity;
+          for (var j = 0; j < wins.length; j++) {
+            var r = wins[j].getBoundingClientRect();
+            if (r.bottom < 0 || r.top > window.innerHeight) continue;
+            var c = (r.top + r.bottom) / 2;
+            var dist = Math.abs(c - mid);
+            if (dist < bestDist) {
+              bestDist = dist;
+              best = wins[j];
+            }
+          }
+          for (var k = 0; k < wins.length; k++) {
+            wins[k].classList.toggle("active", wins[k] === best);
+          }
+        }
+        function onScroll() {
+          if (!ticking) {
+            ticking = true;
+            window.requestAnimationFrame(update);
+          }
+        }
+        window.addEventListener("scroll", onScroll, { passive: true });
+        window.addEventListener("resize", onScroll);
+        update();
+      })();
+
+      // --- window-shade: double-click a title bar to roll up ---
+      (function () {
+        var bars = document.querySelectorAll(".win .titlebar");
+        for (var j = 0; j < bars.length; j++) {
+          bars[j].addEventListener("dblclick", function () {
+            this.parentNode.classList.toggle("rolled");
+          });
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/10b-platinum.html
+++ b/site/riffs/10b-platinum.html
@@ -1,0 +1,1423 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · Mac OS 8</title>
+    <style>
+      @font-face{font-family:'Chicago';src:url(data:font/woff2;base64,d09GMgABAAAAACsAAA8AAAAAanQAACqhAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGhgGVgCEJAgYCYFpCoG1aIGNPguDfAABNgIkA4d0BCAFg34HhDMMOxtGUxXjWAseB4EWqyWianTm7P/L5I3RD00aDHsyRCbDlLRkFRpqNOiSU0i08cIw6RGRzk3GJx+W9E6eka58DR2jZ4PqMOutB2nQ/SM09kmuH63V+wq6uqemp6dndu9u9wj2w34gUkEVY+KBhIqSEY4skEIV+VUSBzg8ze0fxpdJrYja7m63WxASFia1DdgG272DUfpBpawCu/CXQY+6Q8RojPplgYo2adVmDGMDhIfnD3/n3temqE8t/Qu4sQdJwglGY1mUQAJr/d9aOt/Of3EFBFX2VeF7USWSkVXV1bkspbg4e4SLx7hb/v/+p2r5PwA6vEdIravGnZviAkBIwu5RYXe5YzrkC2qAFqgvt04Qps2ajUzyoS5AVOVh+vy9zqr0/6bqKfcSRezlA8qXKNsJsr0kkN5/kvy/rHHLLLuBhtQDbnnQPSRb6prGBYKoj9jtIV5izwGR+wAzzDbaunyD5CAJLwspurro9vfTSlRoOqGpj7FUjPTG333eMOa+f/Yuvfrfxq3aagpoAoIMRYa2lOdyI0pmZQrv8ROOAUA2flrlfzsd+9FD/T8o5BlopWzoairKM9FtMOBL0wmoL4pl5+uMFd5OqmeAOBz8cBLs6p7BzxVp/x+NlNLuRusQGbIJb2ZmUJ9O8Zd3UDCAfYhBWOddDfrtYGRGQfyR/2f7wAIJQsagGOb5pPJ/EMxVOhhkZJTTSX1YnVeD/z8fv3n5uVNH2PR9Aj9fPGFd9U60mQA7+w4HIvQJhOrazqYBfhElje88LJv/yGOtctNt2nUAoFOXJ/FrxFOvvDbAc2+9894HJmYfffLZFxbdvvrmux+sbHr0AnZtYAcAAEQR2GJqcFjG29yV3nSrXtx/o3v8MREuJiRSmdzPPyBwWFBwSOjwESNHjQ4bM3bc+AkTwyMio6IVSlVMbJxao41P0OlJSCUmGZJTUtPSJ03+NSNzytRpWdk5uXnTZ8ycNXsO+OPPXXsqauoPHTx89MixE6dONp4+e+bc+YuXL/397z9Xr1y73rly3vzFT9YfWF7wcm0++IsGqwBYuA4AAMCSzeD4/zvmLgN3AVi65Sko/L365q0HD9vaHz3+DzTfAeD5CwC6NrR2PPtt786i3SWlZcWVVcBYt48B9+6vAABsBACAmL6KAdGpMiB/MTT/ZgfQS+DUbCNYS1tHyO6D7Ubq33Bpfe9pLHJ4ENDIrj6AKPKiD1NGYg6oF2Z10IcGLpVTHhbxBJksSkG2mtbpaThIieRmTjus4o28OEXW1teGIYfBrbx5eWoLPTyU4n0tyEpJGRPQaFAT9SoxJUgg05Hrp8sj79uRHlyfhTKFWErWJx9+f8z7YJnoFG8URRSHP10tyKcWmpLCiPxCpGzbV+R5kEuH9PxSbYDDjH+Z9IXkcZJZDwCbp5KZKMMJJ0O5kToFZbMAR1ckFEX4hKkhoOxBQ2NR6RSP55WwzN2cFvlBLEVEvYysTeAKSoR2k4HhkagbWTu5y0eiwuGESkR78BCdk6wvl9Ic04g1nlKycFBuWOgCKSrMrRasARVooSvUQ1I9mHLsuWpgxYcYGw3AEDdZJuaMIncYAYHnEEa/Ybgvvy3QuFGaJBrRopoe2E9v38RindXjBWZU7CtWtKxKoE3UeUh1tPZtZs1fakd36POq+7NtB/BVMDuvQETMBgGr0NGSRTTUMUQEl2DkSCwZDeEXETnCel6jdE+SZUgEHqB7t+ybWDG9XqPgGBJlkmPvfgZbImQMl1xTeD9XwFZE1qnvoXDI4zXc4MCXH4JjVPJNNI8F9OHxlv1mmb6MIRyOVjOA71WySsQr+VuW2fGpsMF9gCATrXRZ/ae6tsasdYs/wldnQVvw/Im7xB6+mAFybR0nRUra7WLv+1moGa+3WUVTw64YPCmcLtM2+47AhEBCSrq8RG0WrAlhAge4iCuzoaVCqWg5XSIC+XWAmxWyOg5jjkGQATlIEu/6kwaLhxhtXPnlKF7uxOuoy9R8qYx8aFuSLExWCBXyEkvsd0AYYGpW8HHIz1GaB6AxK9SNUyftLiG1vVQhPMjfx+LQw9T17rn6uInpT0RlQqQKJ/CR68itUXeY54Lbmbfb+/MQUFKDBTXgUExYKUGBuIqhQJVjKVILroEya3YR+UDWZZiAukf9+5SmoJApxBCTUOOiEMhPORH60xmE2evIl9mRVzS2vm1PmFY2G8FAPyBIcit3Q7qjaaSTCzWuQWjQRgDCFNLnJx1l7WLtrgR7lwyyyutiPPCHcoFlUgTTTFSTAkWT7ev8mYKpxHnSosc0wA+UsFSomp0EBtZ8D+VMgyBMVKpwpgRISP4d2XPIjpwS+MQFnClNiMFLbAkWMNDq689QNFnniJQp+q6ZImgNZgEd22KyIKYsp0v0OrYAtGb9ftvquunbaWNvKWhsK99aZ5AijpbmLXaTbePwJrFTiVm+e3WsyTTH2w1+oPCKj4t1OqSsAwNVWanBsEi9A92il9bovFVvD6VdKAij0EbzFauBBZ61c/AD3AoHhZRba9DzaTTyYUkZrzOoeb9M3bjL97NpHgbP8vfQrBRRAiDrXrf4zwZdiBRO4PodSRAxVdBgP5S5VKfLqUtE/lprM532QNPhQ4prXUeh48AZrmr3AIdK+C7ND1gdbHh7lxzmAUt1lYQmC7ScSbLsHxYmCzFf8esXw3mJE9/g9GXy6113TJEqW70icqFI7izPgcIFYbW3BEqQS2+6jKWRNnvZOOhS00zbirmMvBOSnqMvUe87czCwyau26FXwujHl7hUJatz50jfpLVqBCRy+WwjD2K5OxijEdyhoEWTit1HrH2yt41uwikR51cUgTrZxtOvoMppAiw30gRFYRmqjqW6O+45rOBGv462BZSU7DFHboqODThNufHBbVEP0eRqbXw6MPCLjScb7QeA6FJQpjByNoD3h7Z2w33XxGbEF2gA9UFzqL4RAX9bAVsOEsSgMlxSlkxRR2DzQZ8+11vF/YURC/BJfZK1Uukvk6RMpDpUegqbVjHWNsZe1Om50ObRZYi9fCTUY2tm0AvsFWn+b2o7liLgstQW1kXU0K4u7vrSembAeRitLJfS9aP6GJJ8ULkehvOjpCs93a/szijYhBkJBrknTls+ycVJieok2iyUiaF969lTP2T/7+OozqFhQ++rTF6RoRSc7sfFcp/Y+SR2b+PXYkCn5yfdkn2qCsXGSmO/cg1ZR1PDd64sNCd0ri+PkpSVUQQCI8Bjxmz6Uv5JOp/rvfxKvYklf20IfTMryYOzhwVAD8331JvbaJKVh0iYexZa+E0Rk57lDBPWzwNS3dp82Zbggxr0aerssl9KO0V8Naljx2D0jalqyoZ3XMd/zYcHur8hT68SMmIDSH20QYdSjLSMpsYi891DRv43iXT4+kfwdR0wcVzyL/lmC0FsTtTa0gEuymjgHmdbyUXhDQU6ISgWeDoLnmKbvC0SUNvWuvOpWxqdwRZdlkB5+Q17jfxA+7g0HOi0VuS96IKWkxJXsLGSL77zgZK296n/+9QH3d8x/Q99mcdzBJE7BTXJAQxIUjmlHV/hcnZUXgRnPC4o/0CrURynpoYWGoQEvPFv/+3xA5H7mM4J5CP8iPlK7VU7xcz9L2oF9fhYfvNvbfiSqQij64LlcvJgUcDhtpM+h/mKFzWpKXJY2ZuGF8T7qKTaCgkZG9y5M8Slf63uXIyNmS+l+PIcAnHCnxgsqwJMBO4unhgCALDXeAOiZzLs7TMafuomBuDVjuvLSs79znydElkGo5R0V8PRROvQ4KV32OUlpDVQQopCmUBmzaqKV30Z4mqpR7r4Klrtk4FABz0sWnGsAKkulmnBcLpa5gFnMk4wieRP2RdjDDPrU8MIIKIeA6j03UCDROF0iq5rPCuc3QJf8pn/8WsmJHcPPJvZHZezhRXzQabOuRAtwqr769CS9zl+5I+d/Eqgflppa6VDUQrqmPtbp0mBDvcl1/dH6mjHwLTVd7vsN+h8UeKb+vVAwjv4rgQj8R2gu/afGA0MNjh2NRBnlN9n6XMFM9+7TN7EP2aQOGhgdp0lRxf2jL+8NFa92bNsC9+zvAlM8l810RkAW+EiHnCSNX5tfRvEBQguhBxWC4Ui9YxCtIV4I/wEjSZCD0qUGZhd7OqfA8Henihj8edW3+AZhxtANxa3yh6QJ+p4G3mwnNwbDd3Nx99EDdMetBLZ9dK+M7Snyj8MGB8oEl4JYkdxj3wGMBuY2nUbuROQU5olJTNgn7HPGju0qfhDtwt83sp0dqXbMdolFjvhz1po/8rF82KUiZpo0ReuDprJetQUvff3sIo/gFtfNrVmw0lZ//318xhvPu1KoGb328O+OJ8N6o8KfwwRDjUk+uEjZgjaDOh8Zb0kEdV5Veaco4ToRAl5FEGHEL5X4HV6JaWznNtnz8ywxiVf9BWdKkfTSWyuuvNQ/Jon5fnnIs4nW6VAMtk/ua0d/Kofd0OLZnayWVzvxKawn4R07woIrfzcu/Z+jTb2itiire96VvaPLM1KHI0r/7jipz2fxJQVoyhBnhnfhUmPOINhSQ7PVh2586228Oh3Ou3CWNqgzGOiHosz75JackMBsF+N5PbnVRl4CatIfB3Z5UiROpuEJLAeLeMn7PgamSZOyIdgFuV4IJWT6vEjhjXxEq2gWkaY4dJb7O9kqZFwevFBXOg7UjdDx5aY5RFix1zHZP2Zv/0ocnvE3w6AgjpHetVs4Wcc4Is/QR+7lQOwZU9A4TRVUVRUeY9LUgFUpx4lfqXg8hJj2F+8khjK5ytM1+pGnbXx73P6U97+HKd0sD3d/GhxkQW5a2K+P2+qP6/Xs0R+FUQA19E0lLOUQ174DbF8EecO9pltVv3TYcx0O4lAJEYdwFvcvgcNHZA8zO/bup2ma5Wj5F8nfmy9E8osKEKSgKB8Rpt9xi/dwO7P7uFxTdieX25Vj4uIi4MRL0449Ft9xLCHsmNbtXMZ4OXtr5JAghagaZ7F2NzflZE5LTp7JsqloFXu9MhOPys5g0V+/0d8oSCUxhs9cwaYnXAjhyq8qRkUXQwaKLMUljHkv13fzItF2w266m7d1KggKwiNmhIcfM0Lb+9mzZ77mRdPe0LeAzTx6QkzMLKhSFO0Rb+qBiaXU6P97qEQjNcryqKaajNcplUn28coeMtGV0hduLkKphO47mJWz1zI0U2vtpru932kbtOkVKRurenKu5LdYRcr3Kkb62yI4Cd+6jpohK471Ky6RFsdg7lwqldi6Krv1vbW11AGerN3QQVyQUXh58xkRpKC49eBK0d7ajS1B46QkVtp0RpREJYkar/7uaV0II/0bpfCsfoJzscLEB0XpaAeCdCIuZ6Ob2Owb0WefurgX/rlHTU+d+blUYNiUJRRkFSQJhUkFWS/4wsdDhVmbxebLd8Imw+y/sE4M/Ymxm6Y1sVEziNSxjx73+zUe+gduzOZAHZ2kh/pyurxWJSlveo2XEW3nV2LyShsDwCHLfv/lopUXWoky/E1TBeFAW3pgDxsuU9UyFEWZKZJy0g7HQ2ooUtLzAP/KruQpV6rclXiIPISyg/uc2F2Gg+RB+E8OKCNN0kwiw5AMk2hvTfpJM/qxEeEBkQCqjYlGYGNoxgEOhPznYmj/swK7bj6HlSLnzE1YBdbeeQ4pxc51tv4LGRXDrjQzpD6RpEodjCV3NdRCC1TL4/QL0SaXdrQYbeu7geo5P3f3cRzWFrfs032Mr5G6EBBp+tmOViJN5iakAbn6/ioS9Ighv5Bso0mjrtPaaBtFUlUVK61WXxvb+qUuFn7UauMrpcMIPVJ9+aOpEDZ/bEYERpKJZwxWeOD7t3icwhiuUoOc/4rHqkUb1/Ms3j40v+GQ3AK1La7W4hpbTa1K1PBjHwD7bIfEEFtx8T1Rgv/oOEhA/ILDGQBO258TpRMH277jJcS788tFsZ9qrDUe1hImgSGtsP7rjzh81vnrkirJ2LUCr5Dvct4XVaOb1rNZNq/WSNP0E/6mar/zNMcjLP+dlXnIaiALGi3QYqPs0CcrMrD618qqZBgmzkuKtru0I3uR9v52VM/p3/sfp7KAPj6TmerQaI23feX0bjRzjARGLOL253a4PJSIVSfViESPq4QbsTj5AH9UzWiE8gWpadGUSnlXEKUU+wb7ipOgYL3H5dHM6rrVvNGcZEIMTL43nEyogtbWaOe6u3t5AwcF2uvcJihT22ps/Ew10XZ+BZqIHezdD8C+HwfwFOLAjYeYurbIxtho7ekrx6nBVE703CzEdhE7m38Q5fjV9jIxyeta1MupiamR9EpJoqztigcVi7aZzmPF2HlzKxpbW6RiVGyjJpGx2qDRbKRsVn52KMXY5tFaT40WnjWjahSOk5HIuZ/taIWovasUKRaVdVzHjURb8w7MalMPi9HQe6vBaGmzl9ZMm9kWE1NCf2FKsXPmVlEZ1mo+hzlbTNae3j1V7bP2Mks3Ls32spIltNkIeUtNEjO84y/zlN2hzUTBPDf6xI0TUjN19MaRxYibop+qobNdVCGqa2gxX/+sWCt6mB4oOnezRAjxcx8ahVozrRWo1v75NiyOKMW3N78lqiRNB2cipdLy6w/E1Qa6tr5nEN9aaWNsmkqMX6Pf+J0E5wA47XjcL0Y86+wVQsuH9t4xeeGjp8Zzl2qkLgQlajC9w5XEu5vbsfGC+JnWKbEuiyODNFISa/jQKlLhb00NON9i6oZMCV3CeFlNtIJUrqgpZ7+YkTu3fWkVSVJso6mYKabNeQ8eutGKJEpX7AFNNonRVqf+WaPUhlXGRhxW/K02Dj0ssdEaRiOwJugYXa3sosWQ1Pckpq3uI/YT5A+OEuyyQvgRQpfrMM3NsjCNpVmcWXGo65+D7jmTa2kzJWRRVAkFHJ8jcHuyf+wsFVQtcurtFTRFcqj9CqYuRVbc6pUWJ0MyXI/svENbGSsf+6rGSHsvzES60e2dH8RVFiNj9LTCSh0PbH3CgWgX6EASkHP9zcgntPljU3yUnaALhdzbW4Q8ltJEM5VI+892tPtvBlHVwr56ulqt6irkQFcvXoI1fTyAfBIeuN0sKkFandtQktu3y4dbUv2jpq6GN+m9nIixewOzgc6r4Pjs6uXo8YbWN3ix+NU7z3B5lor4cKsUfYzOan4vq3SiRGXmK10mKut4h1cxtLs9ddYWQxr6VtvM/UVfmsWc1+JLZBRyo68NVfu2+tjYVcq6fXraTDP76qtQCYrxbUqdY7R0090M7agMbehsx/ao6G5xkVKpyn7BS5EDHz94/Cwn3jUX4p+wHTffE+V4W2cZ9gkvbG69Chkjw4Y0zVRJTJdWCD+hpV0f8JjaL0bGyDfStFnFmZdT2NbfgVR+rWKq2BRdBMZFoGk+o8mJ6Z6mt4CkObDgx7MojdSJoET7K0Ud0xO/393+RBHtBInt/9AqUuLPX9GYT7WJ0UHdXu6TLQJuGQWNEEJGDFRkpstFZZ3SsNdKWiW493AOvTt9UpybUWlhLLQqq7VtRksWxHIq5Qb/hu5DzkPfvVSjZtEjTeVZo7xVQy4CcHHQOf8NUrFdgVJJtzAt9DK0wdSGV+7tC9L3E0Pa+tqQYqTDpQPhOw9V4NMfnzM0DNQS382mbiI8kErUpSV0kuRQK1kAC1jWP7cI+aaSbyZztyQhMJHoPgV6DlBKXrdux6EkDPUd7ZwrJK7unyGiiK1yN4/Aza4HDJ7IdyHHOjDT28lH7ZvvnSbon5WR6TvYLpYPJezYJV8CKUj5daznxfivmQRnkDqoCwlHY5xjpdBd+gQTUG95zktaeFDnxuE89EH3WSmK4uS5bjsxngu1YoX0hd9IYiikoBVyDs3xlPdXzTyr+uWe/ujKuUflZ3rRPWSBY1an4u5IFFPcz+7cNC4YwUJWbPm47xWKIpyXRebNTruAWqOltb1UL+yFG6roC1XlxvKztXQl/GEKKD/r1SFwCLl5Nh6WgfxNN9cCsOnyDvd9GlcfbsB/21xXum77L4CQpxMteS0bLp7tue7BVgA2/r3ak1HzZFwneobr+m36v5Q+40+NE1y7eILNt3lkrTvYW+R9dq8zpoOeroMX2EMSHqHybl7QXrd9XG7uuO16PUlWiteg0z+WW7MhfNgcPTln2MRwaoUk8HCgsDl8ItV/j7xwPw2Qv91nuP3NBkE6Hbhl+MmrJgYNGEzgaB3CJ9J1QYD9t9sM978Rl1eXt2i2CkbnQe8Eb5gcI3Cf7z0tL1aw0Sdy7U4fhcu9ySf3/P5ix4uNDyph5dCgsNDgLUHBOLZdiIVcfmmj2CYW1GhpaDMCrB/D7sK4+k28tfx1cdtEPxDEVRy4eRm6HzE7E3dyvNguQ51O9qdSqcCl2l7U2nlAJDrQ0SrCWzuA4o9yaT23K9/E5fbld3HFIrGYx7JAI+VnfBYZiqEhTVM07dp9Pbd2/xirX61rTd0YtinfxNZyTIvb2VLOFQ548jmXkhYwJH8jX8buzDdxdM2dd7KT2G2LPrA9ZkKZVWbvBsfo8n1yz7s/QgGIKuAFGEwGqWO09StdKaj48BtISo1PYGuKbWr5XLlWtFIep9VSJbAEmmOxa6ZzuIbY2fRG7AstDM249GZMwP8UKYIihyxly0F7VT61Wb4lHqQlV8LKzb/+JlDlT/V57j01P0bwm29MPNj7uc8+q44qi/KLXII4gcEhG/xDZOgGORoUstFPbmQ9ayqUDBTD3StqeVyMH11LMSvgCrlM3nLrwvLlO1d4lF5H9A4XEjiFA1a75sh9NVy/r2o2dfkMMDA6rHbZGlBCHrG5sMcBvKz3xOzrypQ0pUOF843mUt/WrouaGK7HE13pFWRTC35HMSLc28Hx4flsNsFNDCN9HRzqX97fB5X+dDUOeAWOgw3yqLVh/MD6Z3z+s/phfNlmGf9LfaAyw7XddUs7dQc/6POdqK2keqxMImPtgUrBmZ9tqIrW8tcKRI/ay8SQ17XoA4eOoYleGSTK2x6KjIStebuolNjR9J3AJuDVikS2Dvd2JKOjhFwabp89t9+Tgep9kaLETF/6hJNLmR0EZ8HB7azOnYNhESwDSf4zA2baVvWoxFE2RsXUftd4vXfXhiR6+Ji3jTVwoQi8u5+xkhYsvJefXyJJ9VHgA+Q6rX1Eog+UxKdbDJkAjkV/mXvrcJvpHFo6mOtjF2+IGBUWDkD3E0GdqONSmfDP3IW2aC1wHz+qJfTI1aCjR8y9XZt81MnnzdpVe3W7VP5lcwrtGCxScqLkq45B1R6UFHeH4wX5NY7UExR01YFqGv+83udrhFSaGibqy7HK/oMADT+rJc7hibrYE5JTm4b7sCD1o6SOSSDjgdbBJY4OvTMuj9u+2gX0OTfBXLSXUij1+Kmqr+isM/zLmTfH6k9WOQtG8OTDEyZeIK/95czJ8PwRB53IPOMI+AfcKpni6xpN+vjqFa6+PuJE/buApMR5W5AOJKadFseo4XyDdTN1TJkeuXz16hGfmoRUrUKPe0tqqBrR47YiJE3U0HZV9FnQ0HcD0XNNG3vYNbS2CmnqP7A9wgqrEjig+BOHRLs+NyMJvuddTOi8gFmtPyVGRDrP7kTH/zOnogQluZ+KXDisICL2p5z/QwF4wWmTUNljQwKcAFyWC85sJGvHQ94FtwB7wRynoXBcjaaiao29SA5e57dFnYwzivdzrL7/8ePc5OpAwyACkDLcJ5sE3E1g9SyweQuLDeww5TpeuKQwY3cIYWL1flh6Lz+/cckkFWU+QK7jHh6RPpCSA3lS3WUxGqm8mSS5kV5uLijHr3WUiT56pACdMiYuPAzouGg5/s5UhvdlUNGaqHHg6WA7nzr6jzcMPU/d/DLDnzfFB/zZU+6cS+MMTP3yvP+K5HYMtNhj5i98ygxaMK7RkWRzR5jJmrVF9/H5Ird7VeMtfW0BI1kXU1dVHA17epgk5nsPjMY7usqEe7ADXW2EScMwjKaCMTKGEXteYEasves8YsFXND2WGPFXu3af8C0VdbYcwvTcy1uFrhXD9aP8/JNmrBShxR9MUo8vLjEPTVibevR88bn42J9IW2QVely1qrfh7kAd3OsXKqkIfyA/w8QSvxEO7Kmply7mGZINydNZjqH2SvVxA0ajltLam4zFVDGAp3/SdeSYyImBUaw+3sD6emp8dESgAlg9+j4nSmvpSKBpUwZu167VV32ndXBgQ30ikjOe7GMYOHZbAOh/4DpIwYM0z/W1amx30lk5lBuJ/xqgw85iCQEBGDoLwwMeBGtB3upmGPpHohnvBfKOo8cF5ccJhNkFiw5ZlJ9zjBnFzBbVzn7/C24CQWEhwVuDggnsN5ZLQEjI1uAQEVrIatgPHSFpJaFBv7pwVaF+sr591brVGzrhZNZvF7YVbhv9b06gdVjoxWCvKRXX3CsKp2O1jVvF+LaGRlx6evsYbPq26Zh85jUZXnduGS4ubqxF8wrzUPp0iRhfepbBJY3bxmIzts3Axm67KhOd2r8UF287TWNNI3Ny3a9VTPEK+hjq7va+cHlPjlvhOzf3UHOQV2bFNfcp2Tk5rR++TK/gC6HDfniG8l2vSKV3795sPG2vHuvvJw+UyllRq8TuSRLDCP3Fl75ucz8vKbjttGXJL6MC1GFjNIRmPhiyMWKMxit8pAW4SvdURfBuf4p3zhzP5Vxc9WuDb1ACUiJMXNpov+Pohs64eTJ72dA1/qW7lvX/Of2pweEzeFlEJuJkEHQh4Bt4RUwacFIO0Y8LwIkyV7cVbttOBHATuQEnt7nlCvZ0XcnyAvNrB/D5zfyAzS28t0S0rJl/qHjCBwA0K8d8RI/IhhNveS2bffkv3KIHnJhvnuSlaD4BwJ5DBt8c120nA7gaLtJY6Oq3Hxoog1v1zds3W3Jutdy6bW8ktVArUd7WrS25SsL/0biHzdjNZ17hInaAtzZZgwS1UAcDQ9Llyhj55NDTnP6iMhl2s/u3FE68uyvgA2iKC3QPHG5QMRT0wUZ5OfMpinHQFDMlTAmExRCW0NiVNMS/X6pP5k4Y4i9gxaWnN9AsTWp6g0zzsJKvS/GM4Nk7qGNfJsISv1DJawj3uk7Y3MJWqvnH5Ar/Ro/7DEVtxqqOrRddFAsVSUpUai+PQZMECnEjVvf4JLoWUsb7bqe8RnqdcPuC1nyuARXgOHocZe9Kfk8bXo8pXJtmnCqeHI4XzrNXW++ERYWPlVOQbAmLmjhORspPEafvXJMUmf3LlKwRrDmVdupaHOw8+/YsWLy1u/vL++5eO/hrxqTUSVNZWfVyzwz/jLGpkQqlDPU4wlt6xhkVp40WdSScsc+YBFbZSxQjgoRRaRYQb7ZewgRzg/6Yw+dfujznEBqaKoyaKMmo/Z9VeOcEupPxHypzqNzZ0gYOjyK8nR0Eroazy3Pn7ylE9LxNZ45ACBQVy/rt2Tu8OqxltpmBs5mDkziDyODu3dwWoX2fhFB7VF11cjZUk6rL+m2dcMLLhl7MRsWYMQLSO7nYqK6Tvim9lD0covWftcydqhjUO4tZuqv2GvJXzsFbCy4taP8DLjeLjlNuIYKbpQ+FqkR4oLuBF2g0Ntg8zTjveNWfQGSv8dFhTQhCyFB3gLVOscxkcoDy+uvINpdJp5o3fGSAvL6ieOJmjRTcrTCzdMoaMRBkcLHcIUKbAmxhcWGjCEDnoVZ8bm4jZymYPABiHNoUsLSLKOch57/Ulk8OLjIVOXLHStHlBor9HBhnVaPfEBTrgAQXOx7byq1bWOCQcQ7o9NDP6UneIUwsqUCJ2IQXzz6LUax7wOfgfHtbZit268AM2bECBGBngYLX75Gtl67ABcHYPVZj3tUicSSR0h64gp1vLta0kinuyrRYjM04DRGT9rNanjFaJ6YDyvzk6i4fRiGIRp0OJEpFkim3w6SXWZKTGyePdZ81nJKSMrTzgdADEx29N4yjDO0AF+E/vs3MdFtbCeSx7Fs3rh6IZKPu7lsnjN5hV6AMsEFgIDgMf8YeTDIV8V1AKaoMtyTViIL2lM4Sv2QpssrBminuzgbPvmdbttshd5L3GrWCh227cVQoBWINZ8DIGilgb7MFrFqvImERUrnG2BKgFdfowIrO064kFah5QCErilqFv8D01U9raSuYjHWUZuis4nuA7gOmibVlDGPciBwrPxzWbrNs56CBcsKLUdcha51853tFEA8GCRl+2ohRAYr9s+yvq7ooVml13N6qIAO59+DkWU1phEWhCtLqFFM/O1SExwoVJTur1uADitIwSM87mgxnC3tcSE6llDJ6trOCHUb2HY1HUzn60rT0SU0LqqCOVpV06BA6Cd3VCKMp41FNqqopBL2mUFXDAkjfHk0qevm6pdP0oNCpiZgedJlTeJwl9KlCZEqbGJZOscU48gQDUpIbQllDUeRBgMAB4A3ZEEzCjur60WyRF8Z7iqMFM0MeIIGqb3hwfNL3cvx3djaiRlT23lqr2igbpibTKRHNcYOenWvxF27s3cw3bvBNfcs0nMiAGGEWfbX0jB7qcb47oGbrMSw0qblNTIGDJ+7f5ztRndIJDQ1y9T6pssiV5O6SGhmWa6UVrTqR1WmMdJsFhuqtD1a4kztMFguxsnZ3pU2ElODqWJJSoZ3NJl03TkaxsOt0YuUyDNmsze3a3TY2ZVksdFKB9/u91qVH3uYtXebX4B16w9qarKrIzvqCWcahw2fWyU5n8IfJqafUiRjrNuYQKbkihjIFq2llxYqlNYjIWi8LtRWKp0PI84mk2HybJoD0pyMOO1gsZD3rlQqSejGd8iSDuQ0sqskdMPXRhukmEbVZpl59O5ga6Sb30u+JpMVFhBfb57M1A1aRQgBUcVGLJj0f1lAQbNm6nqakQLq00R3qpNNSJ5LsOTMvoYv2BBtfMefcmrUSo1GS6uaR6BKK39NKjSMpop7VafxtFxj0aHdXZn4bKJx3WFdGVhMX3lu3Ud4RLXyHHoJp02+in6AMVnSsVKsMViezkuFth3gmWMuLxZxFjDg7gp3ZtqFltMBpbXXJQcYTjTgBKgOgcdLQre3sTY++ZycfXeFANMWCgyEJCKM5gPNhrfjm+wRTmMU2MJtiAwPuxWx13di2kwlGjQiCYN5brxW1jlRaVcU4QIuNPq80lMKL0EJXhw/k4dXN1c5RFVpBO2t5tj+8oW8A2+c3modqNzfHvGjEAbeRlIgnPXsRwx8/DltbdwdcCrirl/SYtnzdUcZKiE08qtI4APZGeaUGM+0twMvwhFGDAWud3YyBwzCvuoqOI9+yCa0SxNtwpMtYswMHRukZw2kJmPak2IAdmNxP9PpK5M+5H/eaHOT5Facq/r8/QlNLO4A0QjReK8ps2dkgX9Stdjj23+i2Te42JrQMUWlEnBMTeXpN4wZSeRdexJabwVLhgc3LahS3QoQD9IJZk4VlorEWVWIFUTeztURVQeZSZJb0qMCbSSQ2liWczsBhxXQuEEXAsMisbmMESqQoVv4CaqCZ+lS8ruK04Ao1AagzIG9AK56MrsAZwIgY1DCfvFJk10iXLNr6tcWAnizzjmjoQhRM02jb3wE+B1eUbnqY9Mx+RgGnM6CX4jsPpqpObEOJlODFrHxQXikWlhRYJgoGBhbbpJ46nRm7uLkVYuKRDX2uMpbXLIUMoNQiZUFIOHmgk0c1ANYDo+Fmx0Q3mjJ0CU9rG1jZe2HX6f+9s9cgUFY6LP/hRRzkxeDmKeQA1/G/N0m1zVznf4s35JHVi6Hg1LrLsCn6EGhQlgeG1lUWWh2CNj+mZSeGjqdymOClYHkg1WEKuaApf1Gn2XasF13PMheS4omklQewvtJEkyyjxuPto2EKFxHTAOnCovTJZtfr+6z3y4IJelqSK+zQWXx4mWi/aq4WJO7jIIt+DAr3O9EDYhYMJJbc1vhj1mmppQHwOrIgmaoLsuIzLtD4NKimMSAYWBxQ29YwwwUKhpCaSuZ5mLGCBMynDYGYYolFymsMzJVpvmm5FSEQdANkswTO+UyDKJqTXWiBgWdZnsXgixWfpgrApWYwIp0qu4nmUgFhIciUJQ+r6IoIRAw2kRX4O6nwoYPq/8KwAXgol4AsN5VjDiUNJXD1RFOpiRBTf45FZqbJAC9B5u8sv64/p+cFCgLON4N8xtjhCv8vFUL/txUYfG2+HXd54qmHzrnksmeezxcPpMJ1/f4v6VpZp+hVHFw8fK7cuPPgyYs3H74EhBAojAhOjCAhJSPnx1+AQMMECRYi1HAjjDTKaGHGGGuc8SaYKFyESFGiKSipxIgVR01DK14CHT0SREmUxCBZilRp0k0y2a8yZKq23gbn7fbGRoW2KbNPja1arfOnLyx22GOzf3T6rFy9r7p9U+WAa644aIqpfjPNDVmuuu6WJs1ueivbXbe1OCTHJ7974J77cr1nssV0eWaYZabZjOaYZ675FlhkocXyvVNgqSWWWWG5RpVWWWm1NT4wO+OwI1546SzaI48ddcxJp/zruBP+s9bfNtnvfxdctD0GkJBSIKOIX+30h7/ssleRYiVKVajFqNPgtDslfl0zIGZtYPRoMNEQGhobfrbPb4NhWTtrgAmhwf7EgVyNAOvxdhq9dW2QicYaAA==) format('woff2');font-weight:normal;font-style:normal;font-display:swap;}
+@font-face{font-family:'Geneva';src:url(data:font/woff2;base64,d09GMgABAAAAAAvoAA4AAAAAM6gAAAuPAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGiYGVgCDNggEEQgK0wjKGQuCDAABNgIkA4QUBCAFg2kHgkkbMi1FRa2cnCqR/H9YboqILj+A2kIJjjCjQKIRYjOzUnF0V7yBcBDywCYPz3D68G/z919Jx34hVkLEFcJ0Z/qb+3h4fn/UuW+ENTIY9dNSadpazmYSEhiafP7v3f1b926sIZoGOsk6Wfws8TzrA4XxgyDm9gsFOmnHdW9LYybYENfSIDSuKxQ1mXsDmFte+EoLJP+dRLTT+MKrfz22jq3LR714l2Pp0DW/Grzy4iv3M5hotMFaOA3W/wDjAhtIxAW+NpFl2yyL8TiOMkaR8QwRkP+/ZbWH65q5vpwUqSErTphdNAqLwyHU9lT/X2+nOjx6iRdy/vO79qqmenm9l7I85BlDzi4JxUNosFiEtBxj7v8XjtebvIELCU8kvIhONP5af0oEvA0eBx7cmhPgRWRZFihFTSFWCEuFXCQEAhHtmD8P0q49ARvE946faBsiSX4O/qwCIflWbaaeJsjEVgTnP1Qk0kLYXZDDsvqt4qKO4tfmbUVtMk6h+d6uu89rPvFV+OT2de5BGxp7Ou+udOFn4f1fcfrD/88R++zUQsvPb0eA6vjkCZZOtLfMZEcnZ9OnW3YGIp/wSiIhOS3Iyc3LL4izGHEx9fqL6IZp2Y7r+UEYxQAinKRZXpRV3bRdP4yzvaJqumFatuN6fjaXLxSDUrlSrdUbzVa70+31YeZs+IvMW8AfPnHoeM5p7nbJYTT3OewxYgpgLOa7DtkA46YzgIWL4EsXW+IFTHNq03SK+I+1ln1uFBNvoXJXUGUFYF20wEmD++tzByRpbFkLu20ANOlDGx2sGOx1MYZ78Qh50qWO1NZNQTfZqaABOnsR7TzZ5jRG0SH00EnsQd0WQCXrEOkwIS3SjyK2XyoKf8KLgWkY0FBY3rAbUnUVoJB1tz7wgTuCvPAPgqQ5anERHyQfYoJBwIeg1h6gi5jtqwhNZM/J0tdxLkk4xQLFFLnfiKLA5EAiYPhYNqesD9BFfyGEat3vSuC9vqUkDvsD5/uca7xXP/Hhbfzw8JaovMy0I+YTCAN3/SHIMlaHWHHD9mmf0H3CaRbnthJ9dM5m4jiUXXS58oR7isn4iA2YZWgcA/lWTidyIX0Ie8EIXKy7HB2utuH7oG3tMATZaz1MA5X2DnmZluvzELD7N8fv8iUdY3aAyyvAur9BJiM26Fb6oZye5NS3ulJ6Yn1cofjVsSSdj3GfPprITJIIwJkITYSV0jS+T5NpdPKM3mXxQ1Atk8VBKQjQa0VjY+NqOTCypNodNVE5RpjlZSo8qE2WQpPwku4PLCPyBzR5dGRLdXnk0ApIrM8TuKDf8PpmXu/srtjOwoZbpATRDj7poV66QBMDErDzjGYSFZCtjJQZkCsjCIAKtlMBFTFTNthPW9OlkJTgozfAiXQ3A+fOeruzSZjaZxvRwjddWvgifa7TpM5UCYeA+5qU2tsQuNVNYGLuxWxHKaRJwkPmChWrU/IAU4iIL+0IukWSvvcVYOYJGeYIj9wim7XCRCopO4mBs0HwHfWE2dw5ux82RUchn/JeS3sExGcFDBEJde9q/LU8VpjXFkgFggzZxGLoV/rSS7hwF0Ll2FRyOq9Q9ht2G5Yxn9MyjtfQmtwiNOi4MKLmoVakvSzpRmAoABhAXmBqDXA5SB4G2yi9IMfAuXdEnjoY12QpA6JXIFB4jU2TE7KwJRyBFegUSIfnL5CoThZ8eIeICnVznmVlNXuofisQQIIJD6oQUp7jI8vVWsKpqZ4VacZQ/5Am21gJwCr6JBVFGxDtpZ5vWoV+T+oJ5ZnNg0Yb182CKtCw2CM4AwZPvEOXMCKwC0iA2tN+C7FO6CONAnhntVVfhtGMPvUxqiR54EPA9JAWWDVK34Vgvry5IuYj4HNVIzQ+94SXj0k/QSnPoH/WigUzoE+NbDeH3gebqWmFPqGoCh5XlOYdMfuGptdpL5JjRu7oUU2GcVqzEryey06qQre2XqhaUGweIqIcbO6ZHS5vBeYVM0UllfZMbntIwB8rI2UhoPIBMJZ0WoK7I2WkRKOKsXgRkWCg1iMMqLtIZCaxIakKpnRIJhwI9shnydURNarfIXhgp/SRDMpooKhA43oqhRJP2qR8PRGPa+JoNAjFXC22S6EWIJkbCm5T8ryhkp2qAfBUHDVFCD4+5zHCx2uMN/nljPKbIscIc29tQZOAJC6qtAVyyzTY+qQ+CRS4TYOm84AiylAkC2x1K7sFUdfaGprZK2p597K2o3lWRCVfriAyblI/LuEXNxJ4awS5TCpJgpe2UAtrYQZBpIKJRnXhBQomFbDDEEBG0lWjNFKi0aChSBNuxF36Li3IBWLCF8zNhT06E+AqqYxrQnBkKaWMJFjFoYd9aNxVSTf9Iqj6Jom+Tz5qC+fyO1nhVExvX3oT0Nn2dn3IZoqQMBUoGfTSujavrdINQvAmNilXRkbasiharMFX0afliIrHLwHIVwHOijjoqb9HG5HJL3kvXoMZGV+KNVPPSyGBR+NRxrxhj9kibdFe3xWmI0xhC6mumQhOIMi3y2oj7Ir2Vu4MVgeRcjL6cuKMgxBbb9GaxS4kXT3w4fozm2scUm3cJC8ytdylV3s89S47WgaavOZFcb73Z0hV+sx485Tbd0Hl2446BOp5q0bw0+E4OAfO+Wr1LpNxUlxIDamQ69HMN+/FSaP6vuHUqP54QMaAo5IOXD+dDGE8GV0CwIjjGcjdv95eqmCi/hRohQG/PDAlE/pcIvjFQuhSmTHspaqne5HsGR4tVAyJd07nCAHPOai5P3GRosHu1dyZe41FHgW6RoXMgPAu4BxDNz6X2fB5s8Le1A2+D8WciTDh1OP6cu7IokLlx6a19tlsxdm0gbT2be8XjyOLSkam2c7OsuPpm5qxeKKDDD4Xr2wHFxdPw4sT/A2U6zCh/iB6nG388sMuah6WGZMpU6c5vMe2xG+bIjZYPJwtZFgWramugtzg9uPSIuq2yDhJLBi6QjEOwHma+rlgaEmTEv6yZ5PRpnxXLTRoh/+G8O3GQHry3qXPY7uNuN/SKl8kaU8aGEbG6YnMYGjiv4baNL8iKP06t0LIXb9byBjL4HQcq5F0DOUXrq6JWl2kXABaybfinDsePFB52rwXuCMKp4R+YgEW0OxlUBqNSIWnw6V3blEuTjkMGDpTWOFRVR4/v7SmmCfD7KUZ3mWBz17pTYLFTf6AVE+W+FuXil+o8pGXD2JsMFu9+2hVdjYgee7e0eiEpqlQSsev9Lz3DW+F2WmZ0MH/NLpVnTph/rmOXz6PLP+gS6Fl+6eU63fqIea9r07h0lBXK6clDPV4Kz/+PLSZfyODYGyn7eEnvPrLXD9/9+Uc3Umno1ACoe0fW1hFLv4fJAL+S5bFdKJADILIwEICsfAwJWUFGZU33dCzs/Y6C9+HWCvLqYYEaYrTSzOmzNIdMsN3qmpn9qMtxY326u9KR2QIXWmHcmJDlokOvBGS4hVSOnmCnnDjYlOGvX3DvJW1U+zyzMeo9m3c4EFgmf5C6C/bH8nEYE6588IuitWsR6FcpyjJVxHlqOMe5Sr3PMpTyb9Pz1cezcCJ3CJUh09RqC+JklK9oxxtHKNc9b2iPA19f3K++qHpYm5l7EixtXUyQ5dRq/Hx7zE+8OGdzW2MjB0cucZFtnvq8lfxlo8Px7/QFz9/EvQyNjJ3tsZ/x/QzTm0Jmkyij7QfTZuywZ0fN7e1Ierp6euIq3rw20NbEcIA8dEcYSThL/v/1Va+7PcB8M8C/gcqVKRYiVJlylVSmUKl0RlMFpvD5fEFQpFYIpXJFSqqauoamlraOrp6+gaGRsYmpmbmFpZW1ja2djIUKo3OYLLYHC6PLysnr6AoUFJWUVVT19DU0tbR1dMP1hFLLXPVdt9Ybr019jnlqNWW2GJd5FjpNqcdNsTDUE+rjPcywd8llyM38gqm/c8TaOqx5fMx869AOw3r0wgh) format('woff2');font-weight:normal;font-style:normal;font-display:swap;}
+@font-face{font-family:'Monaco';src:url(data:font/woff2;base64,d09GMgABAAAAAAloAA0AAAAAI0QAAAkOAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGhgGYACCXhEICqwEn20LgUoAATYCJAODDgQgBY0WB4F4G3wbRUdzjwOZbDrB/3UCN4ZIfaivUnAoimLBgoXaRCNqPGpsHMqazN+mD/bauxcsH1gRavT89pRJ25cx/73oFRAnOMTRlvZ9HkH9Wvg9b/eIQoQbdEDk4lJRqVMhhUJFxXH5kwH6XxIKRwD998ejmx8HJZO7MwFL6iV8B7Ba0Iq8MyX8jBfsZsOCwuC8K5R70EHk8pDzTX6/7Xb7NsEytXzsId4ioRT0YCiVacHviahg4JydnlEnTAEHDljt/4VKsqxNgZKh1z94bqi/wCoe1Xr1+r9pzWYotY+DLhTOgLC782fy3+6/Sa7t9dDaHmrvVP8JZTZ33UGXWBy+FdmqETi6qkaBUB6hNJtMs5hk/wCM3hgjjCIE6KjbTb5jPhECvvj6+R/e//r9z97yAU10ZUJ+nRSr4q4Xecpr/2/WPrHUO1oIV/YhFP7B27++fYqgwqRJVO6GRB8BUaAwiYwMGcaRwWGZwDiadSRVVQnTfZPwL0ySTAL/7t/9AwFynHYGnHWOKBOASEgAgCDLS+VKVa3eaLbanbeN/gdJ/715fhBGcZJmeVFWddN2/TBO87Ju+3Fe9/OuRc3hEGFCGRdSaeO4nh+EUZykWV6UoLDDmnNVDSIF4/8VYOz5h79CbKZ8hMpBmPtXo0RAonqdJSAyKIluS+gNlBVpYGHUlam3iQedCwgaRPA2MAB2wlZlyyBSY2msEgHbwH60jBGTKvkonh7PzQYrlG2ryVl99nXV4/jITH7jBONacw5y0+SWXRv/qeluIrh9b8KZjUOIJQPXit5lR5i8vbbHJj4N8x4M/QR0OD7nnzlqmlC4vEVSvvsvfSwiBUJOXGnLiBCo5t6hBmGmhkzlkzzSbmH0DV24nKc7fAMh48tgI0SnnLvQiDI0kfIYZA1dM8QA220UCEA/Ucbg2gMDDQOIUBsZpNG0v0VYeIzObe6Tb5DCRXSIxDkvI0nAJhmcFzDnTFS8eJdz5IB0dcYRuBBUVBDmUZKZH5IZhDtDWxyWIAtRSnE5Q9GbtMAZB+qXaxD4eikHmzLEqdwEl/uRxwVVIOMsNL4Yc3sW2d5URHUwCgjSrHPXOPgadEN7yA4FYp6pJUHyTI5vioKSgcWLDRsTRn5UrEeBk1JJIqaALYmY4mqQCZAmQpoARdikDXTVlMBxemx2lKTj3uAXVMLA+KEoyfcSsTthHQIKRE4/xllXDM0gpQUhBuJc7EFaoxkSDFDfGU5HHFUTLn7m+we2tglTBvFwHSMvTGoaLXHWsYzKOCWm7BgjlWkMFMdogcSrpdQwWPAR1wIjJSHkhoPC2vz/jirbqcnsMoWXaDeS1bCrelpbKHSOitk/EhRada71HDVHUQWMiWokRlSQ2a+OmTv5zu57RPALCBbAgUi8lvZiZzdlhpkA2iHtE9Aj5v8DcwE5HtYaaqEC8HRjE4ztvTVqBhbQjSqoLQUb/LUfHT6tMXsCqBxhzLLe6fEE6u1m00gG4rjponvt3CrIBUsOjvsrAfz2pov9Me0vHtQNS2/tPebmBkH28SfvJBdV8mwqWJiMumGAi7dA1GSBSla8V5ymmJZlGWsL7aJtExbMouswW2xadlhU+/XuQbeDp5binIsBtHWp1YLNNsbhVDMgQFpnhcHoDoNb5mxppghGmEQrCXK2FzNgvxr7smivHqEWWZUv/5riV78TwOmnThAiM13A6sUFQHlMC9tcKpPPITsw0tRw5jT18AohhJrImsK5IBIehbzsdz+JPrFgehe2RgODaMYfyHHAsnBHFj0GpA/TYbW319o7IftFSOSmUhEyJSiOd3hEAi3pwe6ObbqN1WAdiHuB9MPWGsRoG1Bgry4JmaJFf91NAOqLu5VJmhV4oigoUBQRkFAaKJh17st7aK+94egWPtU4xOk3+8veyAwPe0DFgZwecPQTZyGVeB4FYZMHashfWqHTX09RSlxCpsIzHN95yFkxyZhqkIZQO1BJxkWJcxkmic+AZcm1lU6hIsrf/Pcvth/fX9f9Op77ss8fgv/zaIKqBILk/0Dq47+Bogdm9znyhPmxQLJF3yuEWoNsakAIwsAY1wD6WcB/vPFONtvZ+hDDDeyB4LBdkRh2UuFJuYS+O6Cld9/+PG86IFFYb1Lc8CAaYwUkQ9kpmVRclZmeRzLX9rksafhTlpVjqKxYFw9l1fD4V9Y00lxZNzPdlA0j07eyaVF2RLbMyr6SbQvycw8fanb+iyeR17CMNzI07ZFJ20WZmeK6zI3zUpaM8L0sa0ZJVlx7GCOr5sRnsmZEGirrdj6ulA0L0hPZdPrxd9my++mObDv+XHp3Q+19vu/jM+kNPiZGoeTQhdAyNLpqjqSya8VCkRi+bFu8iNboX+aoNj9KgR16Xdtcf73PlU6oHthLKzwwowl+Nn0zsL3V9Zw/zuRB0eBdedtr3N/P8Ck4onK/VMbQjUP21fEgbWKZ1l0p4gvhDvi5Iz+k3h9QXG1YJD6UCjdaS+D7a9S7o4M/Z0SiUuwmOsNqYNCvdYP7eqFBRy3pxHy/sRSvu1ffU7f/8Hdmw7OV/fDF90c7tvIEXOY4g5VA4D4U194M+XyjFu6BqnsTZOOqbYT+YBm4mPKrgWPwz197cJT+iV7EWHWUHoyGc+WMfe4SR7fNjB9y45+pqX/+tZe9xiV1xpJeJddnCyMez1Rt6iijNkrgcIrESvTCCYysIPbv8hKYyyRSiUxirIcNPGv/8+eHBPMsSZMM2GKi1UHPSaDtQGzbZ5HW3COZUfYfiTojgaJ8c82jqAO8ctNsLPb+ubdw3zu/3oqJFSVNDahcHTr6epNC0KNQyklakutLHx5LCCTrLQwe/G2kCjUouG9m7ldlLreXH8+KIPHDANguA8nUVKTRY7EVa0bnKP3SBmX6am9RpV9yUeuzGMe+j2k3eD3sLmmK/x8CvkHh7/jVQ/mZLKu+cWw/fIk3pb4BCXBRotD9/GyIFJls2/o9U1XX0NTS1tGlM5gsNocLgBCMoBhO8PgCoUgskcrkCqVKrUm0ajl9IJPZYrXZHU6X2+O1yWZbbLWNCoRgBMVwgqRohsPl8QVCkVgilckVSpXP7/GWx+2+JquatwEAAAA=) format('woff2');font-weight:normal;font-style:normal;font-display:swap;}
+      :root {
+        --chicago: "Chicago", "ChicagoFLF", Geneva, Tahoma, sans-serif;
+        --geneva: Verdana, "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --mono: ui-monospace, "SF Mono", Menlo, Monaco, Consolas,
+          "Liberation Mono", monospace;
+        --plat: #d4d0c8;
+        --plat-lt: #e8e6e1;
+        --plat-dk: #9a968e;
+        --edge-lt: #ffffff;
+        --edge-dk: #82807a;
+        --ink: #1b1a17;
+        --well: #ffffff;
+        --accent: #4d7357;
+        --accent-d: #33543d;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: var(--geneva);
+        font-size: 24px;
+        line-height: 1.55;
+        color: var(--ink);
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        min-height: 100vh;
+        padding-bottom: 60px;
+        /* platinum desktop: soft grey with faint pinstripe */
+        background-color: #b7b4ac;
+        background-image: repeating-linear-gradient(
+          0deg,
+          rgba(255, 255, 255, 0.16) 0 1px,
+          transparent 1px 3px
+        );
+      }
+      a {
+        color: var(--accent-d);
+        text-decoration: none;
+        border-bottom: 1px solid rgba(51, 84, 61, 0.4);
+      }
+      a:hover {
+        color: var(--accent);
+        border-bottom-color: var(--accent);
+      }
+      b,
+      strong {
+        font-weight: 700;
+      }
+      ::selection {
+        background: var(--accent);
+        color: #fff;
+      }
+
+      /* ---------- bevel helpers ---------- */
+      .raised {
+        box-shadow: inset 1px 1px 0 var(--edge-lt),
+          inset -1px -1px 0 var(--edge-dk);
+      }
+
+      /* ---------- menu bar ---------- */
+      .menubar {
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        height: 36px;
+        display: flex;
+        align-items: center;
+        gap: 24px;
+        padding: 0 18px;
+        background: linear-gradient(#efeeea, #d3cfc7);
+        border-bottom: 1px solid #6f6c66;
+        box-shadow: inset 0 1px 0 #fff;
+        font-family: var(--chicago);
+        font-size: 21.5px;
+      }
+      .menubar .apple {
+        width: 24px;
+        height: 24px;
+        display: block;
+        color: #3a3a37;
+      }
+      .menubar .m {
+        cursor: default;
+        padding: 1px 6px;
+        border-radius: 2px;
+      }
+      .menubar .m:hover {
+        background: var(--accent);
+        color: #fff;
+      }
+      .menubar .appmenu {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 1px 6px;
+      }
+      .menubar .appmenu .cl {
+        width: 22px;
+        height: 22px;
+        color: #3a3a37;
+      }
+      .menubar .clock {
+        font-family: var(--chicago);
+        font-size: 20.5px;
+        padding-left: 4px;
+      }
+      @media (max-width: 620px) {
+        .menubar .m.opt {
+          display: none;
+        }
+        .menubar .appmenu .nm {
+          display: none;
+        }
+      }
+
+      /* ---------- windows ---------- */
+      .screen {
+        max-width: 1040px;
+        margin: 0 auto;
+        padding: 40px 18px 0;
+      }
+      .win {
+        position: relative;
+        background: var(--plat);
+        border: 1px solid #4a4844;
+        border-radius: 6px 6px 3px 3px;
+        margin-bottom: 26px;
+        box-shadow: inset 1px 1px 0 var(--edge-lt),
+          inset -1px -1px 0 var(--edge-dk), 2px 3px 7px rgba(0, 0, 0, 0.32);
+        padding-right: 24px; /* room for scrollbar */
+        padding-bottom: 24px; /* room for grow strip */
+      }
+      /* platinum vertical scrollbar (decorative) */
+      .win::after {
+        content: "";
+        position: absolute;
+        top: 31px;
+        right: 1px;
+        bottom: 24px;
+        width: 22px;
+        border-left: 1px solid var(--edge-dk);
+        background-color: #c9c5bd;
+        background-image:
+          /* thumb */ linear-gradient(#eeece7, #c3bfb6) 0 6px / 100% 110px
+            no-repeat,
+          repeating-linear-gradient(
+            45deg,
+            #c4c0b8 0 2px,
+            #bcb8b0 2px 4px
+          );
+        box-shadow: inset 1px 0 0 var(--edge-lt);
+      }
+      /* grow box */
+      .win .grow {
+        position: absolute;
+        right: 1px;
+        bottom: 1px;
+        width: 22px;
+        height: 22px;
+        z-index: 3;
+        background: var(--plat);
+        border-left: 1px solid var(--edge-dk);
+        border-top: 1px solid var(--edge-dk);
+        box-shadow: inset 1px 1px 0 var(--edge-lt);
+      }
+      .win .grow::before {
+        content: "";
+        position: absolute;
+        inset: 3px;
+        background-image: linear-gradient(
+          135deg,
+          transparent 0 40%,
+          var(--edge-dk) 40% 52%,
+          transparent 52% 66%,
+          var(--edge-dk) 66% 78%,
+          transparent 78%
+        );
+      }
+      .titlebar {
+        height: 30px;
+        display: flex;
+        align-items: center;
+        position: relative;
+        border-bottom: 1px solid var(--edge-dk);
+        border-radius: 5px 5px 0 0;
+        /* pinstripes */
+        background: repeating-linear-gradient(
+          to bottom,
+          #eceae5 0 1px,
+          #cdc9c1 1px 2px
+        );
+      }
+      .titlebar .btn3d {
+        width: 18px;
+        height: 18px;
+        margin-left: 10px;
+        border: 1px solid #6d6a64;
+        border-radius: 2px;
+        background: linear-gradient(#f2f0eb, #cbc7bf);
+        box-shadow: inset 1px 1px 0 #fff;
+        flex: 0 0 auto;
+      }
+      .titlebar .zoom {
+        margin-left: auto;
+        margin-right: 7px;
+      }
+      .titlebar .name {
+        position: absolute;
+        left: 50%;
+        transform: translateX(-50%);
+        background: var(--plat);
+        padding: 0 12px;
+        font-family: var(--chicago);
+        font-size: 21.5px;
+        white-space: nowrap;
+        max-width: 66%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        box-shadow: 0 0 0 6px var(--plat);
+      }
+      /* inactive window state */
+      .win.inact .titlebar {
+        background: var(--plat);
+      }
+      .win.inact .titlebar .btn3d {
+        visibility: hidden;
+      }
+      .win.inact .titlebar .name {
+        color: var(--plat-dk);
+      }
+      .win.inact {
+        box-shadow: inset 1px 1px 0 var(--edge-lt),
+          inset -1px -1px 0 var(--edge-dk), 1px 2px 5px rgba(0, 0, 0, 0.28);
+      }
+
+      .win-body {
+        background: var(--well);
+        margin: 8px;
+        padding: 28px 32px 32px;
+        border: 1px solid var(--edge-dk);
+        border-radius: 3px;
+        box-shadow: inset 1px 1px 0 rgba(0, 0, 0, 0.05);
+      }
+      .win-body p {
+        margin: 0 0 12px;
+        max-width: 62ch;
+      }
+      .win-body p:last-child {
+        margin-bottom: 0;
+      }
+      h1,
+      h2,
+      h3 {
+        font-family: var(--chicago);
+        font-weight: 400;
+        letter-spacing: 0;
+      }
+
+      /* ---------- hero ---------- */
+      .eyebrow {
+        font-family: var(--chicago);
+        font-size: 18px;
+        display: inline-block;
+        background: var(--plat);
+        border: 1px solid var(--edge-dk);
+        box-shadow: inset 1px 1px 0 var(--edge-lt);
+        border-radius: 3px;
+        padding: 5px 12px;
+        margin-bottom: 20px;
+      }
+      h1 {
+        font-size: clamp(42px, 8vw, 66px);
+        line-height: 1.1;
+        margin: 0 0 16px;
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        color: var(--accent-d);
+        transition: width 260ms steps(6, end);
+        border-bottom: 3px solid var(--accent);
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+      }
+      .rotator-measure {
+        position: absolute;
+        left: 0;
+        top: 0;
+        visibility: hidden;
+        pointer-events: none;
+        white-space: nowrap;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .rotator {
+          transition: none;
+        }
+      }
+      .lede {
+        font-size: 24px;
+      }
+      .actions {
+        margin-top: 20px;
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      .btn {
+        font-family: var(--chicago);
+        font-size: 21.5px;
+        color: var(--ink);
+        background: linear-gradient(#f4f2ee, #d0ccc4);
+        border: 1px solid #6d6a64;
+        border-radius: 8px;
+        padding: 10px 28px;
+        text-decoration: none;
+        cursor: default;
+        display: inline-block;
+        box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 var(--edge-dk);
+      }
+      .btn:hover {
+        border-bottom-color: #6d6a64;
+      }
+      .btn:active {
+        background: linear-gradient(#c9c5bd, #ded9d1);
+        box-shadow: inset 1px 1px 0 var(--edge-dk);
+      }
+      .btn.default {
+        outline: 2px solid var(--accent-d);
+        outline-offset: 2px;
+      }
+
+      /* ---------- generic list rows ---------- */
+      .rows {
+        margin: 8px 0 4px;
+        border: 1px solid var(--edge-dk);
+        border-radius: 3px;
+        box-shadow: inset 1px 1px 0 #fff;
+        overflow: hidden;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 200px 1fr;
+        gap: 16px;
+        padding: 11px 12px;
+        border-bottom: 1px solid #e2ded6;
+      }
+      .row:nth-child(even) {
+        background: #f6f4f0;
+      }
+      .row:last-child {
+        border-bottom: none;
+      }
+      @media (max-width: 560px) {
+        .row {
+          grid-template-columns: 1fr;
+          gap: 4px;
+        }
+      }
+      .row .k {
+        font-family: var(--chicago);
+        font-size: 23px;
+      }
+      .row .k .t {
+        display: block;
+        font-family: var(--mono);
+        font-size: 20px;
+        -webkit-font-smoothing: antialiased;
+        color: var(--accent-d);
+        margin-top: 3px;
+      }
+      .row .v {
+        font-size: 22.5px;
+      }
+      ul.list {
+        list-style: none;
+        margin: 10px 0 0;
+        display: grid;
+        gap: 8px;
+      }
+      ul.list li {
+        position: relative;
+        padding-left: 24px;
+        font-size: 22.5px;
+      }
+      ul.list li::before {
+        content: "";
+        position: absolute;
+        left: 2px;
+        top: 3px;
+        width: 12px;
+        height: 12px;
+        background: linear-gradient(#f4f2ee, #d0ccc4);
+        border: 1px solid #6d6a64;
+        border-radius: 2px;
+        box-shadow: inset 1px 1px 0 #fff;
+      }
+      ul.list.checked li::after {
+        content: "✓";
+        position: absolute;
+        left: 3px;
+        top: -1px;
+        font-size: 21.5px;
+        font-weight: 700;
+        color: var(--accent-d);
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 20.5px;
+        -webkit-font-smoothing: antialiased;
+        background: #f0eee9;
+        border: 1px solid #d5d1c9;
+        border-radius: 3px;
+        padding: 0 4px;
+      }
+
+      /* ---------- code wells ---------- */
+      pre {
+        font-family: var(--mono);
+        font-size: 21.5px;
+        line-height: 1.6;
+        -webkit-font-smoothing: antialiased;
+        background: #f5f3ef;
+        border: 1px solid var(--edge-dk);
+        border-radius: 3px;
+        padding: 12px 14px;
+        margin: 14px 0;
+        overflow-x: auto;
+        white-space: pre;
+        box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.09);
+      }
+      pre .c {
+        color: #8a877f;
+      }
+      details {
+        border: 1px solid var(--edge-dk);
+        border-radius: 3px;
+        padding: 8px 12px;
+        margin-top: 14px;
+        background: #f6f4f0;
+      }
+      summary {
+        font-family: var(--chicago);
+        font-size: 21.5px;
+        cursor: pointer;
+        color: var(--accent-d);
+      }
+
+      /* progress bar (platinum) */
+      .prog {
+        margin: 16px 0 4px;
+      }
+      .prog .lab {
+        font-family: var(--chicago);
+        font-size: 20px;
+        margin-bottom: 5px;
+      }
+      .prog .track {
+        height: 24px;
+        border: 1px solid var(--edge-dk);
+        border-radius: 8px;
+        background: #efedE8;
+        box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.14);
+        overflow: hidden;
+      }
+      .prog .fill {
+        height: 100%;
+        width: 78%;
+        border-radius: 8px 0 0 8px;
+        background: repeating-linear-gradient(
+          -45deg,
+          #7fa588 0 8px,
+          #6d9678 8px 16px
+        );
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+      }
+
+      /* ---------- diagram ---------- */
+      .diagram {
+        margin-top: 14px;
+        overflow-x: auto;
+      }
+      .diagram svg {
+        width: 100%;
+        min-width: 460px;
+        height: auto;
+        display: block;
+      }
+      .diagram .node {
+        fill: #eeece7;
+        stroke: #6d6a64;
+        stroke-width: 1.2;
+      }
+      .diagram .box {
+        fill: none;
+        stroke: #8a877f;
+        stroke-width: 1.2;
+        stroke-dasharray: 4 4;
+      }
+      .diagram .t {
+        font-family: var(--chicago);
+        font-size: 20.5px;
+        fill: var(--ink);
+      }
+      .diagram .s {
+        font-family: var(--geneva);
+        font-size: 17.5px;
+        fill: #55524c;
+      }
+      .diagram .e {
+        font-family: var(--mono);
+        font-size: 17.5px;
+        fill: #55524c;
+      }
+      .diagram .arr {
+        stroke: #55524c;
+        stroke-width: 1.4;
+        fill: none;
+      }
+
+      /* ---------- demo ---------- */
+      .step-h {
+        font-family: var(--chicago);
+        font-size: 25px;
+        margin: 22px 0 6px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .step-h .n {
+        width: 36px;
+        height: 36px;
+        border: 1px solid #6d6a64;
+        border-radius: 4px;
+        background: linear-gradient(#f4f2ee, #d0ccc4);
+        box-shadow: inset 1px 1px 0 #fff;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 21.5px;
+        flex: 0 0 auto;
+      }
+      .field {
+        font-family: var(--mono);
+        font-size: 20.5px;
+        -webkit-font-smoothing: antialiased;
+        background: #f5f3ef;
+        border: 1px solid var(--edge-dk);
+        border-radius: 3px;
+        box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.09);
+        padding: 8px 10px;
+        margin: 10px 0;
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+      .qa {
+        display: grid;
+        gap: 12px;
+        margin-top: 8px;
+      }
+      .qa .card {
+        border: 1px solid var(--edge-dk);
+        border-radius: 4px;
+        padding: 12px 14px;
+        background: #f8f7f3;
+        box-shadow: inset 1px 1px 0 #fff;
+      }
+      .qa .q {
+        font-family: var(--chicago);
+        font-size: 22.5px;
+        margin-bottom: 8px;
+      }
+      .qa .ans {
+        font-family: var(--chicago);
+        font-size: 34.5px;
+        line-height: 1;
+        color: var(--accent-d);
+      }
+      .qa .note {
+        font-size: 20.5px;
+        margin-top: 6px;
+        display: block;
+        color: #4b4842;
+      }
+      .alert {
+        border: 1px solid var(--edge-dk);
+        border-radius: 4px;
+        padding: 16px;
+        margin: 14px 0;
+        display: grid;
+        grid-template-columns: 46px 1fr;
+        gap: 14px;
+        align-items: start;
+        background: #f8f7f3;
+        box-shadow: inset 1px 1px 0 #fff, 1px 2px 5px rgba(0, 0, 0, 0.16);
+      }
+      .alert .ico {
+        width: 42px;
+        height: 42px;
+        border-radius: 50%;
+        border: 1px solid #6d6a64;
+        background: linear-gradient(#f4f2ee, #d0ccc4);
+        box-shadow: inset 1px 1px 0 #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--chicago);
+        font-size: 36.5px;
+        color: var(--accent-d);
+      }
+
+      /* bar chart (platinum) */
+      .barchart {
+        border: 1px solid var(--edge-dk);
+        border-radius: 4px;
+        padding: 14px;
+        margin-top: 10px;
+        background: #f8f7f3;
+        box-shadow: inset 1px 1px 0 #fff;
+      }
+      .barchart .cl {
+        font-family: var(--chicago);
+        font-size: 20px;
+        margin-bottom: 12px;
+      }
+      .bar {
+        display: grid;
+        grid-template-columns: 150px 1fr 82px;
+        align-items: center;
+        gap: 14px;
+        margin-bottom: 12px;
+        font-size: 20px;
+      }
+      .bar .name {
+        text-align: right;
+        font-family: var(--geneva);
+      }
+      .bar .track {
+        height: 24px;
+        border: 1px solid var(--edge-dk);
+        border-radius: 3px;
+        background: #efedE8;
+        box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.13);
+        overflow: hidden;
+      }
+      .bar .fill {
+        height: 100%;
+        background: linear-gradient(#8fb398, #5f8c6b);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+      }
+      .bar .val {
+        font-family: var(--mono);
+        font-weight: 700;
+      }
+
+      .why-h {
+        font-size: 26.5px;
+        margin: 20px 0 4px;
+      }
+      .why-h:first-child {
+        margin-top: 0;
+      }
+
+      /* ---------- about ---------- */
+      .aboutbox {
+        max-width: 640px;
+        margin: 0 auto 40px;
+      }
+      .aboutbox .win-body {
+        text-align: center;
+        padding: 34px 28px;
+      }
+      .aboutbox .mark {
+        width: 64px;
+        height: 64px;
+        margin: 0 auto 14px;
+        color: var(--ink);
+      }
+      .aboutbox .wm {
+        font-family: var(--chicago);
+        font-size: 39.5px;
+      }
+      .aboutbox .jp {
+        font-size: 20px;
+        margin-top: 8px;
+        color: #4b4842;
+      }
+      .aboutbox .links {
+        margin-top: 14px;
+        font-size: 20.5px;
+        display: flex;
+        gap: 14px;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path
+          d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z"
+          fill="currentColor"
+        />
+      </symbol>
+    </svg>
+
+    <!-- MENU BAR -->
+    <div class="menubar">
+      <svg class="apple" viewBox="0 0 64 64" aria-label="Setoku menu">
+        <use href="#clover" />
+      </svg>
+      <span class="m">File</span>
+      <span class="m">Edit</span>
+      <span class="m opt">View</span>
+      <span class="m opt">Special</span>
+      <span class="appmenu">
+        <svg class="cl" viewBox="0 0 64 64"><use href="#clover" /></svg>
+        <span class="nm">Setoku</span>
+      </span>
+      <span class="clock" id="clock">Setoku 8.6</span>
+    </div>
+
+    <main class="screen" id="top">
+      <!-- HERO -->
+      <section class="win">
+        <div class="grow"></div>
+        <div class="titlebar">
+          <span class="btn3d close"></span>
+          <span class="name">Setoku</span>
+          <span class="btn3d zoom"></span>
+        </div>
+        <div class="win-body">
+          <span class="eyebrow">Open source · MCP server · Apache-2.0</span>
+          <h1>
+            Make any AI fluent in your
+            <span class="rotator" data-words="company,family,personal"
+              ><span class="rotator-word">company</span
+              ><span class="rotator-measure" aria-hidden="true"></span></span>
+            data.
+          </h1>
+          <p class="lede">
+            Setoku is a small self-hosted MCP knowledge server + Claude Code
+            skills for hooking up your data. It does two things: it gives your
+            AI a read-only way to query your data, and it remembers what that
+            data means (the metric definitions, the gotchas), getting better the
+            more you use it. The MCP works with whatever AI you already have, and
+            no model runs on the server, so no added inference cost.
+          </p>
+          <div class="actions">
+            <a
+              class="btn default"
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >View on GitHub</a
+            >
+            <a class="btn" href="#demo">Try the demo</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- QUICKSTART -->
+      <section class="win">
+        <div class="grow"></div>
+        <div class="titlebar">
+          <span class="btn3d close"></span>
+          <span class="name">Quickstart</span>
+          <span class="btn3d zoom"></span>
+        </div>
+        <div class="win-body">
+          <p>
+            Setoku installs as a Claude Code plugin. Add the plugin, then run
+            onboarding from your main project directory, the codebase you want
+            Setoku to learn from:
+          </p>
+<pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+          <div class="prog">
+            <div class="lab">Standing up the server…</div>
+            <div class="track"><div class="fill"></div></div>
+          </div>
+          <p>
+            Onboarding stands up the server, auths your Claude, wires your
+            database read-only, and generates the first knowledge from your
+            code. You stay in the loop for anything that touches your data. To
+            start onboarding, run <code>/setoku:onboard</code>.
+          </p>
+          <p>
+            You’ll need somewhere to host it. Something like OVH’s
+            <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener"
+              >VPS-2</a
+            >
+            is plenty.
+          </p>
+          <details>
+            <summary>Or stand up the server by hand</summary>
+<pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+            <p style="margin-top: 8px">
+              Installs Docker, generates secrets, gets an HTTPS certificate, and
+              prints the connect command. Then add the plugin and run
+              /setoku:onboard from your project; it’ll detect the box you just
+              made.
+            </p>
+          </details>
+        </div>
+      </section>
+
+      <!-- HOW IT WORKS -->
+      <section class="win">
+        <div class="grow"></div>
+        <div class="titlebar">
+          <span class="btn3d close"></span>
+          <span class="name">How it works</span>
+          <span class="btn3d zoom"></span>
+        </div>
+        <div class="win-body">
+          <p>
+            Setoku gives the AI two kinds of MCP tools, and one rule: look up
+            what the data means before you touch it.
+          </p>
+          <div class="rows">
+            <div class="row">
+              <div class="k">
+                Context tools<span class="t">find_context · get_metric</span>
+              </div>
+              <div class="v">
+                The AI reads what your data means first: canonical metric
+                definitions, entity docs, and the gotchas that make a naive
+                query wrong.
+              </div>
+            </div>
+            <div class="row">
+              <div class="k">
+                Read-only query<span class="t">get_schema · run_query</span>
+              </div>
+              <div class="v">
+                Read-only, with a row cap, a statement timeout, a table
+                allow-list, and an append-only audit log. Enforced by the
+                database role, not by parsing SQL.
+              </div>
+            </div>
+            <div class="row">
+              <div class="k">
+                Human-approved<span class="t">report_correction</span>
+              </div>
+              <div class="v">
+                The AI can only propose changes to what Setoku knows. A person
+                accepts them on the admin page, outside the agent loop, so an
+                injected session can’t rewrite the brain.
+              </div>
+            </div>
+          </div>
+          <p style="margin-top: 16px">
+            You set it up with <b>Claude Code</b> skills:
+          </p>
+          <ul class="list">
+            <li>
+              <code>/setoku:onboard</code> sets Setoku up in a repo for the first
+              time.
+            </li>
+            <li>
+              <code>/setoku:connect</code> adds a data source or custom
+              integration.
+            </li>
+            <li>
+              <code>/setoku:generate</code> writes business context from your
+              code.
+            </li>
+            <li>
+              <code>/setoku:curate</code> reviews and approves pending knowledge.
+            </li>
+          </ul>
+          <p style="margin-top: 12px">
+            Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex, or
+            whatever you run. Just ask in plain language, and the tools do the
+            rest.
+          </p>
+        </div>
+      </section>
+
+      <!-- APPS -->
+      <section class="win">
+        <div class="grow"></div>
+        <div class="titlebar">
+          <span class="btn3d close"></span>
+          <span class="name">Apps</span>
+          <span class="btn3d zoom"></span>
+        </div>
+        <div class="win-body">
+          <h2 style="font-size: 28px; margin-bottom: 8px">
+            Save and share the tools Claude builds you
+          </h2>
+          <p>
+            Ask Claude to build a dashboard on your data. Then publish it to a
+            link as a Setoku App, the data stays live, and your whole team can
+            view it. Nothing to deploy, no frontend to maintain.
+          </p>
+          <div class="rows">
+            <div class="row">
+              <div class="k">Built by asking<span class="t">publish_app</span></div>
+              <div class="v">
+                Describe it in plain language; the agent writes the app and
+                publishes it to a URL. Edit it the same way, just ask for the
+                change.
+              </div>
+            </div>
+            <div class="row">
+              <div class="k">
+                Backed by live data<span class="t">read-only</span>
+              </div>
+              <div class="v">
+                Apps read through the same governed path: row caps, audit, a
+                SELECT-only database role. They never get write access to your
+                sources.
+              </div>
+            </div>
+            <div class="row">
+              <div class="k">
+                App-private state<span class="t">no writes to your data</span>
+              </div>
+              <div class="v">
+                Each app keeps its own state (todos, votes, annotations) in a
+                sandbox that belongs to the app, not your database. Worst case,
+                an app messes up its own notes.
+              </div>
+            </div>
+            <div class="row">
+              <div class="k">
+                Share by link<span class="t">team or public</span>
+              </div>
+              <div class="v">
+                A team link is login-gated; an admin can flip one public for a
+                credential-free URL. The page runs in a locked-down sandbox with
+                no network, so a published app can’t phone home.
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ARCHITECTURE -->
+      <section class="win">
+        <div class="grow"></div>
+        <div class="titlebar">
+          <span class="btn3d close"></span>
+          <span class="name">Architecture</span>
+          <span class="btn3d zoom"></span>
+        </div>
+        <div class="win-body">
+          <p>
+            You can host this on whatever infra you like. We put it all on one
+            small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+            helps you add custom integrations. Only the proxy is public, so your
+            databases aren’t exposed. Queries are read-only, and knowledge
+            changes pass through a person.
+          </p>
+          <div class="diagram">
+            <svg
+              viewBox="0 0 680 520"
+              role="img"
+              aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake for analytics, and your sources (GitHub, Vercel, Render, Slack, Mercury) are ingested into the lake."
+            >
+              <defs>
+                <marker
+                  id="ah"
+                  markerWidth="9"
+                  markerHeight="9"
+                  refX="6"
+                  refY="3"
+                  orient="auto-start-reverse"
+                >
+                  <path d="M0 0 L6 3 L0 6 Z" fill="#55524c" />
+                </marker>
+              </defs>
+              <rect class="node" x="250" y="14" width="180" height="44" rx="5" />
+              <text class="t" x="340" y="41" text-anchor="middle">
+                You + your AI
+              </text>
+              <path
+                class="arr"
+                d="M340 58 L340 142"
+                marker-start="url(#ah)"
+                marker-end="url(#ah)"
+              />
+              <text class="e" x="348" y="86">MCP</text>
+              <rect class="box" x="60" y="110" width="560" height="300" rx="6" />
+              <text class="e" x="76" y="130">your box</text>
+              <rect class="node" x="250" y="146" width="180" height="58" rx="5" />
+              <text class="t" x="340" y="171" text-anchor="middle">
+                Setoku gateway
+              </text>
+              <text class="s" x="340" y="189" text-anchor="middle">
+                context · query tools
+              </text>
+              <rect class="node" x="452" y="150" width="150" height="50" rx="5" />
+              <text class="t" x="527" y="179" text-anchor="middle">a person</text>
+              <rect class="node" x="92" y="322" width="180" height="66" rx="5" />
+              <text class="t" x="182" y="350" text-anchor="middle">
+                Lake (ClickHouse)
+              </text>
+              <text class="s" x="182" y="368" text-anchor="middle">
+                logs · events · DB mirror
+              </text>
+              <rect class="node" x="408" y="322" width="190" height="66" rx="5" />
+              <text class="t" x="503" y="359" text-anchor="middle">
+                Knowledge store
+              </text>
+              <rect class="node" x="92" y="440" width="180" height="64" rx="5" />
+              <text class="t" x="182" y="468" text-anchor="middle">
+                Your sources
+              </text>
+              <text class="s" x="182" y="486" text-anchor="middle">
+                GitHub · Vercel · Slack…
+              </text>
+              <rect class="node" x="300" y="440" width="180" height="64" rx="5" />
+              <text class="t" x="390" y="468" text-anchor="middle">
+                Your database
+              </text>
+              <text class="s" x="390" y="486" text-anchor="middle">
+                Postgres · read-only
+              </text>
+              <path
+                class="arr"
+                d="M412 204 L508 322"
+                marker-start="url(#ah)"
+                marker-end="url(#ah)"
+              />
+              <text class="e" x="424" y="266" text-anchor="middle">reads ·</text>
+              <text class="e" x="424" y="282" text-anchor="middle">proposes</text>
+              <path class="arr" d="M527 200 L513 322" marker-end="url(#ah)" />
+              <text class="e" x="534" y="262">approves</text>
+              <path class="arr" d="M210 322 L300 204" marker-end="url(#ah)" />
+              <path class="arr" d="M182 440 L182 388" marker-end="url(#ah)" />
+              <text class="e" x="190" y="420">ingest</text>
+              <path class="arr" d="M388 440 L366 206" marker-end="url(#ah)" />
+              <text class="e" x="300" y="300">read-only</text>
+            </svg>
+          </div>
+        </div>
+      </section>
+
+      <!-- CONNECTORS -->
+      <section class="win">
+        <div class="grow"></div>
+        <div class="titlebar">
+          <span class="btn3d close"></span>
+          <span class="name">Connectors</span>
+          <span class="btn3d zoom"></span>
+        </div>
+        <div class="win-body">
+          <p>
+            Point Setoku at the data you already have. Every source lands in a
+            local
+            <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+              >ClickHouse</a
+            >
+            data lake, on purpose: agents write arbitrary queries (scans, GROUP
+            BYs, whole-table aggregations), and a columnar engine answers those
+            in about a second, so the apps and dashboards they build stay quick.
+            Your app database connects read-only and is mirrored in on a cron;
+            the rest is ingested as it happens.
+          </p>
+          <p
+            style="font-family: var(--chicago); margin: 4px 0 2px"
+          >
+            ClickHouse · one lake, every source
+          </p>
+          <ul class="list checked">
+            <li><b>PostgreSQL</b> — app database, mirrored read-only</li>
+            <li><b>GitHub</b> — issues, PRs &amp; commits</li>
+            <li><b>Vercel</b> — deploys &amp; logs</li>
+            <li><b>Render</b> — deploys &amp; logs</li>
+            <li><b>Slack</b> — messages</li>
+            <li><b>Mercury</b> — banking &amp; finance</li>
+          </ul>
+          <p style="margin-top: 14px">
+            No connector for your source yet? The included setup skills give your
+            coding agent the patterns to wire one up itself. See
+            <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener"
+              >the repo</a
+            >, or open an issue.
+          </p>
+        </div>
+      </section>
+
+      <!-- DEMO -->
+      <section class="win" id="demo">
+        <div class="grow"></div>
+        <div class="titlebar">
+          <span class="btn3d close"></span>
+          <span class="name">Try it on real-ish data</span>
+          <span class="btn3d zoom"></span>
+        </div>
+        <div class="win-body">
+          <p>
+            There’s a live demo wired to a fictional pro sports club, the Bonita
+            Bulldogs (ticketing, sponsorship, concessions, payroll, broadcast
+            rights).
+          </p>
+
+          <div class="step-h"><span class="n">1</span>Connect to the demo MCP server</div>
+          <p style="font-size: 21.5px">
+            In Claude (or any MCP client) open Settings → Connectors → Add custom
+            connector, and paste this URL. The token rides in the URL, so there’s
+            no separate key to enter.
+          </p>
+          <div class="field">
+            https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9
+          </div>
+
+          <div class="step-h"><span class="n">2</span>Ask a question</div>
+          <div class="qa">
+            <div class="card">
+              <div class="q">“How many unique fans do we have?”</div>
+              <div class="ans">71,204</div>
+              <span class="note"
+                >deduped by normalized email, internal accounts excluded. Not the
+                raw 92,118.</span
+              >
+            </div>
+            <div class="card">
+              <div class="q">
+                “What’s our total annual revenue, and how much is media rights?”
+              </div>
+              <div class="ans">$192M</div>
+              <span class="note"
+                >five systems reconciled to the same units. Media rights is the
+                biggest line, ~$90M.</span
+              >
+            </div>
+            <div class="card">
+              <div class="q">“What was ticket revenue this season?”</div>
+              <div class="ans">$46.8M</div>
+              <span class="note"
+                >cents reconciled to dollars; refunds, exchanges, and comps
+                excluded.</span
+              >
+            </div>
+          </div>
+
+          <div class="alert">
+            <div class="ico">!</div>
+            <div>
+              <div class="q" style="font-family: var(--chicago); margin-bottom: 4px">
+                “What’s our total merchandise revenue?”
+              </div>
+              <b>It flags it.</b>
+              <span class="note"
+                >most merch is sold via Fanatics, not in this data, so it says so
+                instead of returning a wrong total.</span
+              >
+            </div>
+          </div>
+
+          <div class="barchart">
+            <div class="cl">“Chart revenue by line.” · Annual revenue · ~$192M total</div>
+            <div class="bar">
+              <span class="name">Media rights</span>
+              <span class="track"><span class="fill" style="width: 100%"></span></span>
+              <span class="val">$90M</span>
+            </div>
+            <div class="bar">
+              <span class="name">Ticketing</span>
+              <span class="track"><span class="fill" style="width: 52%"></span></span>
+              <span class="val">$47M</span>
+            </div>
+            <div class="bar">
+              <span class="name">Sponsorship</span>
+              <span class="track"><span class="fill" style="width: 31%"></span></span>
+              <span class="val">$28M</span>
+            </div>
+            <div class="bar">
+              <span class="name">Concessions</span>
+              <span class="track"><span class="fill" style="width: 16%"></span></span>
+              <span class="val">$14M</span>
+            </div>
+            <div class="bar">
+              <span class="name">Merch</span>
+              <span class="track"><span class="fill" style="width: 9%"></span></span>
+              <span class="val">$8M</span>
+            </div>
+            <div class="bar">
+              <span class="name">Other</span>
+              <span class="track"><span class="fill" style="width: 6%"></span></span>
+              <span class="val">$5M</span>
+            </div>
+          </div>
+
+          <div class="step-h"><span class="n">3</span>Try an app</div>
+          <p style="font-size: 21.5px">
+            Ask Claude to build a dashboard on the same data, then publish it to
+            a link. Two live examples, running on the demo data right now:
+          </p>
+          <ul class="list">
+            <li>
+              <a
+                href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+                target="_blank"
+                rel="noopener"
+                >Sponsorship pricing table ↗</a
+              >
+              — inventory and rates for sponsorship placements.
+            </li>
+            <li>
+              <a
+                href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+                target="_blank"
+                rel="noopener"
+                >Fan lifetime value ↗</a
+              >
+              — segment fans by spend across tickets, merch, and concessions.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- WHY -->
+      <section class="win">
+        <div class="grow"></div>
+        <div class="titlebar">
+          <span class="btn3d close"></span>
+          <span class="name">Why we built it</span>
+          <span class="btn3d zoom"></span>
+        </div>
+        <div class="win-body">
+          <h3 class="why-h">We’re curious.</h3>
+          <p>
+            There are plenty of AI memory stores, and plenty of data gateways.
+            Stapling the two together, and nudging the agent to gather knowledge
+            about the data as it goes, seemed useful and fun to tinker with.
+          </p>
+          <h3 class="why-h">We’re cheap.</h3>
+          <p>
+            We wanted something that runs on one small box, works on a Pro/Max
+            subscription or a cheap model with no added inference cost, mostly
+            sets itself up (no field engineer to pay for), stays portable between
+            providers, and is open source.
+          </p>
+          <h3 class="why-h">We’re paranoid.</h3>
+          <p>
+            HR platforms, CRMs, and clouds are all announcing “context layers.”
+            They’d like the meaning of your business to accumulate on their
+            servers, where it can never leave. Context is deeper lock-in than
+            data, and a hosted context layer has no export button. Setoku exists
+            so that understanding accumulates on a box you own instead. If we
+            disappear tomorrow, your context doesn’t.
+          </p>
+          <h3 class="why-h">We and some friends wanted the same thing.</h3>
+          <ul class="list">
+            <li>
+              <b><a href="https://www.hedgy.works" target="_blank" rel="noopener">Hedgy</a></b>: keep scaling without hiring. Debug from live logs and
+              data, find growth levers, and match candidates and companies better
+              with more data.
+            </li>
+            <li>
+              <b><a href="https://baggu.com" target="_blank" rel="noopener">Baggu</a></b>: give employees state-of-the-art tools. Faster
+              onboarding, and a safe way to vibecode against real data.
+            </li>
+            <li>
+              <b><a href="https://tlon.io" target="_blank" rel="noopener">Tlon</a></b>: experimenting with giving agents curated data to work
+              from.
+            </li>
+            <li>
+              <b>Sports analysts</b>: query across data that doesn’t usually sit
+              together.
+            </li>
+            <li>
+              <b>Academic labs</b>: think through hypotheses against real papers,
+              data, and drafts.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- SETUP HELP -->
+      <section class="win">
+        <div class="grow"></div>
+        <div class="titlebar">
+          <span class="btn3d close"></span>
+          <span class="name">Setup help</span>
+          <span class="btn3d zoom"></span>
+        </div>
+        <div class="win-body">
+          <p>
+            It’s open source, so you can self-host it today. If you like, we’re
+            happy to help set it up. Just email
+            <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+          </p>
+        </div>
+      </section>
+
+      <!-- ABOUT -->
+      <section class="win aboutbox">
+        <div class="grow"></div>
+        <div class="titlebar">
+          <span class="btn3d close"></span>
+          <span class="name">About Setoku</span>
+          <span class="btn3d zoom"></span>
+        </div>
+        <div class="win-body">
+          <svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+          <div class="wm">Setoku</div>
+          <div class="jp">設 × 奥 · set (math) × oku (innermost)</div>
+          <div class="links">
+            <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener"
+              >GitHub</a
+            >
+            <a href="#demo">Demo</a>
+            <a href="mailto:hello@setoku.com">Contact</a>
+            <span>Apache-2.0</span>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      (function () {
+        // live clock
+        var clk = document.getElementById("clock");
+        function tick() {
+          if (!clk) return;
+          var d = new Date();
+          var h = d.getHours();
+          var m = d.getMinutes();
+          var ap = h < 12 ? "AM" : "PM";
+          h = h % 12;
+          if (h === 0) h = 12;
+          clk.textContent =
+            h + ":" + (m < 10 ? "0" + m : m) + " " + ap;
+        }
+        tick();
+        setInterval(tick, 15000);
+
+        // hero word rotator (crisp swap)
+        var box = document.querySelector(".rotator");
+        if (box) {
+          var word = box.querySelector(".rotator-word");
+          var measure = box.querySelector(".rotator-measure");
+          var words = (box.getAttribute("data-words") || "")
+            .split(",")
+            .map(function (w) {
+              return w.trim();
+            })
+            .filter(Boolean);
+          if (words.length >= 2) {
+            var i = 0;
+            var widthOf = function (w) {
+              measure.textContent = w;
+              return measure.getBoundingClientRect().width;
+            };
+            box.style.width = widthOf(words[0]) + "px";
+            setInterval(function () {
+              i = (i + 1) % words.length;
+              word.textContent = words[i];
+              box.style.width = widthOf(words[i]) + "px";
+            }, 2000);
+            window.addEventListener("resize", function () {
+              box.style.width = widthOf(words[i]) + "px";
+            });
+          }
+        }
+
+        // active vs inactive windows: frontmost = nearest viewport center
+        var wins = Array.prototype.slice.call(
+          document.querySelectorAll(".win")
+        );
+        function mark() {
+          var cy = window.innerHeight / 2;
+          var best = null,
+            bestD = Infinity;
+          wins.forEach(function (w) {
+            var r = w.getBoundingClientRect();
+            var d = Math.abs(r.top + r.height / 2 - cy);
+            if (d < bestD) {
+              bestD = d;
+              best = w;
+            }
+          });
+          wins.forEach(function (w) {
+            if (w === best) w.classList.remove("inact");
+            else w.classList.add("inact");
+          });
+        }
+        mark();
+        window.addEventListener("scroll", mark, { passive: true });
+        window.addEventListener("resize", mark);
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/10c-compactmac.html
+++ b/site/riffs/10c-compactmac.html
@@ -1,0 +1,633 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · Macintosh 128K</title>
+    <style>
+@font-face{font-family:'ChicagoPixel';src:url(data:font/woff2;base64,d09GMgABAAAAAA+IAA4AAAAAUzwAAA8rAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGiYGVgCDIggEEQgKgY9IgYtGC4JsAAE2AiQDhVQEIAWDOQeDQRvTTkUHYtg4AMTv6klUvSRodFgdH9gEaqrQ6vY1oiIhhBCrVvzYDvW7M874pr3mf/b9TP0GnnBS/aYnnFyPIPqu+shq7c4B+ITwRLAMWOc9UoBGMORVIs0luY0H+lPfv5AkPBbGdHVPbkFbszI0w97Aoc/f+zr77rdTKqCxeBp2dI54aFhjAdB0l6E0VvFecQMYQM0SFmmPXR4VEOWBTttUP8aEfx0s7a1pfjhjxllPx4wwFahP37mP0NxK47omfRlEdKw8zgCFBVSnMfTS2F9LXydMe/L9ktYqdmuAZMIcANv33u6+sU6rc1daKffuaVfava+bsfx9bkqvNLx11lhga4B0GhwUBMM8ISQMBMDcjzW+h5l2Kr0Wj5+IE5JNOCJrZu51fCcR8PYq3x/hyT3TILw2cIO/QEf0NlgSwq1CiYRAIOI+4lcV6SzyWZyQvHx8Y2JoJ6kL/CCNkHziCcfjaB6mUsisG8GDCEAR6IGl7Nw4otNLB4pfUleFjvb3dL3b3YMXvOsHf/onVo6f4+SMoS50vRvd6QG85AM/kfhzz5/kh/ND+cH8QL4335Pvynfm2/OGNy/eKvADRU3YNBJvSm9KUVZYhH2q8q5qnvUflGx5QayyQqlSa7Q6vcFoMlusNrvD6XJ7vD5/IBgKR6KxeCKZSmeyuXyhWCpXqrV6o9lqd7q9/mComFA6xDwrqrJu+24Y52lZt2M/7wvgA6A9mbn6FLTDwq5zB5+CndjiBNj25oLvPt0atrvb+Dk73YwN34CNb8GPaf/X5L0+6njM/vgTcNz9cSpgDxh+7BE5A24DYmvSqQw5n2E/QF+MwSlOxyMWOklCEUd+91BJggkZqRBG3FYSFKAIF8GkSoaMrq5CXbAgZA5BhMESN0qXp1VLDLg8qaWO3LmzWkspXbnMpbOx6JubFcozG3XEhaCAOK6kqlVne3TrUKu1aRhr9PdQ1nGizC8Az2BHtzgAH7s3tgpYeCvZpzkXxLcrcIaS33q1yIXWWKfGPm230Yjw2bojj+Ew8Fki5JCq1hJbIrc9vV/sXxf/35FD23wj9kTvz2fPtUfDNfhQprYAe+/MiOEaj8rwLtsM6xe/dTaM4+vOWLOoF+O7sWTSs+KpY8TiIrxfDBt7ICp36V3CC8XN3BWSpRc2UNvDq8NIakFJUYTCqUisIi7+e28eBWeWEew6w2/E00rl6VyxZpWvU9Vl77eG6LV+e1471JvN5l6ZLfw2pZGgRsC3sTFtZZKfub4AZmTDrPb+GhaBoLaBRXefe+T7ip36LG6eu4V1ICK55bJ8U89WnZeLRoJavfumsyE8EVtmETAvqCSh8IF7pkNCt/2Wt3mpFJbwLZSh6UqBJlbGy8VIlTQ6S9ieRbDFyzVqpzCo4cQvAZenjFxMfFjJljgFYG1s6wUHjEqy6agNbHEJ/kV6Ua8iv82j/djRplVW4myJ1JEtr+wMFANRVMv5QmEdXHkie6i4Ig0/5raEktpR5E2yexwqS7Y19RyuHKTJpDG9kBiofEGXMSd8OOUP+q0qIdVxp6KI75kt15axhvKVsAq5cl1yNuBClReu3AFYJ5CIb6rKas2yekUWUU/avdZ1I3gw4ArJMFbeIWvDlQE6Zk2fG8BBJrxyZSiUgIADPGKq5fLcJ0AnEnLxPHeVkU8jJy/FF1Xklr2UDnDjjJHLOLeQVE0+7ca1uaNEH9QUhDhJJqyOjOAJCnkodMiwHluqIcVvAkKMiOjSlXQXuY2ufpJPoJoR4MBC9+CzuFyx0lPxJqWOkCxpMnIv6de8T4bIFmFT0KsGIydKoy45pqfYQs6oojLWaHdxVeqnGEOkBWog5/Yq5ULyF6OAHkFXdKEOmI4Qn4mQkNTbtLhSyBoPNNqApVrxOOjlIuVxoxDIYhlY95N0j9NxeDj2/wp4jjFhP7JnYweIJ0XUhCzuCX5OPrbyhinj0+NxPiwA9xYJwOsYh8hX2FHLoykKoT6s0HuVzHiUkfTGbeHnt4GM53boCbhAuzF2lfTKa/ZmL3D1QePEIcKev6uVjHgkh4heLK9PQOlzYbD2qvQz7PueIky7yTqI7M0w58zj3AP3rLMA74groFeYBegMf4tMVZN2s5wzKqI6mbDhSSenGUAWpNIPhHeGEZI+UDQ6nsYaMeSr3Q9x9qPIKjTGDznhF4mdQ7iVSftf/5uxdBl4hs4yv5sun+3sfVrSIPfkhcDfIYz5uVWrZEEPKB+hTqPYo8kQQhVCmKSnRCAbSoqaGNseWgakzKqKwy2zTzLtQuWlXZq0nFi6QFXldRyJbWy+QsL9nJXzytstxMMY1sjSJT3zalTBEOvVoII0X61EOhOIl6qF2hK5b9YjNC6z1SikPgPPRSKxgfTI5mgNC8hxRqmsCcdTy2JMQI2gmZFeQBZz5GBsfguUUHgXbigZmYHmZClE9CUniPuA62RfTwXtQS3yIEiMzoRLS/RESzcx+fXDwsxYoKS3Qy19m8eKt6CXXipr59nJCJt/8cGmKQfZmeUayMDG6fSpi98nU1QyWczTFyjtLxntJ2ZqfUAfuyz7YcOCuzNY1j6R4wDAvHOdQWJcn4g/n7CQkqTlVJc96wU9ICKTJi33E6Xk0zyNPeCPz7Iuu0XG+iT1hiBtSyygnurP5Kr/7YfYU76V5Nbfqbx+oc83nf/5deXzViuEas1duhlulp5lNZwWg3BQ8MMtLq9ZkXEyZ5stKM+xRCXhS5UlfWO4Lu8cYMO2Rd7AfHNyih+Ix02wCddaR9AKKG0Gj5RnalWv49eBOmJqFv+TP5EHuUrfA86QoEivRfRREuu7pUnF41KitLJ+0LOo2/qHd2sVewARHvQMunKP6DKKjQQymJYSphmcba834MVEROw0Me9N2axDVB6R6hS9AQa21cEV7Z6yWFuMyPtcIl9VJZlniDK5xOlfgkcy6fdJPfEpbrMWktytYU8RTnaVo1Mbzqt3dV5yvgml1rM5NsVt1hr08ChceQqepVcJfi0DZEwals9Zp8FZJGBFdt30fAA8MkztAJf9C1jbSXS0KevC5EMHn0DYDN+JCCIpXdRqzcaZFrel6l2fLOqFE7aVNSCBC7HigyYRFUEUTv9Zwrs1h5QDZaN1Gv+djveGbNZusFVsqHm3FrGjD7udNWUDhzOFEZRlS7ATKdNglSvL+3c7LYud0Wzu5mmTF/FrTjpjA3bESJTRm6MlPr749vjbzZPrj9dPzY/Fap9FZ05t7qVJB9Doo0TKbGGmOtMRKdv2SBQkW4AfVmlNPjBWWQmY64Rwq2sTH0ZLuqCLuakOz6/KxHJ6ak2MtAduQkIKKwQPTN+bZpVdiOlh0Q5gO7PdSuzRMYiNJ7NibFYiNFuSBL+6rU4TQ28UpdA/o40L9ANtZbAR0yodNsqeiZr2DIZddncO7jDcytMgMKNMQYqWm3ryMa3oMqlffA250tDY2Q0pMnqw7YPbr7PCoF5qmWNK29dtdrDP7VvdICpPokfJna+THCDJ0MZc8T5gG5n21+HtsMlLLtPeKlnsO7b5G9QyMFK7I5hDNKctqH6SO2jCjKTrwclpr2l/UJxgjGzn5JYZdGzuLQB2o+4SKPRMmOjKykhTbHSMBnk4uc8vtP2juHUg+w3MFGiCjF25KU9dZ0KNA7JvToosjYfUzppXK6JkzdUJBl5/EHeT3yofy2gEHHvmzjsfRuaLLD9FdGO6PxkhCiE/ZE16nSefU6DZVxZX7z8rx7nYoes6mu6DCTUp5WeGQaO20YzL9LeJZmK1nJHLJ+ALlNElJ1Vsf20wT4YpzVZQxl8ZthsUYOalp7S7CPBs/Vk6daSqZFKqh+RgvbNXU3qktMNwQq8B+RAaBwekiLpLKTsbjmr2Fw5kv8nb16ijeXlMICDB/klYzaUXrdsq6I/Mvkk5ImRMB3IO7oLjldX5IbVSpAba93Vjox4N8fE6ZqmTkMoCEGlgqhTbjSbkrLcHLGeZ95gZ7+yNO2WrP+agTptq95r0nuY8t6w12cJv0GNV4pGUrhZkInKMEqA+t121/SsyvHlY4rq6L7TfxtuCMrFJYmO7AXihxWYjLBXyBXeCB3I729MHym8IUgurgvnGjnkJ0y+LgHQ6sahsKQGGad82iPIx75OZhF6ZwQuKmBwUWYEYVKBntWwPTNB4iiqclGXWYbyxClk6xoOeoVifqlzGyI621UCX0E3HmAaMRlCnQJeVXm1p2Ru/+0VxnfZoJehl2m3RamjslPkLsU+FbW7Ds/MDAExWkzERG5GZ9IGYwkGbfhmjh2MpObVzsJmdlHZfcwjzgWvlQWC0Z4PUyoDnCKzLsb99t/bD4P3TGj9eZZtX+x48u/xvnbh5+Ts/+5MdXsfIj4IVnI1UOOU8/h+r8UcOIODTa2X58Ojy3+17J/5eoL8IxsdeALc5AAhYjHl7AuDYBPyj/o4rLgDiDcIQQBQcBbHVojxjSfgabg9icASWjHki9ArUwq2CSSQJeKEarImUL+DGX9AVKcouu4ag89h0DI1U5LWLMiFElQG8z9izLYMlyzIBkR7CFvWS0+saR5kJvt1se+mCmrTKMYyB7jIWekNIOys5id2SEw3c9Dd/eYXqUfnu5umkge10dj1zJS298yzCqXsltRX3KvRyyF6llhv2qnTx9nm1VpC+S5Tt6ImxCIftlXS0YK/CCPW9Sj2dtVdlsLs/dK2nry1hK9vazC4W2MEOdrUlS8yWw+jfuVzvU15oS1tZxkZ2tpkl7GACC6eztP0Qr4HlbGZTW9nNdvxPo/I1nTsDDt3RaQMz3Wz1D7azXWxlB9sbapxxxhvDcNH+xtVLDJVRZwhNG12UsDnmg03UuO3vTVR/geL/INq0a+mgo04666Krbrrroadeeuujr376G2CgQQYbYqhhOHgCkURGQUlFTUNLR89gvAkmmmSyKaaaZroZ3Dy8fPwCghZYaJHFLG4JS1rK0paxrOUsbwUrWsnKVrGq1axuDWtay9rW0dHV0zcwDMklONRhuA+n+9LhjncMzsNVuNTRDsEpRBGl44jKkd6P2vmudrHr8JQnXG9jmzjRpp6xmSc97QXPes7zNveKF73kBmzhRyfhda96zZaOwta2so3tbGt7F9rBTna0s13sZle728Oe9raXfUyM/V2EA90YTbQ1u61nBkPQIG4UMoXm0LrQSf9jrbzgPLPBYAAAAA==) format('woff2');font-weight:normal;font-style:normal;font-display:swap;}
+@font-face{font-family:'Geneva';src:url(data:font/woff2;base64,d09GMgABAAAAAAvoAA4AAAAAM6gAAAuPAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGiYGVgCDNggEEQgK0wjKGQuCDAABNgIkA4QUBCAFg2kHgkkbMi1FRa2cnCqR/H9YboqILj+A2kIJjjCjQKIRYjOzUnF0V7yBcBDywCYPz3D68G/z919Jx34hVkLEFcJ0Z/qb+3h4fn/UuW+ENTIY9dNSadpazmYSEhiafP7v3f1b926sIZoGOsk6Wfws8TzrA4XxgyDm9gsFOmnHdW9LYybYENfSIDSuKxQ1mXsDmFte+EoLJP+dRLTT+MKrfz22jq3LR714l2Pp0DW/Grzy4iv3M5hotMFaOA3W/wDjAhtIxAW+NpFl2yyL8TiOMkaR8QwRkP+/ZbWH65q5vpwUqSErTphdNAqLwyHU9lT/X2+nOjx6iRdy/vO79qqmenm9l7I85BlDzi4JxUNosFiEtBxj7v8XjtebvIELCU8kvIhONP5af0oEvA0eBx7cmhPgRWRZFihFTSFWCEuFXCQEAhHtmD8P0q49ARvE946faBsiSX4O/qwCIflWbaaeJsjEVgTnP1Qk0kLYXZDDsvqt4qKO4tfmbUVtMk6h+d6uu89rPvFV+OT2de5BGxp7Ou+udOFn4f1fcfrD/88R++zUQsvPb0eA6vjkCZZOtLfMZEcnZ9OnW3YGIp/wSiIhOS3Iyc3LL4izGHEx9fqL6IZp2Y7r+UEYxQAinKRZXpRV3bRdP4yzvaJqumFatuN6fjaXLxSDUrlSrdUbzVa70+31YeZs+IvMW8AfPnHoeM5p7nbJYTT3OewxYgpgLOa7DtkA46YzgIWL4EsXW+IFTHNq03SK+I+1ln1uFBNvoXJXUGUFYF20wEmD++tzByRpbFkLu20ANOlDGx2sGOx1MYZ78Qh50qWO1NZNQTfZqaABOnsR7TzZ5jRG0SH00EnsQd0WQCXrEOkwIS3SjyK2XyoKf8KLgWkY0FBY3rAbUnUVoJB1tz7wgTuCvPAPgqQ5anERHyQfYoJBwIeg1h6gi5jtqwhNZM/J0tdxLkk4xQLFFLnfiKLA5EAiYPhYNqesD9BFfyGEat3vSuC9vqUkDvsD5/uca7xXP/Hhbfzw8JaovMy0I+YTCAN3/SHIMlaHWHHD9mmf0H3CaRbnthJ9dM5m4jiUXXS58oR7isn4iA2YZWgcA/lWTidyIX0Ie8EIXKy7HB2utuH7oG3tMATZaz1MA5X2DnmZluvzELD7N8fv8iUdY3aAyyvAur9BJiM26Fb6oZye5NS3ulJ6Yn1cofjVsSSdj3GfPprITJIIwJkITYSV0jS+T5NpdPKM3mXxQ1Atk8VBKQjQa0VjY+NqOTCypNodNVE5RpjlZSo8qE2WQpPwku4PLCPyBzR5dGRLdXnk0ApIrM8TuKDf8PpmXu/srtjOwoZbpATRDj7poV66QBMDErDzjGYSFZCtjJQZkCsjCIAKtlMBFTFTNthPW9OlkJTgozfAiXQ3A+fOeruzSZjaZxvRwjddWvgifa7TpM5UCYeA+5qU2tsQuNVNYGLuxWxHKaRJwkPmChWrU/IAU4iIL+0IukWSvvcVYOYJGeYIj9wim7XCRCopO4mBs0HwHfWE2dw5ux82RUchn/JeS3sExGcFDBEJde9q/LU8VpjXFkgFggzZxGLoV/rSS7hwF0Ll2FRyOq9Q9ht2G5Yxn9MyjtfQmtwiNOi4MKLmoVakvSzpRmAoABhAXmBqDXA5SB4G2yi9IMfAuXdEnjoY12QpA6JXIFB4jU2TE7KwJRyBFegUSIfnL5CoThZ8eIeICnVznmVlNXuofisQQIIJD6oQUp7jI8vVWsKpqZ4VacZQ/5Am21gJwCr6JBVFGxDtpZ5vWoV+T+oJ5ZnNg0Yb182CKtCw2CM4AwZPvEOXMCKwC0iA2tN+C7FO6CONAnhntVVfhtGMPvUxqiR54EPA9JAWWDVK34Vgvry5IuYj4HNVIzQ+94SXj0k/QSnPoH/WigUzoE+NbDeH3gebqWmFPqGoCh5XlOYdMfuGptdpL5JjRu7oUU2GcVqzEryey06qQre2XqhaUGweIqIcbO6ZHS5vBeYVM0UllfZMbntIwB8rI2UhoPIBMJZ0WoK7I2WkRKOKsXgRkWCg1iMMqLtIZCaxIakKpnRIJhwI9shnydURNarfIXhgp/SRDMpooKhA43oqhRJP2qR8PRGPa+JoNAjFXC22S6EWIJkbCm5T8ryhkp2qAfBUHDVFCD4+5zHCx2uMN/nljPKbIscIc29tQZOAJC6qtAVyyzTY+qQ+CRS4TYOm84AiylAkC2x1K7sFUdfaGprZK2p597K2o3lWRCVfriAyblI/LuEXNxJ4awS5TCpJgpe2UAtrYQZBpIKJRnXhBQomFbDDEEBG0lWjNFKi0aChSBNuxF36Li3IBWLCF8zNhT06E+AqqYxrQnBkKaWMJFjFoYd9aNxVSTf9Iqj6Jom+Tz5qC+fyO1nhVExvX3oT0Nn2dn3IZoqQMBUoGfTSujavrdINQvAmNilXRkbasiharMFX0afliIrHLwHIVwHOijjoqb9HG5HJL3kvXoMZGV+KNVPPSyGBR+NRxrxhj9kibdFe3xWmI0xhC6mumQhOIMi3y2oj7Ir2Vu4MVgeRcjL6cuKMgxBbb9GaxS4kXT3w4fozm2scUm3cJC8ytdylV3s89S47WgaavOZFcb73Z0hV+sx485Tbd0Hl2446BOp5q0bw0+E4OAfO+Wr1LpNxUlxIDamQ69HMN+/FSaP6vuHUqP54QMaAo5IOXD+dDGE8GV0CwIjjGcjdv95eqmCi/hRohQG/PDAlE/pcIvjFQuhSmTHspaqne5HsGR4tVAyJd07nCAHPOai5P3GRosHu1dyZe41FHgW6RoXMgPAu4BxDNz6X2fB5s8Le1A2+D8WciTDh1OP6cu7IokLlx6a19tlsxdm0gbT2be8XjyOLSkam2c7OsuPpm5qxeKKDDD4Xr2wHFxdPw4sT/A2U6zCh/iB6nG388sMuah6WGZMpU6c5vMe2xG+bIjZYPJwtZFgWramugtzg9uPSIuq2yDhJLBi6QjEOwHma+rlgaEmTEv6yZ5PRpnxXLTRoh/+G8O3GQHry3qXPY7uNuN/SKl8kaU8aGEbG6YnMYGjiv4baNL8iKP06t0LIXb9byBjL4HQcq5F0DOUXrq6JWl2kXABaybfinDsePFB52rwXuCMKp4R+YgEW0OxlUBqNSIWnw6V3blEuTjkMGDpTWOFRVR4/v7SmmCfD7KUZ3mWBz17pTYLFTf6AVE+W+FuXil+o8pGXD2JsMFu9+2hVdjYgee7e0eiEpqlQSsev9Lz3DW+F2WmZ0MH/NLpVnTph/rmOXz6PLP+gS6Fl+6eU63fqIea9r07h0lBXK6clDPV4Kz/+PLSZfyODYGyn7eEnvPrLXD9/9+Uc3Umno1ACoe0fW1hFLv4fJAL+S5bFdKJADILIwEICsfAwJWUFGZU33dCzs/Y6C9+HWCvLqYYEaYrTSzOmzNIdMsN3qmpn9qMtxY326u9KR2QIXWmHcmJDlokOvBGS4hVSOnmCnnDjYlOGvX3DvJW1U+zyzMeo9m3c4EFgmf5C6C/bH8nEYE6588IuitWsR6FcpyjJVxHlqOMe5Sr3PMpTyb9Pz1cezcCJ3CJUh09RqC+JklK9oxxtHKNc9b2iPA19f3K++qHpYm5l7EixtXUyQ5dRq/Hx7zE+8OGdzW2MjB0cucZFtnvq8lfxlo8Px7/QFz9/EvQyNjJ3tsZ/x/QzTm0Jmkyij7QfTZuywZ0fN7e1Ierp6euIq3rw20NbEcIA8dEcYSThL/v/1Va+7PcB8M8C/gcqVKRYiVJlylVSmUKl0RlMFpvD5fEFQpFYIpXJFSqqauoamlraOrp6+gaGRsYmpmbmFpZW1ja2djIUKo3OYLLYHC6PLysnr6AoUFJWUVVT19DU0tbR1dMP1hFLLXPVdt9Ybr019jnlqNWW2GJd5FjpNqcdNsTDUE+rjPcywd8llyM38gqm/c8TaOqx5fMx869AOw3r0wgh) format('woff2');font-weight:normal;font-style:normal;font-display:swap;}
+@font-face{font-family:'Monaco';src:url(data:font/woff2;base64,d09GMgABAAAAAAloAA0AAAAAI0QAAAkOAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGhgGYACCXhEICqwEn20LgUoAATYCJAODDgQgBY0WB4F4G3wbRUdzjwOZbDrB/3UCN4ZIfaivUnAoimLBgoXaRCNqPGpsHMqazN+mD/bauxcsH1gRavT89pRJ25cx/73oFRAnOMTRlvZ9HkH9Wvg9b/eIQoQbdEDk4lJRqVMhhUJFxXH5kwH6XxIKRwD998ejmx8HJZO7MwFL6iV8B7Ba0Iq8MyX8jBfsZsOCwuC8K5R70EHk8pDzTX6/7Xb7NsEytXzsId4ioRT0YCiVacHviahg4JydnlEnTAEHDljt/4VKsqxNgZKh1z94bqi/wCoe1Xr1+r9pzWYotY+DLhTOgLC782fy3+6/Sa7t9dDaHmrvVP8JZTZ33UGXWBy+FdmqETi6qkaBUB6hNJtMs5hk/wCM3hgjjCIE6KjbTb5jPhECvvj6+R/e//r9z97yAU10ZUJ+nRSr4q4Xecpr/2/WPrHUO1oIV/YhFP7B27++fYqgwqRJVO6GRB8BUaAwiYwMGcaRwWGZwDiadSRVVQnTfZPwL0ySTAL/7t/9AwFynHYGnHWOKBOASEgAgCDLS+VKVa3eaLbanbeN/gdJ/715fhBGcZJmeVFWddN2/TBO87Ju+3Fe9/OuRc3hEGFCGRdSaeO4nh+EUZykWV6UoLDDmnNVDSIF4/8VYOz5h79CbKZ8hMpBmPtXo0RAonqdJSAyKIluS+gNlBVpYGHUlam3iQedCwgaRPA2MAB2wlZlyyBSY2msEgHbwH60jBGTKvkonh7PzQYrlG2ryVl99nXV4/jITH7jBONacw5y0+SWXRv/qeluIrh9b8KZjUOIJQPXit5lR5i8vbbHJj4N8x4M/QR0OD7nnzlqmlC4vEVSvvsvfSwiBUJOXGnLiBCo5t6hBmGmhkzlkzzSbmH0DV24nKc7fAMh48tgI0SnnLvQiDI0kfIYZA1dM8QA220UCEA/Ucbg2gMDDQOIUBsZpNG0v0VYeIzObe6Tb5DCRXSIxDkvI0nAJhmcFzDnTFS8eJdz5IB0dcYRuBBUVBDmUZKZH5IZhDtDWxyWIAtRSnE5Q9GbtMAZB+qXaxD4eikHmzLEqdwEl/uRxwVVIOMsNL4Yc3sW2d5URHUwCgjSrHPXOPgadEN7yA4FYp6pJUHyTI5vioKSgcWLDRsTRn5UrEeBk1JJIqaALYmY4mqQCZAmQpoARdikDXTVlMBxemx2lKTj3uAXVMLA+KEoyfcSsTthHQIKRE4/xllXDM0gpQUhBuJc7EFaoxkSDFDfGU5HHFUTLn7m+we2tglTBvFwHSMvTGoaLXHWsYzKOCWm7BgjlWkMFMdogcSrpdQwWPAR1wIjJSHkhoPC2vz/jirbqcnsMoWXaDeS1bCrelpbKHSOitk/EhRada71HDVHUQWMiWokRlSQ2a+OmTv5zu57RPALCBbAgUi8lvZiZzdlhpkA2iHtE9Aj5v8DcwE5HtYaaqEC8HRjE4ztvTVqBhbQjSqoLQUb/LUfHT6tMXsCqBxhzLLe6fEE6u1m00gG4rjponvt3CrIBUsOjvsrAfz2pov9Me0vHtQNS2/tPebmBkH28SfvJBdV8mwqWJiMumGAi7dA1GSBSla8V5ymmJZlGWsL7aJtExbMouswW2xadlhU+/XuQbeDp5binIsBtHWp1YLNNsbhVDMgQFpnhcHoDoNb5mxppghGmEQrCXK2FzNgvxr7smivHqEWWZUv/5riV78TwOmnThAiM13A6sUFQHlMC9tcKpPPITsw0tRw5jT18AohhJrImsK5IBIehbzsdz+JPrFgehe2RgODaMYfyHHAsnBHFj0GpA/TYbW319o7IftFSOSmUhEyJSiOd3hEAi3pwe6ObbqN1WAdiHuB9MPWGsRoG1Bgry4JmaJFf91NAOqLu5VJmhV4oigoUBQRkFAaKJh17st7aK+94egWPtU4xOk3+8veyAwPe0DFgZwecPQTZyGVeB4FYZMHashfWqHTX09RSlxCpsIzHN95yFkxyZhqkIZQO1BJxkWJcxkmic+AZcm1lU6hIsrf/Pcvth/fX9f9Op77ss8fgv/zaIKqBILk/0Dq47+Bogdm9znyhPmxQLJF3yuEWoNsakAIwsAY1wD6WcB/vPFONtvZ+hDDDeyB4LBdkRh2UuFJuYS+O6Cld9/+PG86IFFYb1Lc8CAaYwUkQ9kpmVRclZmeRzLX9rksafhTlpVjqKxYFw9l1fD4V9Y00lxZNzPdlA0j07eyaVF2RLbMyr6SbQvycw8fanb+iyeR17CMNzI07ZFJ20WZmeK6zI3zUpaM8L0sa0ZJVlx7GCOr5sRnsmZEGirrdj6ulA0L0hPZdPrxd9my++mObDv+XHp3Q+19vu/jM+kNPiZGoeTQhdAyNLpqjqSya8VCkRi+bFu8iNboX+aoNj9KgR16Xdtcf73PlU6oHthLKzwwowl+Nn0zsL3V9Zw/zuRB0eBdedtr3N/P8Ck4onK/VMbQjUP21fEgbWKZ1l0p4gvhDvi5Iz+k3h9QXG1YJD6UCjdaS+D7a9S7o4M/Z0SiUuwmOsNqYNCvdYP7eqFBRy3pxHy/sRSvu1ffU7f/8Hdmw7OV/fDF90c7tvIEXOY4g5VA4D4U194M+XyjFu6BqnsTZOOqbYT+YBm4mPKrgWPwz197cJT+iV7EWHWUHoyGc+WMfe4SR7fNjB9y45+pqX/+tZe9xiV1xpJeJddnCyMez1Rt6iijNkrgcIrESvTCCYysIPbv8hKYyyRSiUxirIcNPGv/8+eHBPMsSZMM2GKi1UHPSaDtQGzbZ5HW3COZUfYfiTojgaJ8c82jqAO8ctNsLPb+ubdw3zu/3oqJFSVNDahcHTr6epNC0KNQyklakutLHx5LCCTrLQwe/G2kCjUouG9m7ldlLreXH8+KIPHDANguA8nUVKTRY7EVa0bnKP3SBmX6am9RpV9yUeuzGMe+j2k3eD3sLmmK/x8CvkHh7/jVQ/mZLKu+cWw/fIk3pb4BCXBRotD9/GyIFJls2/o9U1XX0NTS1tGlM5gsNocLgBCMoBhO8PgCoUgskcrkCqVKrUm0ajl9IJPZYrXZHU6X2+O1yWZbbLWNCoRgBMVwgqRohsPl8QVCkVgilckVSpXP7/GWx+2+JquatwEAAAA=) format('woff2');font-weight:normal;font-style:normal;font-display:swap;}
+      :root {
+        --chicago: "ChicagoPixel", Geneva, Tahoma, sans-serif;
+        /* Body prose uses a real, antialiased system sans for legibility;
+           the pixel ChicagoPixel face is reserved for chrome + headings. */
+        --geneva: Verdana, "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --mono: ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+        --beige: #d8cfbf;
+        --beige-d: #b7ad98;
+        --beige-l: #eae3d5;
+        --screen: #f7f5ee;
+      }
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      html { image-rendering: pixelated; }
+      body {
+        font-family: var(--geneva);
+        font-size: 24px;
+        line-height: 1.55;
+        color: #000;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: auto;
+        /* 50% gray desktop */
+        background-color: #8b8b8b;
+        background-image: linear-gradient(45deg, #000 25%, transparent 25%, transparent 75%, #000 75%, #000),
+          linear-gradient(45deg, #000 25%, transparent 25%, transparent 75%, #000 75%, #000);
+        background-size: 2px 2px;
+        background-position: 0 0, 1px 1px;
+        min-height: 100vh;
+        padding-bottom: 60px;
+      }
+      a { color: #000; text-decoration: underline; }
+      b { font-weight: 700; }
+
+      /* menu bar */
+      .menubar {
+        position: sticky; top: 0; z-index: 100;
+        background: #fff; border-bottom: 2px solid #000;
+        height: 38px; display: flex; align-items: center; gap: 28px;
+        padding: 0 20px; font-family: var(--chicago); font-size: 21px;
+      }
+      .menubar .apple { width: 24px; height: 24px; display: block; }
+      .menubar .clock { margin-left: auto; }
+      @media (max-width: 560px) { .menubar .opt { display: none; } }
+
+      /* ===== the machine ===== */
+      .stage { padding: 40px 14px 10px; display: flex; justify-content: center; }
+      .machine {
+        width: 100%; max-width: 680px;
+        background: var(--beige);
+        border: 2px solid #000;
+        border-radius: 26px 26px 14px 14px;
+        padding: 34px 34px 26px;
+        box-shadow: inset 2px 2px 0 var(--beige-l), inset -3px -3px 0 var(--beige-d),
+          6px 8px 0 rgba(0, 0, 0, 0.35);
+      }
+      .bezel {
+        background: var(--beige-d);
+        border: 2px solid #000;
+        border-radius: 10px;
+        padding: 22px 22px 20px;
+        box-shadow: inset 2px 2px 0 rgba(0,0,0,0.35);
+      }
+      .crt {
+        background: var(--screen);
+        border: 2px solid #000;
+        border-radius: 12px;
+        padding: 22px 24px 24px;
+        position: relative;
+        overflow: hidden;
+        min-height: 440px;
+        box-shadow: inset 0 0 0 2px var(--screen), inset 0 0 22px rgba(0,0,0,0.18);
+      }
+      .crt::after {
+        content: ""; position: absolute; inset: 0; pointer-events: none;
+        background: repeating-linear-gradient(to bottom, rgba(0,0,0,0.05) 0 1px, transparent 1px 3px);
+      }
+      .happy {
+        width: 46px; height: 52px; border: 2px solid #000; border-radius: 7px;
+        display: grid; place-content: center; margin: 4px auto 18px;
+      }
+      .boot-h {
+        font-family: var(--chicago); font-size: 20px; text-align: center;
+        margin-bottom: 20px;
+      }
+      .screen-win { border: 2px solid #000; background: #fff; }
+      .screen-win .tb {
+        height: 27px; border-bottom: 2px solid #000;
+        background: repeating-linear-gradient(to bottom, #000 0 1px, #fff 1px 3px);
+        display: flex; align-items: center; position: relative;
+      }
+      .screen-win .tb .cb { width: 15px; height: 15px; background: #fff; border: 2px solid #000; margin-left: 8px; }
+      .screen-win .tb .nm {
+        position: absolute; left: 50%; transform: translateX(-50%); background: #fff;
+        padding: 0 12px; font-family: var(--chicago); font-size: 19px; white-space: nowrap;
+      }
+      .screen-win .bd { padding: 20px 22px 22px; }
+      .eyebrow {
+        font-family: var(--chicago); font-size: 16px; display: inline-block;
+        border: 2px solid #000; padding: 2px 10px; margin-bottom: 18px;
+      }
+      h1 {
+        font-family: var(--chicago); font-weight: 400;
+        font-size: clamp(31px, 6vw, 43px); line-height: 1.12; margin: 0 0 18px;
+      }
+      .rotator {
+        position: relative; display: inline-block; text-align: left;
+        vertical-align: baseline; transition: width 260ms steps(5, end);
+        border-bottom: 3px solid #000;
+      }
+      .rotator-word { display: inline-block; white-space: nowrap; }
+      .rotator-measure { position: absolute; left: 0; top: 0; visibility: hidden; pointer-events: none; white-space: nowrap; }
+      @media (prefers-reduced-motion: reduce) { .rotator { transition: none; } }
+      .lede { font-size: 23px; line-height: 1.5; margin-bottom: 18px; }
+      .actions { display: flex; gap: 14px; flex-wrap: wrap; align-items: center; }
+      .btn {
+        font-family: var(--chicago); font-size: 20px; background: #fff; color: #000;
+        border: 2px solid #000; border-radius: 12px; padding: 8px 24px;
+        text-decoration: none; cursor: default; display: inline-block;
+      }
+      .btn:active { background: #000; color: #fff; }
+      .btn.default { box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000; margin: 2px; }
+      .caption {
+        font-family: var(--chicago); font-size: 16px; color: var(--beige-l);
+        text-align: right; margin-top: 8px;
+      }
+      .slot {
+        height: 8px; margin: 16px 20px 0; border-radius: 3px;
+        background: var(--beige-d);
+        box-shadow: inset 1px 1px 0 rgba(0,0,0,0.4), inset -1px -1px 0 var(--beige-l);
+      }
+      .badge {
+        display: flex; align-items: center; justify-content: space-between;
+        margin-top: 10px; font-family: var(--chicago); font-size: 18px; color: #4a4638;
+      }
+
+      /* ===== windows on the desktop ===== */
+      .screen { max-width: 920px; margin: 0 auto; padding: 32px 16px 0; }
+      .win { background: #fff; border: 2px solid #000; margin-bottom: 34px; box-shadow: 4px 4px 0 rgba(0,0,0,0.4); }
+      .titlebar {
+        height: 30px; border-bottom: 2px solid #000; display: flex; align-items: center; position: relative;
+        background: repeating-linear-gradient(to bottom, #000 0 1px, #fff 1px 3px);
+      }
+      .titlebar .box { width: 16px; height: 16px; background: #fff; border: 2px solid #000; margin-left: 8px; flex: 0 0 auto; }
+      .titlebar .name {
+        position: absolute; left: 50%; transform: translateX(-50%); background: #fff; padding: 0 14px;
+        font-family: var(--chicago); font-size: 19px; white-space: nowrap; max-width: 72%;
+        overflow: hidden; text-overflow: ellipsis;
+      }
+      .win-body { padding: 26px 28px 30px; }
+      .win-body p { margin: 0 0 18px; max-width: 62ch; }
+      .win-body p:last-child { margin-bottom: 0; }
+      h2, h3 { font-family: var(--chicago); font-weight: 400; }
+
+      .rows { margin: 8px 0 4px; border-top: 2px solid #000; }
+      .row { display: grid; grid-template-columns: 290px 1fr; gap: 22px; padding: 17px 0; border-bottom: 1px dotted #000; }
+      @media (max-width: 620px) { .row { grid-template-columns: 1fr; gap: 5px; } }
+      .row .k { font-family: var(--chicago); font-size: 21px; }
+      .row .k .t { display: block; font-family: var(--mono); font-size: 18px; margin-top: 5px; -webkit-font-smoothing: antialiased; }
+      .row .v { font-size: 23px; line-height: 1.5; }
+
+      ul.list { list-style: none; margin: 14px 0 0; display: grid; gap: 12px; }
+      ul.list li { position: relative; padding-left: 34px; font-size: 23px; line-height: 1.5; }
+      ul.list li::before { content: ""; position: absolute; left: 2px; top: 6px; width: 16px; height: 16px; border: 2px solid #000; background: #fff; }
+      ul.list.checked li::after { content: "✔"; position: absolute; left: 4px; top: 2px; font-size: 18px; font-weight: 700; }
+      code { font-family: var(--mono); font-size: 19px; background: #fff; border: 1px solid #000; padding: 1px 5px; -webkit-font-smoothing: antialiased; }
+
+      pre { font-family: var(--mono); font-size: 19px; line-height: 1.55; background: #fff; border: 2px solid #000; padding: 16px 20px; margin: 18px 0; overflow-x: auto; white-space: pre; -webkit-font-smoothing: antialiased; }
+      pre .c { opacity: 0.55; }
+      details { border: 2px solid #000; padding: 12px 16px; margin-top: 18px; }
+      summary { font-family: var(--chicago); font-size: 19px; cursor: default; }
+
+      .step-h { font-family: var(--chicago); font-size: 23px; margin: 28px 0 8px; display: flex; align-items: center; gap: 13px; }
+      .step-h .n { width: 32px; height: 32px; border: 2px solid #000; display: inline-flex; align-items: center; justify-content: center; font-size: 19px; flex: 0 0 auto; }
+      .field { font-family: var(--mono); font-size: 19px; border: 2px solid #000; padding: 12px 14px; margin: 14px 0; overflow-x: auto; white-space: nowrap; -webkit-font-smoothing: antialiased; }
+
+      .qa { display: grid; gap: 16px; margin-top: 10px; }
+      .qa .card { border: 2px solid #000; padding: 16px 20px; }
+      .qa .q { font-family: var(--chicago); font-size: 21px; margin-bottom: 10px; }
+      .qa .ans { font-family: var(--chicago); font-size: 33px; line-height: 1; }
+      .qa .note { font-size: 22px; line-height: 1.5; margin-top: 9px; display: block; }
+      .alert { border: 2px solid #000; padding: 20px; margin: 18px 0; display: grid; grid-template-columns: 62px 1fr; gap: 18px; align-items: start; box-shadow: 4px 4px 0 rgba(0,0,0,0.4); }
+      .alert .ico { width: 58px; height: 58px; border: 2px solid #000; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: var(--chicago); font-size: 33px; }
+
+      /* diagram */
+      .diagram { margin-top: 14px; overflow-x: auto; }
+      .diagram svg { width: 100%; min-width: 620px; height: auto; display: block; }
+      .diagram .node { fill: #fff; stroke: #000; stroke-width: 2; }
+      .diagram .box { fill: none; stroke: #000; stroke-width: 2; stroke-dasharray: 5 4; }
+      .diagram .t { font-family: var(--chicago); font-size: 15px; fill: #000; }
+      .diagram .s { font-family: var(--geneva); font-size: 13px; fill: #000; }
+      .diagram .e { font-family: var(--mono); font-size: 13px; fill: #000; }
+      .diagram .arr { stroke: #000; stroke-width: 2; fill: none; }
+
+      /* bar chart */
+      .barchart { border: 2px solid #000; padding: 18px; margin-top: 14px; }
+      .barchart .cl { font-family: var(--chicago); font-size: 19px; margin-bottom: 16px; }
+      .bar { display: grid; grid-template-columns: 150px 1fr 74px; align-items: center; gap: 13px; margin-bottom: 11px; font-size: 19px; }
+      .bar .name { text-align: right; }
+      .bar .track { height: 22px; border: 2px solid #000; background: #fff; }
+      .bar .fill { height: 100%; border-right: 2px solid #000; }
+      .bar .val { font-family: var(--mono); font-weight: 700; }
+      .d100 { background: #000; }
+      .d75 { background-color: #fff; background-image: linear-gradient(45deg, #000 40%, transparent 40%, transparent 90%, #000 90%, #000), linear-gradient(45deg, #000 40%, transparent 40%, transparent 90%, #000 90%, #000); background-size: 3px 3px; background-position: 0 0, 1.5px 1.5px; }
+      .d50 { background-color: #fff; background-image: linear-gradient(45deg, #000 25%, transparent 25%, transparent 75%, #000 75%, #000), linear-gradient(45deg, #000 25%, transparent 25%, transparent 75%, #000 75%, #000); background-size: 3px 3px; background-position: 0 0, 1.5px 1.5px; }
+      .d25 { background-color: #fff; background-image: radial-gradient(#000 34%, transparent 36%); background-size: 3px 3px; }
+
+      .why-h { font-size: 25px; margin: 26px 0 6px; }
+      .why-h:first-child { margin-top: 0; }
+
+      .aboutbox { max-width: 620px; margin: 0 auto 40px; }
+      .aboutbox .win-body { text-align: center; padding: 34px 28px; }
+      .aboutbox .mark { width: 60px; height: 60px; margin: 0 auto 14px; }
+      .aboutbox .wm { font-family: var(--chicago); font-size: 36px; }
+      .aboutbox .jp { font-size: 21px; margin-top: 11px; }
+      .aboutbox .links { margin-top: 20px; font-size: 22px; display: flex; gap: 20px; justify-content: center; flex-wrap: wrap; }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z" fill="currentColor" />
+        <path d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z" fill="currentColor" />
+        <path d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z" fill="currentColor" />
+      </symbol>
+    </svg>
+
+    <!-- MENU BAR -->
+    <div class="menubar">
+      <svg class="apple" viewBox="0 0 64 64" aria-label="Setoku menu"><use href="#clover" /></svg>
+      <span>File</span>
+      <span>Edit</span>
+      <span class="opt">View</span>
+      <span class="opt">Special</span>
+      <span class="clock">Macintosh</span>
+    </div>
+
+    <!-- THE MACHINE -->
+    <div class="stage">
+      <div class="machine">
+        <div class="bezel">
+          <div class="crt">
+            <div class="happy" aria-hidden="true">
+              <svg width="16" height="18" viewBox="0 0 16 18">
+                <rect x="3" y="3" width="2" height="3" fill="#000" />
+                <rect x="11" y="3" width="2" height="3" fill="#000" />
+                <path d="M3 10 h2 v2 h6 v-2 h2 v2 h-2 v2 H5 v-2 H3 Z" fill="#000" />
+              </svg>
+            </div>
+            <div class="boot-h">Welcome to Setoku</div>
+            <div class="screen-win">
+              <div class="tb"><span class="cb"></span><span class="nm">Setoku</span></div>
+              <div class="bd">
+                <span class="eyebrow">Open source · MCP server · Apache-2.0</span>
+                <h1>
+                  Make any AI fluent in your
+                  <span class="rotator" data-words="company,family,personal"
+                    ><span class="rotator-word">company</span
+                    ><span class="rotator-measure" aria-hidden="true"></span></span>
+                  data.
+                </h1>
+                <p class="lede">
+                  Setoku is a small self-hosted MCP knowledge server + Claude Code
+                  skills for hooking up your data. It does two things: it gives
+                  your AI a read-only way to query your data, and it remembers
+                  what that data means (the metric definitions, the gotchas),
+                  getting better the more you use it. The MCP works with whatever
+                  AI you already have, and no model runs on the server, so no
+                  added inference cost.
+                </p>
+                <div class="actions">
+                  <a class="btn default" href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">View on GitHub</a>
+                  <a class="btn" href="#demo">Try the demo</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="slot" aria-hidden="true"></div>
+        <div class="badge">
+          <span>Macintosh</span>
+          <svg width="24" height="24" viewBox="0 0 64 64" aria-hidden="true" style="color:#4a4638"><use href="#clover" /></svg>
+        </div>
+      </div>
+    </div>
+
+    <main class="screen" id="top">
+      <!-- QUICKSTART -->
+      <section class="win">
+        <div class="titlebar"><span class="box"></span><span class="name">Insert disk: Quickstart</span><span class="box"></span></div>
+        <div class="win-body">
+          <p>
+            Setoku installs as a Claude Code plugin. Add the plugin, then run
+            onboarding from your main project directory, the codebase you want
+            Setoku to learn from:
+          </p>
+<pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+          <p>
+            Onboarding stands up the server, auths your Claude, wires your
+            database read-only, and generates the first knowledge from your code.
+            You stay in the loop for anything that touches your data. To start
+            onboarding, run <code>/setoku:onboard</code>.
+          </p>
+          <p>
+            You’ll need somewhere to host it. Something like OVH’s
+            <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener">VPS-2</a>
+            is plenty.
+          </p>
+          <details>
+            <summary>Or stand up the server by hand</summary>
+<pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+            <p style="margin-top: 8px">
+              Installs Docker, generates secrets, gets an HTTPS certificate, and
+              prints the connect command. Then add the plugin and run
+              /setoku:onboard from your project; it’ll detect the box you just
+              made.
+            </p>
+          </details>
+        </div>
+      </section>
+
+      <!-- HOW IT WORKS -->
+      <section class="win">
+        <div class="titlebar"><span class="box"></span><span class="name">How it works</span><span class="box"></span></div>
+        <div class="win-body">
+          <p>
+            Setoku gives the AI two kinds of MCP tools, and one rule: look up what
+            the data means before you touch it.
+          </p>
+          <div class="rows">
+            <div class="row">
+              <div class="k">Context tools<span class="t">find_context · get_metric</span></div>
+              <div class="v">The AI reads what your data means first: canonical metric definitions, entity docs, and the gotchas that make a naive query wrong.</div>
+            </div>
+            <div class="row">
+              <div class="k">Read-only query<span class="t">get_schema · run_query</span></div>
+              <div class="v">Read-only, with a row cap, a statement timeout, a table allow-list, and an append-only audit log. Enforced by the database role, not by parsing SQL.</div>
+            </div>
+            <div class="row">
+              <div class="k">Human-approved<span class="t">report_correction</span></div>
+              <div class="v">The AI can only propose changes to what Setoku knows. A person accepts them on the admin page, outside the agent loop, so an injected session can’t rewrite the brain.</div>
+            </div>
+          </div>
+          <p style="margin-top: 15px">You set it up with <b>Claude Code</b> skills:</p>
+          <ul class="list">
+            <li><code>/setoku:onboard</code> sets Setoku up in a repo for the first time.</li>
+            <li><code>/setoku:connect</code> adds a data source or custom integration.</li>
+            <li><code>/setoku:generate</code> writes business context from your code.</li>
+            <li><code>/setoku:curate</code> reviews and approves pending knowledge.</li>
+          </ul>
+          <p style="margin-top: 11px">
+            Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex, or
+            whatever you run. Just ask in plain language, and the tools do the
+            rest.
+          </p>
+        </div>
+      </section>
+
+      <!-- APPS -->
+      <section class="win">
+        <div class="titlebar"><span class="box"></span><span class="name">Apps</span><span class="box"></span></div>
+        <div class="win-body">
+          <h2 style="font-size: 26px; margin-bottom: 10px">Save and share the tools Claude builds you</h2>
+          <p>
+            Ask Claude to build a dashboard on your data. Then publish it to a
+            link as a Setoku App, the data stays live, and your whole team can
+            view it. Nothing to deploy, no frontend to maintain.
+          </p>
+          <div class="rows">
+            <div class="row">
+              <div class="k">Built by asking<span class="t">publish_app</span></div>
+              <div class="v">Describe it in plain language; the agent writes the app and publishes it to a URL. Edit it the same way, just ask for the change.</div>
+            </div>
+            <div class="row">
+              <div class="k">Backed by live data<span class="t">read-only</span></div>
+              <div class="v">Apps read through the same governed path: row caps, audit, a SELECT-only database role. They never get write access to your sources.</div>
+            </div>
+            <div class="row">
+              <div class="k">App-private state<span class="t">no writes to your data</span></div>
+              <div class="v">Each app keeps its own state (todos, votes, annotations) in a sandbox that belongs to the app, not your database. Worst case, an app messes up its own notes.</div>
+            </div>
+            <div class="row">
+              <div class="k">Share by link<span class="t">team or public</span></div>
+              <div class="v">A team link is login-gated; an admin can flip one public for a credential-free URL. The page runs in a locked-down sandbox with no network, so a published app can’t phone home.</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ARCHITECTURE -->
+      <section class="win">
+        <div class="titlebar"><span class="box"></span><span class="name">Architecture</span><span class="box"></span></div>
+        <div class="win-body">
+          <p>
+            You can host this on whatever infra you like. We put it all on one
+            small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+            helps you add custom integrations. Only the proxy is public, so your
+            databases aren’t exposed. Queries are read-only, and knowledge changes
+            pass through a person.
+          </p>
+          <div class="diagram">
+            <svg viewBox="0 0 680 520" role="img" aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake for analytics, and your sources are ingested into the lake.">
+              <defs>
+                <marker id="ah" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto-start-reverse">
+                  <path d="M0 0 L6 3 L0 6 Z" fill="#000" />
+                </marker>
+              </defs>
+              <rect class="node" x="250" y="14" width="180" height="44" />
+              <text class="t" x="340" y="41" text-anchor="middle">You + your AI</text>
+              <path class="arr" d="M340 58 L340 142" marker-start="url(#ah)" marker-end="url(#ah)" />
+              <text class="e" x="348" y="86">MCP</text>
+              <rect class="box" x="60" y="110" width="560" height="300" />
+              <text class="e" x="76" y="130">your box</text>
+              <rect class="node" x="250" y="146" width="180" height="58" />
+              <text class="t" x="340" y="171" text-anchor="middle">Setoku gateway</text>
+              <text class="s" x="340" y="189" text-anchor="middle">context · query tools</text>
+              <rect class="node" x="452" y="150" width="150" height="50" />
+              <text class="t" x="527" y="179" text-anchor="middle">a person</text>
+              <rect class="node" x="92" y="322" width="180" height="66" />
+              <text class="t" x="182" y="350" text-anchor="middle">Lake (ClickHouse)</text>
+              <text class="s" x="182" y="368" text-anchor="middle">logs · events · DB mirror</text>
+              <rect class="node" x="408" y="322" width="190" height="66" />
+              <text class="t" x="503" y="359" text-anchor="middle">Knowledge store</text>
+              <rect class="node" x="92" y="440" width="180" height="64" />
+              <text class="t" x="182" y="468" text-anchor="middle">Your sources</text>
+              <text class="s" x="182" y="486" text-anchor="middle">GitHub · Vercel · Slack…</text>
+              <rect class="node" x="300" y="440" width="180" height="64" />
+              <text class="t" x="390" y="468" text-anchor="middle">Your database</text>
+              <text class="s" x="390" y="486" text-anchor="middle">Postgres · read-only</text>
+              <path class="arr" d="M412 204 L508 322" marker-start="url(#ah)" marker-end="url(#ah)" />
+              <text class="e" x="424" y="266" text-anchor="middle">reads ·</text>
+              <text class="e" x="424" y="282" text-anchor="middle">proposes</text>
+              <path class="arr" d="M527 200 L513 322" marker-end="url(#ah)" />
+              <text class="e" x="534" y="262">approves</text>
+              <path class="arr" d="M210 322 L300 204" marker-end="url(#ah)" />
+              <path class="arr" d="M182 440 L182 388" marker-end="url(#ah)" />
+              <text class="e" x="190" y="420">ingest</text>
+              <path class="arr" d="M388 440 L366 206" marker-end="url(#ah)" />
+              <text class="e" x="300" y="300">read-only</text>
+            </svg>
+          </div>
+        </div>
+      </section>
+
+      <!-- CONNECTORS -->
+      <section class="win">
+        <div class="titlebar"><span class="box"></span><span class="name">Connectors</span><span class="box"></span></div>
+        <div class="win-body">
+          <p>
+            Point Setoku at the data you already have. Every source lands in a
+            local
+            <a href="https://clickhouse.com/" target="_blank" rel="noopener">ClickHouse</a>
+            data lake, on purpose: agents write arbitrary queries (scans, GROUP
+            BYs, whole-table aggregations), and a columnar engine answers those in
+            about a second, so the apps and dashboards they build stay quick. Your
+            app database connects read-only and is mirrored in on a cron; the rest
+            is ingested as it happens.
+          </p>
+          <p style="font-family: var(--chicago); margin: 4px 0 2px">ClickHouse · one lake, every source</p>
+          <ul class="list checked">
+            <li><b>PostgreSQL</b> — app database, mirrored read-only</li>
+            <li><b>GitHub</b> — issues, PRs &amp; commits</li>
+            <li><b>Vercel</b> — deploys &amp; logs</li>
+            <li><b>Render</b> — deploys &amp; logs</li>
+            <li><b>Slack</b> — messages</li>
+            <li><b>Mercury</b> — banking &amp; finance</li>
+          </ul>
+          <p style="margin-top: 13px">
+            No connector for your source yet? The included setup skills give your
+            coding agent the patterns to wire one up itself. See
+            <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">the repo</a>, or open an issue.
+          </p>
+        </div>
+      </section>
+
+      <!-- DEMO -->
+      <section class="win" id="demo">
+        <div class="titlebar"><span class="box"></span><span class="name">Try it on real-ish data</span><span class="box"></span></div>
+        <div class="win-body">
+          <p>
+            There’s a live demo wired to a fictional pro sports club, the Bonita
+            Bulldogs (ticketing, sponsorship, concessions, payroll, broadcast
+            rights).
+          </p>
+
+          <div class="step-h"><span class="n">1</span>Connect to the demo MCP server</div>
+          <p style="font-size: 20px">
+            In Claude (or any MCP client) open Settings → Connectors → Add custom
+            connector, and paste this URL. The token rides in the URL, so there’s
+            no separate key to enter.
+          </p>
+          <div class="field">https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</div>
+
+          <div class="step-h"><span class="n">2</span>Ask a question</div>
+          <div class="qa">
+            <div class="card">
+              <div class="q">“How many unique fans do we have?”</div>
+              <div class="ans">71,204</div>
+              <span class="note">deduped by normalized email, internal accounts excluded. Not the raw 92,118.</span>
+            </div>
+            <div class="card">
+              <div class="q">“What’s our total annual revenue, and how much is media rights?”</div>
+              <div class="ans">$192M</div>
+              <span class="note">five systems reconciled to the same units. Media rights is the biggest line, ~$90M.</span>
+            </div>
+            <div class="card">
+              <div class="q">“What was ticket revenue this season?”</div>
+              <div class="ans">$46.8M</div>
+              <span class="note">cents reconciled to dollars; refunds, exchanges, and comps excluded.</span>
+            </div>
+          </div>
+
+          <div class="alert">
+            <div class="ico">!</div>
+            <div>
+              <div class="q" style="font-family: var(--chicago); margin-bottom: 4px">“What’s our total merchandise revenue?”</div>
+              <b>It flags it.</b>
+              <span class="note">most merch is sold via Fanatics, not in this data, so it says so instead of returning a wrong total.</span>
+            </div>
+          </div>
+
+          <div class="barchart">
+            <div class="cl">“Chart revenue by line.” · Annual revenue · ~$192M total</div>
+            <div class="bar"><span class="name">Media rights</span><span class="track"><span class="fill d100" style="width: 100%"></span></span><span class="val">$90M</span></div>
+            <div class="bar"><span class="name">Ticketing</span><span class="track"><span class="fill d75" style="width: 52%"></span></span><span class="val">$47M</span></div>
+            <div class="bar"><span class="name">Sponsorship</span><span class="track"><span class="fill d50" style="width: 31%"></span></span><span class="val">$28M</span></div>
+            <div class="bar"><span class="name">Concessions</span><span class="track"><span class="fill d50" style="width: 16%"></span></span><span class="val">$14M</span></div>
+            <div class="bar"><span class="name">Merch</span><span class="track"><span class="fill d25" style="width: 9%"></span></span><span class="val">$8M</span></div>
+            <div class="bar"><span class="name">Other</span><span class="track"><span class="fill d25" style="width: 6%"></span></span><span class="val">$5M</span></div>
+          </div>
+
+          <div class="step-h"><span class="n">3</span>Try an app</div>
+          <p style="font-size: 20px">
+            Ask Claude to build a dashboard on the same data, then publish it to a
+            link. Two live examples, running on the demo data right now:
+          </p>
+          <ul class="list">
+            <li>
+              <a href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d" target="_blank" rel="noopener">Sponsorship pricing table ↗</a>
+              — inventory and rates for sponsorship placements.
+            </li>
+            <li>
+              <a href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea" target="_blank" rel="noopener">Fan lifetime value ↗</a>
+              — segment fans by spend across tickets, merch, and concessions.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- WHY -->
+      <section class="win">
+        <div class="titlebar"><span class="box"></span><span class="name">Why we built it</span><span class="box"></span></div>
+        <div class="win-body">
+          <h3 class="why-h">We’re curious.</h3>
+          <p>There are plenty of AI memory stores, and plenty of data gateways. Stapling the two together, and nudging the agent to gather knowledge about the data as it goes, seemed useful and fun to tinker with.</p>
+          <h3 class="why-h">We’re cheap.</h3>
+          <p>We wanted something that runs on one small box, works on a Pro/Max subscription or a cheap model with no added inference cost, mostly sets itself up (no field engineer to pay for), stays portable between providers, and is open source.</p>
+          <h3 class="why-h">We’re paranoid.</h3>
+          <p>HR platforms, CRMs, and clouds are all announcing “context layers.” They’d like the meaning of your business to accumulate on their servers, where it can never leave. Context is deeper lock-in than data, and a hosted context layer has no export button. Setoku exists so that understanding accumulates on a box you own instead. If we disappear tomorrow, your context doesn’t.</p>
+          <h3 class="why-h">We and some friends wanted the same thing.</h3>
+          <ul class="list">
+            <li><b><a href="https://www.hedgy.works" target="_blank" rel="noopener">Hedgy</a></b>: keep scaling without hiring. Debug from live logs and data, find growth levers, and match candidates and companies better with more data.</li>
+            <li><b><a href="https://baggu.com" target="_blank" rel="noopener">Baggu</a></b>: give employees state-of-the-art tools. Faster onboarding, and a safe way to vibecode against real data.</li>
+            <li><b><a href="https://tlon.io" target="_blank" rel="noopener">Tlon</a></b>: experimenting with giving agents curated data to work from.</li>
+            <li><b>Sports analysts</b>: query across data that doesn’t usually sit together.</li>
+            <li><b>Academic labs</b>: think through hypotheses against real papers, data, and drafts.</li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- SETUP HELP -->
+      <section class="win">
+        <div class="titlebar"><span class="box"></span><span class="name">Setup help</span><span class="box"></span></div>
+        <div class="win-body">
+          <p>It’s open source, so you can self-host it today. If you like, we’re happy to help set it up. Just email <a href="mailto:hello@setoku.com">hello@setoku.com</a>.</p>
+        </div>
+      </section>
+
+      <!-- ABOUT -->
+      <section class="win aboutbox">
+        <div class="titlebar"><span class="box"></span><span class="name">About Setoku</span><span class="box"></span></div>
+        <div class="win-body">
+          <svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+          <div class="wm">Setoku</div>
+          <div class="jp">設 × 奥 · set (math) × oku (innermost)</div>
+          <div class="links">
+            <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">GitHub</a>
+            <a href="#demo">Demo</a>
+            <a href="mailto:hello@setoku.com">Contact</a>
+            <span>Apache-2.0</span>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "").split(",").map(function (w) { return w.trim(); }).filter(Boolean);
+        if (words.length < 2) return;
+        var i = 0;
+        function widthOf(w) { measure.textContent = w; return measure.getBoundingClientRect().width; }
+        box.style.width = widthOf(words[0]) + "px";
+        function swap() {
+          i = (i + 1) % words.length;
+          word.textContent = words[i];
+          box.style.width = widthOf(words[i]) + "px";
+        }
+        setInterval(swap, 2000);
+        window.addEventListener("resize", function () { box.style.width = widthOf(words[i]) + "px"; });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/11-nfo.html
+++ b/site/riffs/11-nfo.html
@@ -1,0 +1,875 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SETOKU.NFO · open-source MCP server for company data</title>
+    <style>
+      :root {
+        --paper: #f4efe1;
+        --paper-2: #efe8d6;
+        --ink: #22271f;
+        --ink-soft: #454b3e;
+        --ink-faint: #6b6f5f;
+        --sage: #33543d;
+        --sage-2: #4c7a58;
+        --rule: rgba(34, 39, 31, 0.28);
+        --rule-soft: rgba(34, 39, 31, 0.14);
+        --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas,
+          "Liberation Mono", "DejaVu Sans Mono", monospace;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        -webkit-font-smoothing: antialiased;
+        scroll-behavior: smooth;
+      }
+      body {
+        background: var(--paper);
+        background-image: radial-gradient(
+            rgba(34, 39, 31, 0.03) 1px,
+            transparent 1px
+          );
+        background-size: 3px 3px;
+        color: var(--ink);
+        font-family: var(--mono);
+        font-size: 14px;
+        line-height: 1.55;
+        padding: 0 16px 80px;
+      }
+      .sheet {
+        max-width: 82ch;
+        margin: 0 auto;
+        padding-top: 22px;
+      }
+      a {
+        color: var(--sage);
+        text-decoration: none;
+        border-bottom: 1px dotted var(--sage-2);
+      }
+      a:hover {
+        background: var(--sage);
+        color: var(--paper);
+        border-bottom-color: var(--sage);
+      }
+      b,
+      strong {
+        font-weight: 700;
+        color: var(--ink);
+      }
+      ::selection {
+        background: var(--sage);
+        color: var(--paper);
+      }
+
+      pre {
+        overflow-x: auto;
+        white-space: pre;
+        line-height: 1.2;
+        margin: 0;
+      }
+      pre.tight {
+        line-height: 1.15;
+      }
+
+      /* masthead */
+      .banner {
+        color: var(--ink);
+        font-size: clamp(8px, 2.1vw, 14px);
+        letter-spacing: 0;
+      }
+      .banner .g {
+        color: var(--sage-2);
+      }
+      .tagline {
+        margin: 6px 0 2px;
+        font-size: clamp(13px, 3vw, 20px);
+        line-height: 1.3;
+        color: var(--ink);
+        letter-spacing: -0.01em;
+      }
+      .rot {
+        display: inline-block;
+        min-width: 9ch;
+        text-align: center;
+        color: var(--sage);
+        border-bottom: 1px solid var(--sage-2);
+      }
+      .cur {
+        display: inline-block;
+        width: 0.62em;
+        height: 1.05em;
+        transform: translateY(0.18em);
+        background: var(--ink);
+        margin-left: 2px;
+        animation: blink 1.05s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .cur {
+          animation: none;
+        }
+      }
+
+      /* release info + framed callouts (drawn, so borders always align) */
+      .frame {
+        border: 1px solid var(--rule);
+        background: var(--paper-2);
+        padding: 12px 15px;
+        margin: 14px 0;
+        position: relative;
+      }
+      .frame > .tag {
+        position: absolute;
+        top: -0.72em;
+        left: 12px;
+        background: var(--paper);
+        padding: 0 7px;
+        color: var(--sage);
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      .kv {
+        display: grid;
+        grid-template-columns: max-content 1fr;
+        gap: 2px 10px;
+        font-size: 13px;
+        color: var(--ink-soft);
+      }
+      .kv .k {
+        color: var(--ink-faint);
+      }
+      .kv .k::after {
+        content: " ";
+      }
+
+      /* section rule */
+      .rule {
+        color: var(--sage);
+        margin: 34px 0 14px;
+        font-size: clamp(10px, 2.2vw, 14px);
+        overflow-x: auto;
+        white-space: pre;
+      }
+      section {
+        scroll-margin-top: 12px;
+      }
+      h2 {
+        font: inherit;
+      }
+
+      p {
+        color: var(--ink-soft);
+        max-width: 74ch;
+        margin: 10px 0;
+      }
+      p.lede {
+        color: var(--ink);
+      }
+      .muted {
+        color: var(--ink-faint);
+      }
+
+      /* generic terminal-ish list */
+      .list {
+        list-style: none;
+        margin: 10px 0;
+        max-width: 74ch;
+      }
+      .list li {
+        color: var(--ink-soft);
+        padding-left: 3.2ch;
+        position: relative;
+        margin: 4px 0;
+      }
+      .list li::before {
+        content: "*";
+        position: absolute;
+        left: 0.6ch;
+        color: var(--sage-2);
+      }
+
+      /* code blocks */
+      .code {
+        border: 1px solid var(--rule-soft);
+        border-left: 3px solid var(--sage-2);
+        background: var(--paper-2);
+        padding: 12px 14px;
+        margin: 12px 0;
+        overflow-x: auto;
+      }
+      .code pre {
+        line-height: 1.6;
+      }
+      .code .c {
+        color: var(--ink-faint);
+      }
+      code.inl {
+        color: var(--sage);
+      }
+
+      /* how-it-works / apps rows */
+      .rows {
+        margin: 14px 0;
+      }
+      .rows .r {
+        border-top: 1px dotted var(--rule-soft);
+        padding: 11px 0;
+        display: grid;
+        grid-template-columns: 20ch 1fr;
+        gap: 4px 18px;
+      }
+      .rows .r:last-child {
+        border-bottom: 1px dotted var(--rule-soft);
+      }
+      .rows .r .name {
+        color: var(--ink);
+      }
+      .rows .r .name b {
+        display: block;
+      }
+      .rows .r .name .fn {
+        color: var(--sage-2);
+        font-size: 12.5px;
+      }
+      .rows .r .desc {
+        color: var(--ink-soft);
+      }
+      @media (max-width: 620px) {
+        .rows .r {
+          grid-template-columns: 1fr;
+          gap: 2px;
+        }
+      }
+
+      /* Q & A */
+      .qa {
+        margin: 12px 0;
+        border-top: 1px dotted var(--rule-soft);
+        padding-top: 12px;
+      }
+      .qa .q::before {
+        content: "> ";
+        color: var(--sage-2);
+      }
+      .qa .q {
+        color: var(--ink);
+      }
+      .qa .a {
+        padding-left: 2.2ch;
+        margin-top: 4px;
+        color: var(--ink-faint);
+      }
+      .qa .a b {
+        color: var(--sage);
+        font-size: 15px;
+      }
+
+      /* nav toc anchors */
+      .toc a {
+        border-bottom: none;
+      }
+      .toc a:hover {
+        background: none;
+        color: var(--sage-2);
+        text-decoration: underline;
+      }
+
+      hr.dotted {
+        border: none;
+        border-top: 1px dotted var(--rule-soft);
+        margin: 22px 0;
+      }
+
+      footer {
+        margin-top: 40px;
+        color: var(--ink-faint);
+        font-size: 13px;
+      }
+      footer .jp {
+        color: var(--ink-soft);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="sheet">
+      <!-- ===================== MASTHEAD ===================== -->
+      <pre class="banner tight" aria-label="SETOKU"> <span class="g">.----------------------------------------------------------------------.</span>
+<span class="g"> :</span>   ______     ______     ______   ______     __  __     __  __      <span class="g">:</span>
+<span class="g"> :</span>  /\  ___\   /\  ___\   /\__  _\ /\  __ \   /\ \/ /    /\ \/\ \     <span class="g">:</span>
+<span class="g"> :</span>  \ \___  \  \ \  __\   \/_/\ \/ \ \ \/\ \  \ \  _"-.  \ \ \_\ \    <span class="g">:</span>
+<span class="g"> :</span>   \/\_____\  \ \_____\    \ \_\  \ \_____\  \ \_\ \_\  \ \_____\   <span class="g">:</span>
+<span class="g"> :</span>    \/_____/   \/_____/     \/_/   \/_____/   \/_/\/_/   \/_____/   <span class="g">:</span>
+<span class="g"> :</span>                                                                      <span class="g">:</span>
+<span class="g"> :</span>   an open-source MCP server between your AI and your company data     <span class="g">:</span>
+<span class="g"> '----------------------------------------------------------------------'</span></pre>
+
+      <p class="tagline">
+        make any AI fluent in your
+        <span
+          class="rot"
+          data-words="company,family,personal"
+          >company</span
+        >
+        data.<span class="cur" aria-hidden="true"></span>
+      </p>
+
+      <div class="frame">
+        <span class="tag">release.nfo</span>
+        <div class="kv">
+          <span class="k">supply .......</span>
+          <span
+            ><a
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >github.com/Hedgy-Labs/setoku</a
+            ></span
+          >
+          <span class="k">packaged by ..</span>
+          <span>Hedgy Labs</span>
+          <span class="k">license ......</span>
+          <span>Apache-2.0 · you self-host it</span>
+          <span class="k">inference ....</span>
+          <span>none on the server · $0 added cost</span>
+          <span class="k">requires .....</span>
+          <span>one small box (a ~$12/mo VPS) + any MCP client</span>
+          <span class="k">works with ...</span>
+          <span>Claude, Codex, or whatever you already run</span>
+        </div>
+      </div>
+
+      <!-- ===================== TOC ===================== -->
+      <pre class="rule toc"> .-=[ CONTENTS ]=-.------------------------------------------------------
+   01 <a href="#synopsis">SYNOPSIS</a> ......... what this is
+   02 <a href="#quickstart">QUICKSTART</a> ....... install &amp; onboard in two steps
+   03 <a href="#how">HOW IT WORKS</a> ..... two tool families, one rule
+   04 <a href="#apps">APPS</a> ............. publish the tools Claude builds you
+   05 <a href="#arch">ARCHITECTURE</a> ..... the whole thing on one box
+   06 <a href="#connectors">CONNECTORS</a> ....... one lake, every source
+   07 <a href="#demo">DEMO</a> ............. try it on real-ish data
+   08 <a href="#why">RATIONALE</a> ........ curious / cheap / paranoid
+   09 <a href="#help">GREETZ &amp; CONTACT</a> . setup help
+ ----------------------------------------------------------------------</pre>
+
+      <!-- ===================== 01 SYNOPSIS ===================== -->
+      <section id="synopsis">
+        <pre class="rule"> .-=[ 01. SYNOPSIS ]=-.------------------------------------------------</pre>
+        <p class="lede">
+          Setoku is a small self-hosted MCP knowledge server + Claude Code
+          skills for hooking up your data. It does two things: it gives your AI
+          a read-only way to query your data, and it remembers what that data
+          means (the metric definitions, the gotchas), getting better the more
+          you use it. The MCP works with whatever AI you already have, and no
+          model runs on the server, so no added inference cost.
+        </p>
+        <ul class="list">
+          <li>
+            <a
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >[ view on github ]</a
+            >
+          </li>
+          <li><a href="#demo">[ try the demo ]</a></li>
+        </ul>
+      </section>
+
+      <!-- ===================== 02 QUICKSTART ===================== -->
+      <section id="quickstart">
+        <pre class="rule"> .-=[ 02. QUICKSTART ]=-.----------------------------------------------</pre>
+        <p>
+          Setoku installs as a Claude Code plugin. Add the plugin, then run
+          onboarding from your main project directory, the codebase you want
+          Setoku to learn from:
+        </p>
+        <div class="code">
+          <pre><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</pre>
+        </div>
+        <p>
+          Onboarding stands up the server, auths your Claude, wires your
+          database read-only, and generates the first knowledge from your code.
+          You stay in the loop for anything that touches your data. To start
+          onboarding, run <code class="inl">/setoku:onboard</code>.
+        </p>
+        <p>
+          You’ll need somewhere to host it. Something like OVH’s
+          <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener"
+            >VPS-2</a
+          >
+          is plenty.
+        </p>
+        <details>
+          <summary
+            class="muted"
+            style="cursor: pointer; margin-top: 8px"
+          >
+            [+] or stand up the server by hand
+          </summary>
+          <div class="code">
+            <pre><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</pre>
+          </div>
+          <p>
+            Installs Docker, generates secrets, gets an HTTPS certificate, and
+            prints the connect command. Then add the plugin and run
+            /setoku:onboard from your project; it’ll detect the box you just
+            made.
+          </p>
+        </details>
+      </section>
+
+      <!-- ===================== 03 HOW IT WORKS ===================== -->
+      <section id="how">
+        <pre class="rule"> .-=[ 03. HOW IT WORKS ]=-.--------------------------------------------</pre>
+        <p class="lede">
+          Setoku gives the AI two kinds of MCP tools, and one rule: look up what
+          the data means before you touch it.
+        </p>
+        <div class="rows">
+          <div class="r">
+            <div class="name">
+              <b>Context tools</b
+              ><span class="fn">find_context · get_metric</span>
+            </div>
+            <div class="desc">
+              The AI reads what your data means first: canonical metric
+              definitions, entity docs, and the gotchas that make a naive query
+              wrong.
+            </div>
+          </div>
+          <div class="r">
+            <div class="name">
+              <b>Read-only query</b
+              ><span class="fn">get_schema · run_query</span>
+            </div>
+            <div class="desc">
+              Read-only, with a row cap, a statement timeout, a table allow-list,
+              and an append-only audit log. Enforced by the database role, not by
+              parsing SQL.
+            </div>
+          </div>
+          <div class="r">
+            <div class="name">
+              <b>Human-approved</b><span class="fn">report_correction</span>
+            </div>
+            <div class="desc">
+              The AI can only propose changes to what Setoku knows. A person
+              accepts them on the admin page, outside the agent loop, so an
+              injected session can’t rewrite the brain.
+            </div>
+          </div>
+        </div>
+        <p class="muted">You set it up with <b>Claude Code</b> skills:</p>
+        <ul class="list">
+          <li>
+            <code class="inl">/setoku:onboard</code> sets Setoku up in a repo for
+            the first time.
+          </li>
+          <li>
+            <code class="inl">/setoku:connect</code> adds a data source or custom
+            integration.
+          </li>
+          <li>
+            <code class="inl">/setoku:generate</code> writes business context
+            from your code.
+          </li>
+          <li>
+            <code class="inl">/setoku:curate</code> reviews and approves pending
+            knowledge.
+          </li>
+        </ul>
+        <p>
+          Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex, or
+          whatever you run. Just ask in plain language, and the tools do the
+          rest.
+        </p>
+      </section>
+
+      <!-- ===================== 04 APPS ===================== -->
+      <section id="apps">
+        <pre class="rule"> .-=[ 04. APPS // save &amp; share the tools Claude builds you ]=-.--------</pre>
+        <p class="lede">
+          Ask Claude to build a dashboard on your data. Then publish it to a link
+          as a Setoku App, the data stays live, and your whole team can view it.
+          Nothing to deploy, no frontend to maintain.
+        </p>
+        <div class="rows">
+          <div class="r">
+            <div class="name">
+              <b>Built by asking</b><span class="fn">publish_app</span>
+            </div>
+            <div class="desc">
+              Describe it in plain language; the agent writes the app and
+              publishes it to a URL. Edit it the same way, just ask for the
+              change.
+            </div>
+          </div>
+          <div class="r">
+            <div class="name">
+              <b>Backed by live data</b><span class="fn">read-only</span>
+            </div>
+            <div class="desc">
+              Apps read through the same governed path: row caps, audit, a
+              SELECT-only database role. They never get write access to your
+              sources.
+            </div>
+          </div>
+          <div class="r">
+            <div class="name">
+              <b>App-private state</b
+              ><span class="fn">no writes to your data</span>
+            </div>
+            <div class="desc">
+              Each app keeps its own state (todos, votes, annotations) in a
+              sandbox that belongs to the app, not your database. Worst case, an
+              app messes up its own notes.
+            </div>
+          </div>
+          <div class="r">
+            <div class="name">
+              <b>Share by link</b><span class="fn">team or public</span>
+            </div>
+            <div class="desc">
+              A team link is login-gated; an admin can flip one public for a
+              credential-free URL. The page runs in a locked-down sandbox with no
+              network, so a published app can’t phone home.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== 05 ARCHITECTURE ===================== -->
+      <section id="arch">
+        <pre class="rule"> .-=[ 05. ARCHITECTURE ]=-.--------------------------------------------</pre>
+        <p class="lead lede">
+          You can host this on whatever infra you like. We put it all on one
+          small box (a ~$12/mo VPS). The <code class="inl">/setoku:connect</code>
+          skill helps you add custom integrations. Only the proxy is public, so
+          your databases aren’t exposed. Queries are read-only, and knowledge
+          changes pass through a person.
+        </p>
+        <pre
+          class="rule"
+          style="color: var(--ink-soft); margin-top: 18px"
+          aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake, and your sources are ingested into the lake."
+>                          +---------------------+
+                          |    You + your AI    |
+                          +----------+----------+
+                                     |
+                                 MCP | bearer token in URL
+                                     |
+   +--------------------------- your box ----------------------------+
+   |                    +----------+----------+      approves        |
+   |                    |   Setoku gateway    |------------------.   |
+   |                    |  context * query    |                  v   |
+   |                    +--+--------------+---+           ( a person )
+   |         reads /       |              |                          |
+   |         proposes      |              |                          |
+   |             +---------+----+   +-----+--------+                 |
+   |             |  Knowledge   |   |     Lake     |                 |
+   |             |    store     |   |  ClickHouse  |<---.            |
+   |             +--------------+   +------+-------+     \           |
+   |                                  ^    |    ^         \ ingest   |
+   |                        read-only |    |    | mirror   \         |
+   +----------------------------------|----|----|-----------|-------+
+                            +---------+--+ |    +--------+   |
+                            | Your data  |-'    | Your   |---'
+                            | base (r/o) |      | sources|
+                            | Postgres   |      | gh·slk |
+                            +------------+      +--------+</pre>
+      </section>
+
+      <!-- ===================== 06 CONNECTORS ===================== -->
+      <section id="connectors">
+        <pre class="rule"> .-=[ 06. CONNECTORS // one lake, every source ]=-.-------------------</pre>
+        <p class="lede">
+          Point Setoku at the data you already have. Every source lands in a
+          local
+          <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+            >ClickHouse</a
+          >
+          data lake, on purpose: agents write arbitrary queries (scans, GROUP
+          BYs, whole-table aggregations), and a columnar engine answers those in
+          about a second, so the apps and dashboards they build stay quick. Your
+          app database connects read-only and is mirrored in on a cron; the rest
+          is ingested as it happens.
+        </p>
+        <div class="frame">
+          <span class="tag">[o] ClickHouse · lake</span>
+          <div class="rows" style="margin: 0">
+            <div class="r">
+              <div class="name"><b>PostgreSQL</b></div>
+              <div class="desc">app database, mirrored read-only</div>
+            </div>
+            <div class="r">
+              <div class="name"><b>GitHub</b></div>
+              <div class="desc">issues, PRs &amp; commits</div>
+            </div>
+            <div class="r">
+              <div class="name"><b>Vercel</b></div>
+              <div class="desc">deploys &amp; logs</div>
+            </div>
+            <div class="r">
+              <div class="name"><b>Render</b></div>
+              <div class="desc">deploys &amp; logs</div>
+            </div>
+            <div class="r">
+              <div class="name"><b>Slack</b></div>
+              <div class="desc">messages</div>
+            </div>
+            <div class="r">
+              <div class="name"><b>Mercury</b></div>
+              <div class="desc">banking &amp; finance</div>
+            </div>
+          </div>
+        </div>
+        <p class="muted">
+          No connector for your source yet? The included setup skills give your
+          coding agent the patterns to wire one up itself. See
+          <a
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >the repo</a
+          >, or open an issue.
+        </p>
+      </section>
+
+      <!-- ===================== 07 DEMO ===================== -->
+      <section id="demo">
+        <pre class="rule"> .-=[ 07. DEMO // try it on real-ish data ]=-.-----------------------</pre>
+        <p class="lede">
+          There’s a live demo wired to a fictional pro sports club, the Bonita
+          Bulldogs (ticketing, sponsorship, concessions, payroll, broadcast
+          rights).
+        </p>
+
+        <div class="frame">
+          <span class="tag">step 1 · connect</span>
+          <p style="margin-top: 2px">
+            In Claude (or any MCP client) open Settings &rarr; Connectors &rarr;
+            Add custom connector, and paste this URL. The token rides in the URL,
+            so there’s no separate key to enter.
+          </p>
+          <div class="code">
+            <pre>https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</pre>
+          </div>
+        </div>
+
+        <p class="muted" style="margin-top: 20px">
+          step 2 · ask a question
+        </p>
+        <div class="qa">
+          <div class="q">How many unique fans do we have?</div>
+          <div class="a">
+            <b>71,204</b> &nbsp;deduped by normalized email, internal accounts
+            excluded. Not the raw 92,118.
+          </div>
+        </div>
+        <div class="qa">
+          <div class="q">
+            What’s our total annual revenue, and how much is media rights?
+          </div>
+          <div class="a">
+            <b>$192M</b> &nbsp;five systems reconciled to the same units. Media
+            rights is the biggest line, ~$90M.
+          </div>
+        </div>
+        <div class="qa">
+          <div class="q">What was ticket revenue this season?</div>
+          <div class="a">
+            <b>$46.8M</b> &nbsp;cents reconciled to dollars; refunds, exchanges,
+            and comps excluded.
+          </div>
+        </div>
+        <div class="qa">
+          <div class="q">What’s our total merchandise revenue?</div>
+          <div class="a">
+            <b>It flags it</b> &nbsp;most merch is sold via Fanatics, not in this
+            data, so it says so instead of returning a wrong total.
+          </div>
+        </div>
+        <div class="qa">
+          <div class="q">Chart revenue by line.</div>
+          <div class="a" style="padding-left: 0; margin-top: 8px">
+            <pre
+              class="rule"
+              style="color: var(--ink); margin: 6px 0"
+              aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M."
+>  Annual revenue by line  ·  ~$192M total
+
+  Media rights |<span style="color: var(--sage)">########################################</span>  $90M
+  Ticketing    |<span style="color: var(--sage)">#####################</span>                     $47M
+  Sponsorship  |<span style="color: var(--sage)">############</span>                              $28M
+  Concessions  |<span style="color: var(--sage)">######</span>                                    $14M
+  Merch        |<span style="color: var(--sage)">###</span>                                        $8M
+  Other        |<span style="color: var(--sage)">##</span>                                         $5M</pre>
+          </div>
+        </div>
+
+        <p class="muted" style="margin-top: 20px">step 3 · try an app</p>
+        <p>
+          Ask Claude to build a dashboard on the same data, then publish it to a
+          link. Two live examples, running on the demo data right now:
+        </p>
+        <ul class="list">
+          <li>
+            <a
+              href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+              target="_blank"
+              rel="noopener"
+              >Sponsorship pricing table &rarr;</a
+            >
+            — inventory and rates for sponsorship placements.
+          </li>
+          <li>
+            <a
+              href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+              target="_blank"
+              rel="noopener"
+              >Fan lifetime value &rarr;</a
+            >
+            — segment fans by spend across tickets, merch, and concessions.
+          </li>
+        </ul>
+      </section>
+
+      <!-- ===================== 08 RATIONALE ===================== -->
+      <section id="why">
+        <pre class="rule"> .-=[ 08. RATIONALE // why we built it ]=-.--------------------------</pre>
+        <p class="lede" style="color: var(--ink)"><b>We’re curious.</b></p>
+        <p>
+          There are plenty of AI memory stores, and plenty of data gateways.
+          Stapling the two together, and nudging the agent to gather knowledge
+          about the data as it goes, seemed useful and fun to tinker with.
+        </p>
+        <p class="lede" style="color: var(--ink)"><b>We’re cheap.</b></p>
+        <p>
+          We wanted something that runs on one small box, works on a Pro/Max
+          subscription or a cheap model with no added inference cost, mostly sets
+          itself up (no field engineer to pay for), stays portable between
+          providers, and is open source.
+        </p>
+        <p class="lede" style="color: var(--ink)"><b>We’re paranoid.</b></p>
+        <p>
+          HR platforms, CRMs, and clouds are all announcing “context layers.”
+          They’d like the meaning of your business to accumulate on their
+          servers, where it can never leave. Context is deeper lock-in than data,
+          and a hosted context layer has no export button. Setoku exists so that
+          understanding accumulates on a box you own instead. If we disappear
+          tomorrow, your context doesn’t.
+        </p>
+        <p class="lede" style="color: var(--ink)">
+          <b>We and some friends wanted the same thing.</b>
+        </p>
+        <ul class="list">
+          <li>
+            <b
+              ><a href="https://www.hedgy.works" target="_blank" rel="noopener"
+                >Hedgy</a
+              ></b
+            >: keep scaling without hiring. Debug from live logs and data, find
+            growth levers, and match candidates and companies better with more
+            data.
+          </li>
+          <li>
+            <b
+              ><a href="https://baggu.com" target="_blank" rel="noopener"
+                >Baggu</a
+              ></b
+            >: give employees state-of-the-art tools. Faster onboarding, and a
+            safe way to vibecode against real data.
+          </li>
+          <li>
+            <b
+              ><a href="https://tlon.io" target="_blank" rel="noopener"
+                >Tlon</a
+              ></b
+            >: experimenting with giving agents curated data to work from.
+          </li>
+          <li>
+            <b>Sports analysts</b>: query across data that doesn’t usually sit
+            together.
+          </li>
+          <li>
+            <b>Academic labs</b>: think through hypotheses against real papers,
+            data, and drafts.
+          </li>
+        </ul>
+      </section>
+
+      <!-- ===================== 09 GREETZ / CONTACT ===================== -->
+      <section id="help">
+        <pre class="rule"> .-=[ 09. GREETZ &amp; CONTACT // setup help ]=-.-----------------------</pre>
+        <p>
+          It’s open source, so you can self-host it today. If you like, we’re
+          happy to help set it up. Just email
+          <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+        </p>
+      </section>
+
+      <hr class="dotted" />
+      <footer>
+        <pre class="rule tight" style="color: var(--ink-faint); margin: 0 0 10px"> ----------------------------------------------------------------------</pre>
+        <div>
+          <a
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >GitHub</a
+          >
+          &nbsp;·&nbsp; <a href="#demo">Demo</a> &nbsp;·&nbsp;
+          <a href="mailto:hello@setoku.com">Contact</a> &nbsp;·&nbsp;
+          <span class="muted">Apache-2.0</span>
+        </div>
+        <div class="jp" style="margin-top: 8px">
+          設 × 奥 · set (math) × oku (innermost)
+        </div>
+        <div class="muted" style="margin-top: 10px">
+          EOF · setoku.nfo · no model runs on the server
+        </div>
+      </footer>
+    </div>
+
+    <script>
+      (function () {
+        var el = document.querySelector(".rot");
+        if (!el) return;
+        var words = (el.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) {
+            return w.trim();
+          })
+          .filter(Boolean);
+        if (words.length < 2) return;
+        var i = 0;
+        setInterval(function () {
+          i = (i + 1) % words.length;
+          el.style.opacity = "0.15";
+          setTimeout(function () {
+            el.textContent = words[i];
+            el.style.opacity = "1";
+          }, 130);
+        }, 2400);
+        el.style.transition = "opacity 130ms steps(2)";
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/12-terminal.html
+++ b/site/riffs/12-terminal.html
@@ -1,0 +1,650 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>setoku · tui</title>
+    <style>
+      :root {
+        --bg: #1a1f1c;
+        --bg-2: #20261f;
+        --panel: #1e241f;
+        --fg: #d8dcd3;
+        --fg-soft: #aab1a6;
+        --fg-dim: #78806f;
+        --border: #38413a;
+        --border-hi: #4d5a4c;
+        --sage: #7fae86;
+        --sage-d: #5f8c6b;
+        --amber: #c9b483;
+        --mono: ui-monospace, "SF Mono", "Menlo", "Cascadia Code",
+          "Consolas", "Liberation Mono", monospace;
+      }
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      html { -webkit-font-smoothing: antialiased; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--mono);
+        font-size: 14px;
+        line-height: 1.65;
+        letter-spacing: -0.01em;
+        padding-bottom: 34px;
+      }
+      a { color: var(--sage); text-decoration: none; }
+      a:hover { text-decoration: underline; text-underline-offset: 3px; }
+      ::selection { background: var(--sage-d); color: #12160f; }
+      b, strong { color: var(--fg); font-weight: 700; }
+
+      /* ── top status bar (tmux) ─────────────────────────── */
+      .statusbar {
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        flex-wrap: wrap;
+        background: #151a16;
+        border-bottom: 1px solid var(--border);
+        padding: 7px 14px;
+        font-size: 12.5px;
+        color: var(--fg-soft);
+      }
+      .statusbar .win {
+        color: #12160f;
+        background: var(--sage);
+        padding: 1px 9px;
+        border-radius: 3px;
+        font-weight: 700;
+      }
+      .statusbar .seg { color: var(--fg-dim); }
+      .statusbar .ok { color: var(--sage); }
+      .statusbar .warn { color: var(--amber); }
+      .statusbar .right { margin-left: auto; color: var(--fg-dim); }
+      @media (max-width: 620px) { .statusbar .right { display: none; } }
+
+      .screen { max-width: 940px; margin: 0 auto; padding: 22px 16px 0; }
+
+      /* ── panes ─────────────────────────────────────────── */
+      .pane {
+        position: relative;
+        border: 1px solid var(--border);
+        border-radius: 5px;
+        background: var(--panel);
+        padding: 20px 20px 18px;
+        margin-bottom: 22px;
+      }
+      .pane > .pt {
+        position: absolute;
+        top: -0.72em;
+        left: 14px;
+        background: var(--bg);
+        padding: 0 9px;
+        font-size: 12px;
+        color: var(--sage);
+        letter-spacing: 0.02em;
+        white-space: nowrap;
+      }
+      .pane > .pt .k { color: var(--fg-dim); }
+      .pane > .pn {
+        position: absolute;
+        top: -0.72em;
+        right: 14px;
+        background: var(--bg);
+        padding: 0 9px;
+        font-size: 12px;
+        color: var(--fg-dim);
+      }
+      p { color: var(--fg-soft); margin: 10px 0; max-width: 70ch; }
+      .dim { color: var(--fg-dim); }
+
+      /* ── hero ──────────────────────────────────────────── */
+      .eyebrow { color: var(--sage-d); font-size: 12.5px; letter-spacing: 0.04em; }
+      h1 {
+        font-size: clamp(23px, 3.8vw, 33px);
+        font-weight: 700;
+        line-height: 1.18;
+        letter-spacing: -0.02em;
+        color: var(--fg);
+        margin: 12px 0 4px;
+        max-width: 20ch;
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        color: var(--sage);
+        transition: width 420ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word { display: inline-block; white-space: nowrap; will-change: transform, opacity; }
+      .rotator-measure { position: absolute; left: 0; top: 0; visibility: hidden; pointer-events: none; white-space: nowrap; }
+      .caret {
+        display: inline-block;
+        width: 0.58em;
+        height: 1.02em;
+        background: var(--sage);
+        margin-left: 2px;
+        transform: translateY(0.16em);
+        animation: blink 1.06s steps(1) infinite;
+      }
+      @keyframes blink { 50% { opacity: 0; } }
+      @media (prefers-reduced-motion: reduce) {
+        .rotator { transition: none; }
+        .caret { animation: none; }
+      }
+      .lede { max-width: 74ch; }
+      .actions { margin-top: 16px; display: flex; gap: 10px; flex-wrap: wrap; }
+      .btn {
+        display: inline-block;
+        border: 1px solid var(--border-hi);
+        border-radius: 4px;
+        padding: 6px 13px;
+        color: var(--fg);
+        font-size: 13px;
+        background: var(--bg-2);
+      }
+      .btn:hover { border-color: var(--sage); color: var(--sage); text-decoration: none; }
+      .btn.pri { background: var(--sage); color: #12160f; border-color: var(--sage); font-weight: 700; }
+      .btn.pri:hover { background: #93bd99; color: #12160f; }
+
+      /* ── shell blocks ──────────────────────────────────── */
+      pre {
+        background: #151a16;
+        border: 1px solid var(--border);
+        border-radius: 5px;
+        padding: 14px 16px;
+        overflow-x: auto;
+        margin: 12px 0;
+        font-size: 13px;
+        line-height: 1.75;
+        color: var(--fg);
+      }
+      pre .p { color: var(--sage); }
+      pre .c { color: var(--fg-dim); }
+      code {
+        color: var(--sage);
+        background: #151a16;
+        border: 1px solid var(--border);
+        border-radius: 3px;
+        padding: 0.5px 5px;
+        font-size: 0.92em;
+      }
+      details { margin-top: 12px; }
+      summary {
+        cursor: pointer;
+        color: var(--fg-soft);
+        font-size: 13px;
+        padding: 3px 0;
+      }
+      summary:hover { color: var(--sage); }
+
+      /* ── key/value rows ────────────────────────────────── */
+      .rows { margin-top: 12px; display: grid; gap: 1px; background: var(--border); border: 1px solid var(--border); border-radius: 5px; overflow: hidden; }
+      .row { display: grid; grid-template-columns: 210px 1fr; gap: 0; background: var(--panel); }
+      @media (max-width: 600px) { .row { grid-template-columns: 1fr; } }
+      .row .k { padding: 12px 14px; border-right: 1px solid var(--border); }
+      @media (max-width: 600px) { .row .k { border-right: none; border-bottom: 1px solid var(--border); } }
+      .row .k b { display: block; color: var(--fg); }
+      .row .k .t { display: block; color: var(--sage-d); font-size: 12px; margin-top: 3px; }
+      .row .v { padding: 12px 14px; color: var(--fg-soft); }
+
+      /* ── lists ─────────────────────────────────────────── */
+      ul.stat { list-style: none; margin: 12px 0; display: grid; gap: 7px; }
+      ul.stat li { color: var(--fg-soft); padding-left: 20px; position: relative; max-width: 74ch; }
+      ul.stat li::before { content: "●"; position: absolute; left: 2px; color: var(--sage); font-size: 10px; top: 0.32em; }
+      ul.stat li.off::before { content: "○"; color: var(--fg-dim); }
+
+      /* ── connectors ────────────────────────────────────── */
+      .conn { margin-top: 12px; display: grid; gap: 6px; }
+      .conn .c-hd { color: var(--fg-dim); font-size: 12.5px; margin-bottom: 4px; }
+      .conn .line { display: grid; grid-template-columns: 18px 130px 1fr; align-items: baseline; gap: 8px; }
+      .conn .line .d { color: var(--sage); font-size: 10px; }
+      .conn .line b { color: var(--fg); }
+      .conn .line span { color: var(--fg-soft); }
+      @media (max-width: 520px) { .conn .line { grid-template-columns: 18px 1fr; } .conn .line span { grid-column: 2; } }
+
+      /* ── ascii art ─────────────────────────────────────── */
+      .art { margin: 12px 0; overflow-x: auto; }
+      .art pre { border: none; background: transparent; padding: 0; color: var(--fg-soft); font-size: 12.5px; line-height: 1.35; }
+      .art .hi { color: var(--sage); }
+      .art .lbl { color: var(--fg); }
+
+      /* ── repl / demo ───────────────────────────────────── */
+      .repl { margin-top: 4px; }
+      .ex { border-top: 1px solid var(--border); padding: 14px 0; }
+      .ex:first-child { border-top: none; }
+      .ex .q { color: var(--fg); }
+      .ex .q .pr { color: var(--sage); font-weight: 700; margin-right: 8px; }
+      .ex .a { margin-top: 6px; padding-left: 20px; }
+      .ex .a .val { color: var(--sage); font-weight: 700; font-size: 16px; }
+      .ex .a .cav { color: var(--fg-soft); display: block; margin-top: 2px; }
+      .chart { margin-top: 6px; padding-left: 20px; }
+      .chart .cl { color: var(--fg-dim); font-size: 12.5px; margin-bottom: 8px; }
+      .chart table { border-collapse: collapse; font-size: 13px; }
+      .chart td { padding: 1.5px 0; white-space: nowrap; vertical-align: middle; }
+      .chart td.name { color: var(--fg-soft); padding-right: 14px; text-align: right; }
+      .chart td.bar { color: var(--sage); letter-spacing: -1px; }
+      .chart td.num { color: var(--fg); padding-left: 10px; }
+
+      .step-h { color: var(--sage); margin: 16px 0 4px; font-weight: 700; }
+      .step-h .n { color: var(--fg-dim); margin-right: 8px; }
+
+      /* ── why ───────────────────────────────────────────── */
+      .why h3 { color: var(--sage); font-size: 14px; font-weight: 700; margin: 18px 0 2px; }
+      .why h3::before { content: "# "; color: var(--fg-dim); }
+
+      /* ── keybar footer ─────────────────────────────────── */
+      .keybar {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 20;
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        background: #151a16;
+        border-top: 1px solid var(--border);
+        padding: 7px 14px;
+        font-size: 12px;
+        color: var(--fg-dim);
+      }
+      .keybar b { color: var(--sage); }
+      .keybar .jp { margin-left: auto; }
+      @media (max-width: 620px) { .keybar .hidesm { display: none; } }
+
+      .foot-note { color: var(--fg-dim); font-size: 12.5px; margin-top: 14px; }
+    </style>
+  </head>
+  <body>
+    <div class="statusbar">
+      <span class="win">setoku</span>
+      <span class="seg">MCP:<span class="ok"> connected</span></span>
+      <span class="seg">lake:<span class="ok"> flowing</span></span>
+      <span class="seg">queue:<span class="warn"> 1 pending</span></span>
+      <span class="right">Apache-2.0 · self-hosted · no server-side inference</span>
+    </div>
+
+    <main class="screen" id="top">
+      <!-- HERO -->
+      <section class="pane">
+        <span class="pt">─ <span class="k">win 0:</span> setoku</span>
+        <span class="pn">1/9</span>
+        <span class="eyebrow">$ open source · MCP server · Apache-2.0</span>
+        <h1>Make any AI fluent in your <span
+            class="rotator"
+            data-words="company,family,personal"
+          ><span class="rotator-word">company</span><span
+              class="rotator-measure"
+              aria-hidden="true"
+            ></span></span> data.<span class="caret" aria-hidden="true"></span></h1>
+        <p class="lede">
+          Setoku is a small self-hosted MCP knowledge server + Claude Code
+          skills for hooking up your data. It does two things: it gives your AI
+          a read-only way to query your data, and it remembers what that data
+          means (the metric definitions, the gotchas), getting better the more
+          you use it. The MCP works with whatever AI you already have, and no
+          model runs on the server, so no added inference cost.
+        </p>
+        <div class="actions">
+          <a class="btn pri" href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">View on GitHub ↗</a>
+          <a class="btn" href="#demo">Try the demo</a>
+        </div>
+      </section>
+
+      <!-- QUICKSTART -->
+      <section class="pane" id="quickstart">
+        <span class="pt">─ <span class="k">pane:</span> quickstart</span>
+        <span class="pn">2/9</span>
+        <p>
+          Setoku installs as a Claude Code plugin. Add the plugin, then run
+          onboarding from your main project directory, the codebase you want
+          Setoku to learn from:
+        </p>
+        <pre><span class="c"># 1 · add the plugin (skills only)</span>
+<span class="p">$</span> /plugin marketplace add Hedgy-Labs/setoku
+<span class="p">$</span> /plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+<span class="p">$</span> /setoku:onboard</pre>
+        <p>
+          Onboarding stands up the server, auths your Claude, wires your
+          database read-only, and generates the first knowledge from your
+          code. You stay in the loop for anything that touches your data. To
+          start onboarding, run <code>/setoku:onboard</code>.
+        </p>
+        <p>
+          You’ll need somewhere to host it. Something like OVH’s
+          <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener">VPS-2</a>
+          is plenty.
+        </p>
+        <details>
+          <summary>› or stand up the server by hand</summary>
+          <pre><span class="c"># on a fresh Ubuntu VPS</span>
+<span class="p">$</span> git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+<span class="p">$</span> cd /opt/setoku
+<span class="p">$</span> SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</pre>
+          <p class="dim">
+            Installs Docker, generates secrets, gets an HTTPS certificate, and
+            prints the connect command. Then add the plugin and run
+            /setoku:onboard from your project; it’ll detect the box you just
+            made.
+          </p>
+        </details>
+      </section>
+
+      <!-- HOW IT WORKS -->
+      <section class="pane" id="how">
+        <span class="pt">─ <span class="k">pane:</span> how_it_works</span>
+        <span class="pn">3/9</span>
+        <p>
+          Setoku gives the AI two kinds of MCP tools, and one rule: look up
+          what the data means before you touch it.
+        </p>
+        <div class="rows">
+          <div class="row">
+            <div class="k"><b>Context tools</b><span class="t">find_context · get_metric</span></div>
+            <div class="v">The AI reads what your data means first: canonical metric definitions, entity docs, and the gotchas that make a naive query wrong.</div>
+          </div>
+          <div class="row">
+            <div class="k"><b>Read-only query</b><span class="t">get_schema · run_query</span></div>
+            <div class="v">Read-only, with a row cap, a statement timeout, a table allow-list, and an append-only audit log. Enforced by the database role, not by parsing SQL.</div>
+          </div>
+          <div class="row">
+            <div class="k"><b>Human-approved</b><span class="t">report_correction</span></div>
+            <div class="v">The AI can only propose changes to what Setoku knows. A person accepts them on the admin page, outside the agent loop, so an injected session can’t rewrite the brain.</div>
+          </div>
+        </div>
+        <p class="foot-note">You set it up with <b>Claude Code</b> skills:</p>
+        <ul class="stat">
+          <li><code>/setoku:onboard</code> sets Setoku up in a repo for the first time.</li>
+          <li><code>/setoku:connect</code> adds a data source or custom integration.</li>
+          <li><code>/setoku:generate</code> writes business context from your code.</li>
+          <li><code>/setoku:curate</code> reviews and approves pending knowledge.</li>
+        </ul>
+        <p class="foot-note">
+          Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex, or
+          whatever you run. Just ask in plain language, and the tools do the
+          rest.
+        </p>
+      </section>
+
+      <!-- APPS -->
+      <section class="pane" id="apps">
+        <span class="pt">─ <span class="k">pane:</span> apps</span>
+        <span class="pn">4/9</span>
+        <p class="lede" style="color: var(--fg)">
+          <b>Apps: save and share the tools Claude builds you.</b>
+        </p>
+        <p>
+          Ask Claude to build a dashboard on your data. Then publish it to a
+          link as a Setoku App, the data stays live, and your whole team can
+          view it. Nothing to deploy, no frontend to maintain.
+        </p>
+        <div class="rows">
+          <div class="row">
+            <div class="k"><b>Built by asking</b><span class="t">publish_app</span></div>
+            <div class="v">Describe it in plain language; the agent writes the app and publishes it to a URL. Edit it the same way, just ask for the change.</div>
+          </div>
+          <div class="row">
+            <div class="k"><b>Backed by live data</b><span class="t">read-only</span></div>
+            <div class="v">Apps read through the same governed path: row caps, audit, a SELECT-only database role. They never get write access to your sources.</div>
+          </div>
+          <div class="row">
+            <div class="k"><b>App-private state</b><span class="t">no writes to your data</span></div>
+            <div class="v">Each app keeps its own state (todos, votes, annotations) in a sandbox that belongs to the app, not your database. Worst case, an app messes up its own notes.</div>
+          </div>
+          <div class="row">
+            <div class="k"><b>Share by link</b><span class="t">team or public</span></div>
+            <div class="v">A team link is login-gated; an admin can flip one public for a credential-free URL. The page runs in a locked-down sandbox with no network, so a published app can’t phone home.</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ARCHITECTURE -->
+      <section class="pane" id="architecture">
+        <span class="pt">─ <span class="k">pane:</span> architecture</span>
+        <span class="pn">5/9</span>
+        <p>
+          You can host this on whatever infra you like. We put it all on one
+          small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+          helps you add custom integrations. Only the proxy is public, so your
+          databases aren’t exposed. Queries are read-only, and knowledge
+          changes pass through a person.
+        </p>
+        <div class="art" role="img" aria-label="Setoku architecture: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Your Postgres database is queried read-only and mirrored into the lake, and your sources are ingested into the lake.">
+<pre>                        <span class="lbl">┌───────────────────┐</span>
+                        <span class="lbl">│    You + your AI  │</span>
+                        <span class="lbl">└─────────┬─────────┘</span>
+                                  <span class="hi">│ MCP</span>
+   <span class="lbl">┌──────────────────────────────┼───────────────────────────┐</span>
+   <span class="lbl">│</span> your box                     <span class="lbl">│</span>                           <span class="lbl">│</span>
+   <span class="lbl">│</span>                    <span class="lbl">┌─────────┴─────────┐   ┌──────────┐</span>  <span class="lbl">│</span>
+   <span class="lbl">│</span>                    <span class="lbl">│   Setoku gateway  │◀─▶│ a person │</span>  <span class="lbl">│</span>
+   <span class="lbl">│</span>                    <span class="lbl">│  context · query  │   │ approves │</span>  <span class="lbl">│</span>
+   <span class="lbl">│</span>                    <span class="lbl">└────┬─────────┬────┘   └──────────┘</span>  <span class="lbl">│</span>
+   <span class="lbl">│</span>          <span class="lbl">reads·proposes</span>  <span class="lbl">│</span>       <span class="lbl">│</span>                     <span class="lbl">│</span>
+   <span class="lbl">│</span>          <span class="lbl">┌───────────────┴──┐  ┌─┴────────────────┐</span>          <span class="lbl">│</span>
+   <span class="lbl">│</span>          <span class="lbl">│ Lake (ClickHouse)│  │  Knowledge store │</span>          <span class="lbl">│</span>
+   <span class="lbl">│</span>          <span class="lbl">│ logs·events·mirr │  │   approved ctx   │</span>          <span class="lbl">│</span>
+   <span class="lbl">│</span>          <span class="lbl">└────────┬─────────┘  └──────────────────┘</span>          <span class="lbl">│</span>
+   <span class="lbl">└───────────────────┼─────────────────────────────────────────┘</span>
+              <span class="hi">ingest</span> <span class="lbl">│</span>          <span class="hi">read-only</span>
+           <span class="lbl">┌─────────┴────────┐   ┌──────────────────┐</span>
+           <span class="lbl">│   Your sources   │   │   Your database  │</span>
+           <span class="lbl">│ GitHub·Vercel·…  │   │  Postgres · RO   │</span>
+           <span class="lbl">└──────────────────┘   └──────────────────┘</span></pre>
+        </div>
+      </section>
+
+      <!-- CONNECTORS -->
+      <section class="pane" id="connectors">
+        <span class="pt">─ <span class="k">pane:</span> connectors</span>
+        <span class="pn">6/9</span>
+        <p>
+          Point Setoku at the data you already have. Every source lands in a
+          local
+          <a href="https://clickhouse.com/" target="_blank" rel="noopener">ClickHouse</a>
+          data lake, on purpose: agents write arbitrary queries (scans,
+          GROUP BYs, whole-table aggregations), and a columnar engine answers
+          those in about a second, so the apps and dashboards they build stay
+          quick. Your app database connects read-only and is mirrored in on a
+          cron; the rest is ingested as it happens.
+        </p>
+        <div class="conn">
+          <div class="c-hd">● ClickHouse · one lake, every source</div>
+          <div class="line"><span class="d">●</span><b>PostgreSQL</b><span>app database, mirrored read-only</span></div>
+          <div class="line"><span class="d">●</span><b>GitHub</b><span>issues, PRs &amp; commits</span></div>
+          <div class="line"><span class="d">●</span><b>Vercel</b><span>deploys &amp; logs</span></div>
+          <div class="line"><span class="d">●</span><b>Render</b><span>deploys &amp; logs</span></div>
+          <div class="line"><span class="d">●</span><b>Slack</b><span>messages</span></div>
+          <div class="line"><span class="d">●</span><b>Mercury</b><span>banking &amp; finance</span></div>
+        </div>
+        <p class="foot-note">
+          No connector for your source yet? The included setup skills give your
+          coding agent the patterns to wire one up itself. See
+          <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">the repo</a>,
+          or open an issue.
+        </p>
+      </section>
+
+      <!-- DEMO -->
+      <section class="pane" id="demo">
+        <span class="pt">─ <span class="k">pane:</span> demo · repl</span>
+        <span class="pn">7/9</span>
+        <p class="lede" style="color: var(--fg)">
+          <b>Try it on real-ish data.</b>
+        </p>
+        <p>
+          There’s a live demo wired to a fictional pro sports club, the Bonita
+          Bulldogs (ticketing, sponsorship, concessions, payroll, broadcast
+          rights).
+        </p>
+
+        <div class="step-h"><span class="n">01</span>Connect to the demo MCP server</div>
+        <p class="dim" style="margin-top: 2px">
+          In Claude (or any MCP client) open Settings → Connectors → Add custom
+          connector, and paste this URL. The token rides in the URL, so there’s
+          no separate key to enter.
+        </p>
+        <pre><span class="p">$</span> https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</pre>
+
+        <div class="step-h"><span class="n">02</span>Ask a question</div>
+        <div class="repl">
+          <div class="ex">
+            <div class="q"><span class="pr">❯</span>How many unique fans do we have?</div>
+            <div class="a">
+              <span class="val">71,204</span>
+              <span class="cav">deduped by normalized email, internal accounts excluded. Not the raw 92,118.</span>
+            </div>
+          </div>
+          <div class="ex">
+            <div class="q"><span class="pr">❯</span>What’s our total annual revenue, and how much is media rights?</div>
+            <div class="a">
+              <span class="val">$192M</span>
+              <span class="cav">five systems reconciled to the same units. Media rights is the biggest line, ~$90M.</span>
+            </div>
+          </div>
+          <div class="ex">
+            <div class="q"><span class="pr">❯</span>What was ticket revenue this season?</div>
+            <div class="a">
+              <span class="val">$46.8M</span>
+              <span class="cav">cents reconciled to dollars; refunds, exchanges, and comps excluded.</span>
+            </div>
+          </div>
+          <div class="ex">
+            <div class="q"><span class="pr">❯</span>What’s our total merchandise revenue?</div>
+            <div class="a">
+              <span class="val">It flags it</span>
+              <span class="cav">most merch is sold via Fanatics, not in this data, so it says so instead of returning a wrong total.</span>
+            </div>
+          </div>
+          <div class="ex">
+            <div class="q"><span class="pr">❯</span>Chart revenue by line.</div>
+            <div class="chart">
+              <div class="cl">Annual revenue by line · ~$192M total</div>
+              <table role="img" aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M.">
+                <tr><td class="name">Media rights</td><td class="bar">████████████████████████████████████████</td><td class="num">$90M</td></tr>
+                <tr><td class="name">Ticketing</td><td class="bar">█████████████████████</td><td class="num">$47M</td></tr>
+                <tr><td class="name">Sponsorship</td><td class="bar">████████████</td><td class="num">$28M</td></tr>
+                <tr><td class="name">Concessions</td><td class="bar">██████</td><td class="num">$14M</td></tr>
+                <tr><td class="name">Merch</td><td class="bar">███▌</td><td class="num">$8M</td></tr>
+                <tr><td class="name">Other</td><td class="bar">██</td><td class="num">$5M</td></tr>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <div class="step-h"><span class="n">03</span>Try an app</div>
+        <p class="dim" style="margin-top: 2px">
+          Ask Claude to build a dashboard on the same data, then publish it to a
+          link. Two live examples, running on the demo data right now:
+        </p>
+        <ul class="stat">
+          <li>
+            <a href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d" target="_blank" rel="noopener">Sponsorship pricing table ↗</a>
+            — inventory and rates for sponsorship placements.
+          </li>
+          <li>
+            <a href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea" target="_blank" rel="noopener">Fan lifetime value ↗</a>
+            — segment fans by spend across tickets, merch, and concessions.
+          </li>
+        </ul>
+      </section>
+
+      <!-- WHY -->
+      <section class="pane why" id="why">
+        <span class="pt">─ <span class="k">pane:</span> why_we_built_it</span>
+        <span class="pn">8/9</span>
+        <h3>We’re curious.</h3>
+        <p>
+          There are plenty of AI memory stores, and plenty of data gateways.
+          Stapling the two together, and nudging the agent to gather knowledge
+          about the data as it goes, seemed useful and fun to tinker with.
+        </p>
+        <h3>We’re cheap.</h3>
+        <p>
+          We wanted something that runs on one small box, works on a Pro/Max
+          subscription or a cheap model with no added inference cost, mostly
+          sets itself up (no field engineer to pay for), stays portable between
+          providers, and is open source.
+        </p>
+        <h3>We’re paranoid.</h3>
+        <p>
+          HR platforms, CRMs, and clouds are all announcing “context layers.”
+          They’d like the meaning of your business to accumulate on their
+          servers, where it can never leave. Context is deeper lock-in than
+          data, and a hosted context layer has no export button. Setoku exists
+          so that understanding accumulates on a box you own instead. If we
+          disappear tomorrow, your context doesn’t.
+        </p>
+        <h3>We and some friends wanted the same thing.</h3>
+        <ul class="stat">
+          <li><b><a href="https://www.hedgy.works" target="_blank" rel="noopener">Hedgy</a></b>: keep scaling without hiring. Debug from live logs and data, find growth levers, and match candidates and companies better with more data.</li>
+          <li><b><a href="https://baggu.com" target="_blank" rel="noopener">Baggu</a></b>: give employees state-of-the-art tools. Faster onboarding, and a safe way to vibecode against real data.</li>
+          <li><b><a href="https://tlon.io" target="_blank" rel="noopener">Tlon</a></b>: experimenting with giving agents curated data to work from.</li>
+          <li><b>Sports analysts</b>: query across data that doesn’t usually sit together.</li>
+          <li><b>Academic labs</b>: think through hypotheses against real papers, data, and drafts.</li>
+        </ul>
+      </section>
+
+      <!-- SETUP HELP -->
+      <section class="pane" id="help">
+        <span class="pt">─ <span class="k">pane:</span> setup_help</span>
+        <span class="pn">9/9</span>
+        <p>
+          It’s open source, so you can self-host it today. If you like, we’re
+          happy to help set it up. Just email
+          <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+        </p>
+      </section>
+    </main>
+
+    <div class="keybar">
+      <span><b>↵</b> run</span>
+      <span><b>/</b> search</span>
+      <span class="hidesm"><b>g</b> <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">github</a></span>
+      <span class="hidesm"><b>d</b> <a href="#demo">demo</a></span>
+      <span><b>@</b> <a href="mailto:hello@setoku.com">contact</a></span>
+      <span class="jp">設 × 奥 · set (math) × oku (innermost)</span>
+    </div>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",").map(function (w) { return w.trim(); }).filter(Boolean);
+        if (words.length < 2) return;
+        var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        var LIFT = "0.72em", HALF = 220, HOLD = 2400, i = 0;
+        function widthOf(w) { measure.textContent = w; return measure.getBoundingClientRect().width; }
+        box.style.width = widthOf(words[0]) + "px";
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next; box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length; return;
+          }
+          word.animate(
+            [{ transform: "translateY(0)", opacity: 1 }, { transform: "translateY(-" + LIFT + ")", opacity: 0 }],
+            { duration: HALF, easing: "cubic-bezier(0.4,0,1,1)", fill: "forwards" }
+          ).finished.then(function () {
+            word.textContent = next; box.style.width = widthOf(next) + "px";
+            word.animate(
+              [{ transform: "translateY(" + LIFT + ")", opacity: 0 }, { transform: "translateY(0)", opacity: 1 }],
+              { duration: HALF, easing: "cubic-bezier(0,0,0.2,1)", fill: "forwards" }
+            );
+            i = (i + 1) % words.length;
+          }).catch(function () {});
+        }
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () { box.style.width = widthOf(words[i]) + "px"; });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/13-japanese.html
+++ b/site/riffs/13-japanese.html
@@ -1,0 +1,1416 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · 設奥</title>
+    <meta
+      name="description"
+      content="Setoku is an open-source MCP server that gives your AI a read-only view of your company’s data, plus the context to use it correctly."
+    />
+    <style>
+      :root {
+        --washi: #f4f1e8;
+        --washi-2: #ebe6d8;
+        --paper: #fbfaf5;
+        --sumi: #1c1c1a;
+        --sumi-soft: #3d3d39;
+        --sumi-faint: #6c6b63;
+        --line: rgba(28, 28, 26, 0.14);
+        --line-soft: rgba(28, 28, 26, 0.07);
+        --seal: #b1341f;
+        --seal-soft: rgba(177, 52, 31, 0.9);
+        --serif: "Hiragino Mincho ProN", "Yu Mincho", "YuMincho", "Songti SC",
+          "Times New Roman", Georgia, serif;
+        --sans: "Hiragino Kaku Gothic ProN", "Yu Gothic", "Helvetica Neue",
+          system-ui, sans-serif;
+        --mono: ui-monospace, "SF Mono", Menlo, monospace;
+        --w: 1080px;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        scroll-behavior: smooth;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+      body {
+        background: var(--washi);
+        color: var(--sumi);
+        font-family: var(--serif);
+        font-size: 16px;
+        line-height: 1.95;
+        font-feature-settings: "palt" 1;
+      }
+      a {
+        color: var(--sumi);
+        text-decoration: none;
+        border-bottom: 1px solid var(--line);
+        transition: border-color 0.2s;
+      }
+      a:hover {
+        border-color: var(--seal);
+      }
+      svg {
+        display: block;
+      }
+      .wrap {
+        max-width: var(--w);
+        margin: 0 auto;
+        padding-inline: clamp(24px, 6vw, 88px);
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 0.82em;
+        color: var(--seal);
+      }
+      ::selection {
+        background: var(--seal);
+        color: var(--paper);
+      }
+
+      /* vertical label (tategaki) */
+      .tate {
+        writing-mode: vertical-rl;
+        text-orientation: upright;
+        font-family: var(--sans);
+        font-size: 12px;
+        letter-spacing: 0.35em;
+        color: var(--sumi-faint);
+        line-height: 1;
+      }
+
+      /* hanko seal */
+      .hanko {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 46px;
+        height: 46px;
+        border: 2px solid var(--seal);
+        border-radius: 7px;
+        color: var(--seal);
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: 18px;
+        line-height: 1;
+        letter-spacing: -0.02em;
+        flex: none;
+      }
+      .hanko span {
+        display: block;
+        transform: translateY(0.5px);
+      }
+
+      /* header */
+      header {
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        background: color-mix(in srgb, var(--washi) 90%, transparent);
+        backdrop-filter: blur(8px);
+        border-bottom: 1px solid var(--line-soft);
+      }
+      .bar {
+        max-width: var(--w);
+        margin: 0 auto;
+        padding: 16px clamp(24px, 6vw, 88px);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        border: none;
+      }
+      .brand .seal-sm {
+        width: 30px;
+        height: 30px;
+        border: 1.5px solid var(--seal);
+        border-radius: 5px;
+        color: var(--seal);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 13px;
+        line-height: 1;
+      }
+      .brand .name {
+        font-family: var(--sans);
+        font-weight: 600;
+        font-size: 16px;
+        letter-spacing: 0.14em;
+      }
+      .brand .name small {
+        color: var(--sumi-faint);
+        font-weight: 400;
+        margin-left: 6px;
+        letter-spacing: 0.1em;
+      }
+      nav.nav {
+        display: flex;
+        gap: 26px;
+        align-items: center;
+      }
+      nav.nav a {
+        font-family: var(--sans);
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        color: var(--sumi-soft);
+        border: none;
+      }
+      nav.nav a:hover {
+        color: var(--seal);
+      }
+      @media (max-width: 680px) {
+        nav.nav a.hideable {
+          display: none;
+        }
+      }
+
+      /* index numbering for sections */
+      .sec {
+        border-top: 1px solid var(--line-soft);
+        padding-block: clamp(64px, 9vw, 120px);
+        position: relative;
+      }
+      .sec-grid {
+        display: grid;
+        grid-template-columns: 150px 1fr;
+        gap: clamp(24px, 5vw, 72px);
+        align-items: start;
+      }
+      @media (max-width: 760px) {
+        .sec-grid {
+          grid-template-columns: 1fr;
+          gap: 20px;
+        }
+      }
+      .sec-aside {
+        display: flex;
+        gap: 16px;
+        align-items: flex-start;
+      }
+      .sec-no {
+        font-family: var(--mono);
+        font-size: 12px;
+        letter-spacing: 0.1em;
+        color: var(--sumi-faint);
+      }
+      @media (max-width: 760px) {
+        .sec-aside {
+          border-left: 2px solid var(--seal);
+          padding-left: 14px;
+        }
+        .tate {
+          writing-mode: horizontal-tb;
+          letter-spacing: 0.25em;
+        }
+      }
+      h2 {
+        font-family: var(--sans);
+        font-weight: 600;
+        font-size: clamp(21px, 2.6vw, 27px);
+        letter-spacing: 0.02em;
+        line-height: 1.4;
+        margin-bottom: 22px;
+      }
+      .sec p {
+        color: var(--sumi-soft);
+        max-width: 40em;
+        margin-bottom: 18px;
+      }
+      .sec p.lead {
+        color: var(--sumi);
+        font-size: 18px;
+      }
+
+      /* hero */
+      .hero {
+        padding-block: clamp(64px, 12vh, 150px) clamp(48px, 8vh, 96px);
+        position: relative;
+        overflow: hidden;
+      }
+      .hero .kanji-bg {
+        position: absolute;
+        top: 50%;
+        right: -0.12em;
+        transform: translateY(-50%);
+        font-family: var(--serif);
+        font-size: clamp(180px, 40vw, 460px);
+        line-height: 0.9;
+        color: var(--washi-2);
+        z-index: 0;
+        pointer-events: none;
+        user-select: none;
+      }
+      .hero-inner {
+        position: relative;
+        z-index: 1;
+      }
+      .eyebrow {
+        font-family: var(--sans);
+        font-size: 12px;
+        letter-spacing: 0.28em;
+        color: var(--sumi-faint);
+        text-transform: uppercase;
+        display: block;
+        margin-bottom: 34px;
+      }
+      h1 {
+        font-family: var(--serif);
+        font-weight: 500;
+        font-size: clamp(34px, 6.2vw, 66px);
+        line-height: 1.28;
+        letter-spacing: 0.01em;
+        max-width: 15em;
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        color: var(--seal);
+        transition: width 480ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+        will-change: transform, opacity;
+      }
+      .rotator-measure {
+        position: absolute;
+        left: 0;
+        top: 0;
+        visibility: hidden;
+        pointer-events: none;
+        white-space: nowrap;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .rotator {
+          transition: none;
+        }
+      }
+      .lede {
+        font-family: var(--serif);
+        color: var(--sumi-soft);
+        font-size: clamp(16px, 1.9vw, 19px);
+        line-height: 2;
+        margin-top: 40px;
+        max-width: 38em;
+      }
+      .actions {
+        margin-top: 44px;
+        display: flex;
+        gap: 14px;
+        flex-wrap: wrap;
+      }
+      .btn {
+        font-family: var(--sans);
+        font-size: 13px;
+        letter-spacing: 0.1em;
+        padding: 13px 26px;
+        border: 1px solid var(--sumi);
+        color: var(--sumi);
+        background: transparent;
+        transition: all 0.2s;
+      }
+      .btn:hover {
+        background: var(--sumi);
+        color: var(--washi);
+        border-color: var(--sumi);
+      }
+      .btn.seal {
+        border-color: var(--seal);
+        color: var(--seal);
+      }
+      .btn.seal:hover {
+        background: var(--seal);
+        color: var(--paper);
+        border-color: var(--seal);
+      }
+
+      /* code */
+      pre {
+        background: var(--paper);
+        border: 1px solid var(--line);
+        padding: 22px 24px;
+        overflow-x: auto;
+        margin: 22px 0;
+      }
+      pre code {
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 2.1;
+        color: var(--sumi);
+        white-space: pre;
+      }
+      pre code .c {
+        color: var(--sumi-faint);
+      }
+      details.manual {
+        margin-top: 8px;
+      }
+      details.manual summary {
+        font-family: var(--sans);
+        font-size: 13px;
+        letter-spacing: 0.06em;
+        color: var(--sumi-faint);
+        cursor: pointer;
+        padding: 8px 0;
+      }
+      details.manual summary:hover {
+        color: var(--seal);
+      }
+
+      /* how it works rows */
+      .rows {
+        margin-top: 4px;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 220px 1fr;
+        gap: 28px;
+        padding: 22px 0;
+        border-top: 1px solid var(--line-soft);
+      }
+      @media (max-width: 640px) {
+        .row {
+          grid-template-columns: 1fr;
+          gap: 8px;
+        }
+      }
+      .row .k {
+        font-family: var(--sans);
+        font-weight: 600;
+        font-size: 15px;
+        letter-spacing: 0.04em;
+      }
+      .row .k .t {
+        display: block;
+        font-family: var(--mono);
+        font-weight: 400;
+        font-size: 11.5px;
+        color: var(--seal);
+        margin-top: 6px;
+        letter-spacing: 0.02em;
+      }
+      .row .v {
+        color: var(--sumi-soft);
+        max-width: 34em;
+      }
+      .uses {
+        list-style: none;
+        margin-top: 20px;
+        display: grid;
+        gap: 14px;
+      }
+      .uses li {
+        color: var(--sumi-soft);
+        padding-left: 24px;
+        position: relative;
+        max-width: 40em;
+      }
+      .uses li::before {
+        content: "—";
+        position: absolute;
+        left: 0;
+        color: var(--seal);
+      }
+      .uses b {
+        color: var(--sumi);
+        font-weight: 600;
+      }
+      .note {
+        font-size: 15px;
+      }
+
+      /* diagram */
+      .diagram {
+        margin-top: 12px;
+        overflow-x: auto;
+      }
+      .diagram svg {
+        width: 100%;
+        min-width: 560px;
+        height: auto;
+      }
+      .diagram .node {
+        fill: var(--paper);
+        stroke: var(--sumi);
+        stroke-width: 1;
+      }
+      .diagram .box {
+        fill: none;
+        stroke: var(--sumi-faint);
+        stroke-width: 1;
+        stroke-dasharray: 2 6;
+      }
+      .diagram .t {
+        font-family: var(--sans);
+        font-size: 13px;
+        fill: var(--sumi);
+      }
+      .diagram .s {
+        font-family: var(--sans);
+        font-size: 10.5px;
+        fill: var(--sumi-faint);
+      }
+      .diagram .e {
+        font-family: var(--mono);
+        font-size: 10px;
+        fill: var(--sumi-faint);
+      }
+      .diagram .arr {
+        stroke: var(--sumi-soft);
+        stroke-width: 1;
+        fill: none;
+      }
+      .diagram .seal-node {
+        stroke: var(--seal);
+      }
+      .diagram .seal-t {
+        fill: var(--seal);
+      }
+
+      /* connectors list */
+      .conn {
+        margin-top: 6px;
+        border-top: 1px solid var(--line-soft);
+      }
+      .conn .item {
+        display: grid;
+        grid-template-columns: 170px 1fr;
+        gap: 24px;
+        padding: 16px 0;
+        border-bottom: 1px solid var(--line-soft);
+        align-items: baseline;
+      }
+      @media (max-width: 560px) {
+        .conn .item {
+          grid-template-columns: 1fr;
+          gap: 2px;
+        }
+      }
+      .conn .item b {
+        font-family: var(--sans);
+        font-weight: 600;
+        font-size: 15px;
+        letter-spacing: 0.02em;
+      }
+      .conn .item span {
+        color: var(--sumi-soft);
+        font-size: 15px;
+      }
+      .conn-cap {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        color: var(--sumi-faint);
+        text-transform: uppercase;
+        margin-bottom: 14px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .conn-cap::before {
+        content: "";
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--seal);
+      }
+
+      /* demo */
+      .demo-step {
+        margin-top: 40px;
+      }
+      .demo-step h3 {
+        font-family: var(--sans);
+        font-weight: 600;
+        font-size: 16px;
+        letter-spacing: 0.04em;
+        margin-bottom: 12px;
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
+      }
+      .demo-step h3 .n {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--seal);
+        letter-spacing: 0;
+      }
+      .examples {
+        display: grid;
+        gap: 20px;
+        margin-top: 24px;
+      }
+      .ex {
+        border: 1px solid var(--line);
+        background: var(--paper);
+        padding: 24px 26px;
+      }
+      .ex .q {
+        font-family: var(--serif);
+        font-size: 17px;
+        color: var(--sumi);
+        margin-bottom: 16px;
+        line-height: 1.7;
+      }
+      .ex .a {
+        display: flex;
+        align-items: baseline;
+        gap: 18px;
+        flex-wrap: wrap;
+        border-top: 1px solid var(--line-soft);
+        padding-top: 16px;
+      }
+      .ex .a > b {
+        font-family: var(--serif);
+        font-weight: 500;
+        font-size: clamp(28px, 4vw, 40px);
+        color: var(--seal);
+        line-height: 1;
+        letter-spacing: 0.01em;
+      }
+      .ex .a > span {
+        color: var(--sumi-soft);
+        font-size: 14.5px;
+        max-width: 30em;
+        line-height: 1.7;
+      }
+      .chart {
+        width: 100%;
+      }
+      .chart .cl {
+        font-family: var(--sans);
+        font-size: 12.5px;
+        letter-spacing: 0.05em;
+        color: var(--sumi-faint);
+        margin-bottom: 14px;
+      }
+      .chart svg {
+        width: 100%;
+        height: auto;
+      }
+      .token {
+        font-family: var(--mono);
+        font-size: 12px;
+      }
+
+      /* why */
+      .why h3 {
+        font-family: var(--serif);
+        font-weight: 500;
+        font-size: clamp(19px, 2.4vw, 24px);
+        color: var(--sumi);
+        margin: 40px 0 10px;
+        letter-spacing: 0.02em;
+      }
+      .why h3:first-of-type {
+        margin-top: 0;
+      }
+
+      /* footer */
+      footer {
+        border-top: 1px solid var(--line);
+        padding-block: 56px 72px;
+        margin-top: 40px;
+      }
+      .foot {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-end;
+        gap: 30px;
+        flex-wrap: wrap;
+      }
+      .foot .fl {
+        display: flex;
+        gap: 22px;
+        align-items: center;
+        flex-wrap: wrap;
+        font-family: var(--sans);
+        font-size: 13px;
+        letter-spacing: 0.08em;
+        color: var(--sumi-soft);
+      }
+      .foot .fl a {
+        border: none;
+        color: var(--sumi-soft);
+      }
+      .foot .fl a:hover {
+        color: var(--seal);
+      }
+      .foot .jp {
+        font-family: var(--serif);
+        font-size: 14px;
+        color: var(--sumi-faint);
+        letter-spacing: 0.04em;
+      }
+      .foot .jp b {
+        color: var(--seal);
+        font-weight: 500;
+      }
+      .foot-kanji {
+        font-family: var(--serif);
+        font-size: clamp(90px, 22vw, 240px);
+        line-height: 0.82;
+        color: var(--washi-2);
+        margin-top: 40px;
+        letter-spacing: 0.04em;
+        user-select: none;
+      }
+      .ma {
+        height: clamp(40px, 8vh, 90px);
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="bar">
+        <a class="brand" href="#top">
+          <span class="seal-sm">設</span>
+          <span class="name">SETOKU<small>設奥</small></span>
+        </a>
+        <nav class="nav">
+          <a class="hideable" href="#how">How it works</a>
+          <a class="hideable" href="#apps">Apps</a>
+          <a class="hideable" href="#connectors">Connectors</a>
+          <a
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >GitHub ↗</a
+          >
+        </nav>
+      </div>
+    </header>
+
+    <main id="top">
+      <!-- HERO -->
+      <div class="hero">
+        <div class="kanji-bg" aria-hidden="true">奥</div>
+        <div class="wrap hero-inner">
+          <span class="eyebrow">Open source ・ MCP server ・ Apache-2.0</span>
+          <h1>
+            Make any AI fluent in your <span
+              class="rotator"
+              data-words="company,family,personal"
+              ><span class="rotator-word">company</span
+              ><span class="rotator-measure" aria-hidden="true"></span></span>
+            data.
+          </h1>
+          <p class="lede">
+            Setoku is a small self-hosted MCP knowledge server + Claude Code
+            skills for hooking up your data. It does two things: it gives your
+            AI a read-only way to query your data, and it remembers what that
+            data means (the metric definitions, the gotchas), getting better
+            the more you use it. The MCP works with whatever AI you already
+            have, and no model runs on the server, so no added inference cost.
+          </p>
+          <div class="actions">
+            <a
+              class="btn"
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >View on GitHub ↗</a
+            >
+            <a class="btn seal" href="#demo">Try the demo</a>
+          </div>
+        </div>
+      </div>
+
+      <!-- QUICKSTART -->
+      <section class="sec" id="quickstart">
+        <div class="wrap sec-grid">
+          <div class="sec-aside">
+            <span class="tate">始</span>
+            <span class="sec-no">壱 / 01</span>
+          </div>
+          <div>
+            <h2>Quickstart</h2>
+            <p>
+              Setoku installs as a Claude Code plugin. Add the plugin, then run
+              onboarding from your main project directory, the codebase you
+              want Setoku to learn from:
+            </p>
+            <pre><code><span class="c"># 1 ・ add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 ・ from your project directory</span>
+/setoku:onboard</code></pre>
+            <p>
+              Onboarding stands up the server, auths your Claude, wires your
+              database read-only, and generates the first knowledge from your
+              code. You stay in the loop for anything that touches your data.
+              To start onboarding, run <code>/setoku:onboard</code>.
+            </p>
+            <p>
+              You’ll need somewhere to host it. Something like OVH’s
+              <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener"
+                >VPS-2</a
+              >
+              is plenty.
+            </p>
+            <details class="manual">
+              <summary>Or stand up the server by hand</summary>
+              <pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+              <p style="margin-top: 12px">
+                Installs Docker, generates secrets, gets an HTTPS certificate,
+                and prints the connect command. Then add the plugin and run
+                /setoku:onboard from your project; it’ll detect the box you just
+                made.
+              </p>
+            </details>
+          </div>
+        </div>
+      </section>
+
+      <!-- HOW IT WORKS -->
+      <section class="sec" id="how">
+        <div class="wrap sec-grid">
+          <div class="sec-aside">
+            <span class="tate">理</span>
+            <span class="sec-no">弐 / 02</span>
+          </div>
+          <div>
+            <h2>How it works</h2>
+            <p class="lead">
+              Setoku gives the AI two kinds of MCP tools, and one rule: look up
+              what the data means before you touch it.
+            </p>
+            <div class="rows">
+              <div class="row">
+                <div class="k">
+                  Context tools<span class="t">find_context ・ get_metric</span>
+                </div>
+                <div class="v">
+                  The AI reads what your data means first: canonical metric
+                  definitions, entity docs, and the gotchas that make a naive
+                  query wrong.
+                </div>
+              </div>
+              <div class="row">
+                <div class="k">
+                  Read-only query<span class="t">get_schema ・ run_query</span>
+                </div>
+                <div class="v">
+                  Read-only, with a row cap, a statement timeout, a table
+                  allow-list, and an append-only audit log. Enforced by the
+                  database role, not by parsing SQL.
+                </div>
+              </div>
+              <div class="row">
+                <div class="k">
+                  Human-approved<span class="t">report_correction</span>
+                </div>
+                <div class="v">
+                  The AI can only propose changes to what Setoku knows. A person
+                  accepts them on the admin page, outside the agent loop, so an
+                  injected session can’t rewrite the brain.
+                </div>
+              </div>
+            </div>
+            <p class="note" style="margin-top: 26px">
+              You set it up with <b>Claude Code</b> skills:
+            </p>
+            <ul class="uses">
+              <li>
+                <code>/setoku:onboard</code> sets Setoku up in a repo for the
+                first time.
+              </li>
+              <li>
+                <code>/setoku:connect</code> adds a data source or custom
+                integration.
+              </li>
+              <li>
+                <code>/setoku:generate</code> writes business context from your
+                code.
+              </li>
+              <li>
+                <code>/setoku:curate</code> reviews and approves pending
+                knowledge.
+              </li>
+            </ul>
+            <p class="note" style="margin-top: 18px">
+              Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex,
+              or whatever you run. Just ask in plain language, and the tools do
+              the rest.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- APPS -->
+      <section class="sec" id="apps">
+        <div class="wrap sec-grid">
+          <div class="sec-aside">
+            <span class="tate">応</span>
+            <span class="sec-no">参 / 03</span>
+          </div>
+          <div>
+            <h2>Apps: save and share the tools Claude builds you</h2>
+            <p class="lead">
+              Ask Claude to build a dashboard on your data. Then publish it to a
+              link as a Setoku App, the data stays live, and your whole team can
+              view it. Nothing to deploy, no frontend to maintain.
+            </p>
+            <div class="rows">
+              <div class="row">
+                <div class="k">
+                  Built by asking<span class="t">publish_app</span>
+                </div>
+                <div class="v">
+                  Describe it in plain language; the agent writes the app and
+                  publishes it to a URL. Edit it the same way, just ask for the
+                  change.
+                </div>
+              </div>
+              <div class="row">
+                <div class="k">
+                  Backed by live data<span class="t">read-only</span>
+                </div>
+                <div class="v">
+                  Apps read through the same governed path: row caps, audit, a
+                  SELECT-only database role. They never get write access to your
+                  sources.
+                </div>
+              </div>
+              <div class="row">
+                <div class="k">
+                  App-private state<span class="t">no writes to your data</span>
+                </div>
+                <div class="v">
+                  Each app keeps its own state (todos, votes, annotations) in a
+                  sandbox that belongs to the app, not your database. Worst
+                  case, an app messes up its own notes.
+                </div>
+              </div>
+              <div class="row">
+                <div class="k">
+                  Share by link<span class="t">team or public</span>
+                </div>
+                <div class="v">
+                  A team link is login-gated; an admin can flip one public for a
+                  credential-free URL. The page runs in a locked-down sandbox
+                  with no network, so a published app can’t phone home.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ARCHITECTURE -->
+      <section class="sec" id="architecture">
+        <div class="wrap sec-grid">
+          <div class="sec-aside">
+            <span class="tate">構</span>
+            <span class="sec-no">肆 / 04</span>
+          </div>
+          <div>
+            <h2>Architecture</h2>
+            <p class="lead">
+              You can host this on whatever infra you like. We put it all on one
+              small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+              helps you add custom integrations. Only the proxy is public, so
+              your databases aren’t exposed. Queries are read-only, and
+              knowledge changes pass through a person.
+            </p>
+            <div class="diagram">
+              <svg
+                viewBox="0 0 680 520"
+                role="img"
+                aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake, and your sources are ingested into the lake."
+              >
+                <defs>
+                  <marker
+                    id="ah"
+                    markerWidth="9"
+                    markerHeight="9"
+                    refX="6"
+                    refY="3"
+                    orient="auto-start-reverse"
+                  >
+                    <path d="M0 0 L6 3 L0 6 Z" fill="#6c6b63" />
+                  </marker>
+                </defs>
+
+                <rect class="node" x="250" y="14" width="180" height="44" rx="2" />
+                <text class="t" x="340" y="41" text-anchor="middle">
+                  You + your AI
+                </text>
+                <path
+                  class="arr"
+                  d="M340 58 L340 142"
+                  marker-start="url(#ah)"
+                  marker-end="url(#ah)"
+                />
+                <text class="e" x="348" y="86">MCP</text>
+
+                <rect class="box" x="60" y="110" width="560" height="300" rx="2" />
+                <text class="e" x="76" y="130">your box</text>
+
+                <rect class="node" x="250" y="146" width="180" height="58" rx="2" />
+                <text class="t" x="340" y="171" text-anchor="middle">
+                  Setoku gateway
+                </text>
+                <text class="s" x="340" y="189" text-anchor="middle">
+                  context ・ query tools
+                </text>
+
+                <rect
+                  class="node seal-node"
+                  x="452"
+                  y="150"
+                  width="150"
+                  height="50"
+                  rx="2"
+                />
+                <text class="t seal-t" x="527" y="179" text-anchor="middle">
+                  a person
+                </text>
+
+                <rect class="node" x="92" y="322" width="180" height="66" rx="2" />
+                <text class="t" x="182" y="350" text-anchor="middle">
+                  Lake (ClickHouse)
+                </text>
+                <text class="s" x="182" y="368" text-anchor="middle">
+                  logs ・ events ・ DB mirror
+                </text>
+
+                <rect class="node" x="408" y="322" width="190" height="66" rx="2" />
+                <text class="t" x="503" y="359" text-anchor="middle">
+                  Knowledge store
+                </text>
+
+                <rect class="node" x="92" y="440" width="180" height="64" rx="2" />
+                <text class="t" x="182" y="468" text-anchor="middle">
+                  Your sources
+                </text>
+                <text class="s" x="182" y="486" text-anchor="middle">
+                  GitHub ・ Vercel ・ Slack…
+                </text>
+
+                <rect class="node" x="300" y="440" width="180" height="64" rx="2" />
+                <text class="t" x="390" y="468" text-anchor="middle">
+                  Your database
+                </text>
+                <text class="s" x="390" y="486" text-anchor="middle">
+                  Postgres ・ read-only
+                </text>
+
+                <path
+                  class="arr"
+                  d="M412 204 L508 322"
+                  marker-start="url(#ah)"
+                  marker-end="url(#ah)"
+                />
+                <text class="e" x="424" y="266" text-anchor="middle">reads ・</text>
+                <text class="e" x="424" y="282" text-anchor="middle">proposes</text>
+                <path class="arr" d="M527 200 L513 322" marker-end="url(#ah)" />
+                <text class="e seal-t" x="534" y="262">approves</text>
+                <path class="arr" d="M210 322 L300 204" marker-end="url(#ah)" />
+                <path class="arr" d="M182 440 L182 388" marker-end="url(#ah)" />
+                <text class="e" x="190" y="420">ingest</text>
+                <path class="arr" d="M388 440 L366 206" marker-end="url(#ah)" />
+                <text class="e" x="300" y="300">read-only</text>
+              </svg>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- CONNECTORS -->
+      <section class="sec" id="connectors">
+        <div class="wrap sec-grid">
+          <div class="sec-aside">
+            <span class="tate">源</span>
+            <span class="sec-no">伍 / 05</span>
+          </div>
+          <div>
+            <h2>Connectors</h2>
+            <p class="lead">
+              Point Setoku at the data you already have. Every source lands in a
+              local
+              <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+                >ClickHouse</a
+              >
+              data lake, on purpose: agents write arbitrary queries (scans,
+              GROUP BYs, whole-table aggregations), and a columnar engine
+              answers those in about a second, so the apps and dashboards they
+              build stay quick. Your app database connects read-only and is
+              mirrored in on a cron; the rest is ingested as it happens.
+            </p>
+            <div class="conn">
+              <div class="conn-cap">ClickHouse ・ one lake, every source</div>
+              <div class="item">
+                <b>PostgreSQL</b><span>app database, mirrored read-only</span>
+              </div>
+              <div class="item">
+                <b>GitHub</b><span>issues, PRs &amp; commits</span>
+              </div>
+              <div class="item"><b>Vercel</b><span>deploys &amp; logs</span></div>
+              <div class="item"><b>Render</b><span>deploys &amp; logs</span></div>
+              <div class="item"><b>Slack</b><span>messages</span></div>
+              <div class="item">
+                <b>Mercury</b><span>banking &amp; finance</span>
+              </div>
+            </div>
+            <p class="note" style="margin-top: 20px">
+              No connector for your source yet? The included setup skills give
+              your coding agent the patterns to wire one up itself. See
+              <a
+                href="https://github.com/Hedgy-Labs/setoku"
+                target="_blank"
+                rel="noopener"
+                >the repo</a
+              >, or open an issue.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- DEMO -->
+      <section class="sec" id="demo">
+        <div class="wrap sec-grid">
+          <div class="sec-aside">
+            <span class="tate">試</span>
+            <span class="sec-no">陸 / 06</span>
+          </div>
+          <div>
+            <h2>Try it on real-ish data</h2>
+            <p class="lead">
+              There’s a live demo wired to a fictional pro sports club, the
+              Bonita Bulldogs (ticketing, sponsorship, concessions, payroll,
+              broadcast rights).
+            </p>
+
+            <div class="demo-step">
+              <h3><span class="n">壱</span>Connect to the demo MCP server</h3>
+              <p class="note">
+                In Claude (or any MCP client) open Settings → Connectors → Add
+                custom connector, and paste this URL. The token rides in the
+                URL, so there’s no separate key to enter.
+              </p>
+              <pre><code class="token">https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</code></pre>
+            </div>
+
+            <div class="demo-step">
+              <h3><span class="n">弐</span>Ask a question</h3>
+              <div class="examples">
+                <div class="ex">
+                  <div class="q">“How many unique fans do we have?”</div>
+                  <div class="a">
+                    <b>71,204</b>
+                    <span
+                      >deduped by normalized email, internal accounts excluded.
+                      Not the raw 92,118.</span
+                    >
+                  </div>
+                </div>
+                <div class="ex">
+                  <div class="q">
+                    “What’s our total annual revenue, and how much is media
+                    rights?”
+                  </div>
+                  <div class="a">
+                    <b>$192M</b>
+                    <span
+                      >five systems reconciled to the same units. Media rights
+                      is the biggest line, ~$90M.</span
+                    >
+                  </div>
+                </div>
+                <div class="ex">
+                  <div class="q">“What was ticket revenue this season?”</div>
+                  <div class="a">
+                    <b>$46.8M</b>
+                    <span
+                      >cents reconciled to dollars; refunds, exchanges, and
+                      comps excluded.</span
+                    >
+                  </div>
+                </div>
+                <div class="ex">
+                  <div class="q">“What’s our total merchandise revenue?”</div>
+                  <div class="a">
+                    <b>It flags it</b>
+                    <span
+                      >most merch is sold via Fanatics, not in this data, so it
+                      says so instead of returning a wrong total.</span
+                    >
+                  </div>
+                </div>
+                <div class="ex">
+                  <div class="q">“Chart revenue by line.”</div>
+                  <div class="a" style="display: block">
+                    <div class="chart">
+                      <div class="cl">Annual revenue by line ・ ~$192M total</div>
+                      <svg
+                        viewBox="0 0 640 214"
+                        role="img"
+                        aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M."
+                      >
+                        <g fill="#b1341f">
+                          <rect x="148" y="14" width="400" height="16" />
+                          <rect x="148" y="48" width="209" height="16" />
+                          <rect x="148" y="82" width="124" height="16" />
+                          <rect x="148" y="116" width="62" height="16" />
+                          <rect x="148" y="150" width="36" height="16" />
+                          <rect x="148" y="184" width="22" height="16" />
+                        </g>
+                        <g
+                          font-family="'Hiragino Kaku Gothic ProN', system-ui, sans-serif"
+                          font-size="12.5"
+                          fill="#3d3d39"
+                        >
+                          <text x="8" y="26">Media rights</text>
+                          <text x="8" y="60">Ticketing</text>
+                          <text x="8" y="94">Sponsorship</text>
+                          <text x="8" y="128">Concessions</text>
+                          <text x="8" y="162">Merch</text>
+                          <text x="8" y="196">Other</text>
+                        </g>
+                        <g
+                          font-family="ui-monospace, 'SF Mono', Menlo, monospace"
+                          font-size="12"
+                          fill="#1c1c1a"
+                        >
+                          <text x="555" y="26">$90M</text>
+                          <text x="364" y="60">$47M</text>
+                          <text x="279" y="94">$28M</text>
+                          <text x="217" y="128">$14M</text>
+                          <text x="191" y="162">$8M</text>
+                          <text x="177" y="196">$5M</text>
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="demo-step">
+              <h3><span class="n">参</span>Try an app</h3>
+              <p class="note">
+                Ask Claude to build a dashboard on the same data, then publish it
+                to a link. Two live examples, running on the demo data right now:
+              </p>
+              <ul class="uses">
+                <li>
+                  <a
+                    href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+                    target="_blank"
+                    rel="noopener"
+                    >Sponsorship pricing table ↗</a
+                  >
+                  — inventory and rates for sponsorship placements.
+                </li>
+                <li>
+                  <a
+                    href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+                    target="_blank"
+                    rel="noopener"
+                    >Fan lifetime value ↗</a
+                  >
+                  — segment fans by spend across tickets, merch, and
+                  concessions.
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- WHY -->
+      <section class="sec why" id="why">
+        <div class="wrap sec-grid">
+          <div class="sec-aside">
+            <span class="tate">志</span>
+            <span class="sec-no">漆 / 07</span>
+          </div>
+          <div>
+            <h2>Why we built it</h2>
+            <h3>We’re curious.</h3>
+            <p>
+              There are plenty of AI memory stores, and plenty of data gateways.
+              Stapling the two together, and nudging the agent to gather
+              knowledge about the data as it goes, seemed useful and fun to
+              tinker with.
+            </p>
+            <h3>We’re cheap.</h3>
+            <p>
+              We wanted something that runs on one small box, works on a Pro/Max
+              subscription or a cheap model with no added inference cost, mostly
+              sets itself up (no field engineer to pay for), stays portable
+              between providers, and is open source.
+            </p>
+            <h3>We’re paranoid.</h3>
+            <p>
+              HR platforms, CRMs, and clouds are all announcing “context
+              layers.” They’d like the meaning of your business to accumulate on
+              their servers, where it can never leave. Context is deeper lock-in
+              than data, and a hosted context layer has no export button. Setoku
+              exists so that understanding accumulates on a box you own instead.
+              If we disappear tomorrow, your context doesn’t.
+            </p>
+            <h3>We and some friends wanted the same thing.</h3>
+            <ul class="uses">
+              <li>
+                <b
+                  ><a href="https://www.hedgy.works" target="_blank" rel="noopener"
+                    >Hedgy</a
+                  ></b
+                >: keep scaling without hiring. Debug from live logs and data,
+                find growth levers, and match candidates and companies better
+                with more data.
+              </li>
+              <li>
+                <b
+                  ><a href="https://baggu.com" target="_blank" rel="noopener"
+                    >Baggu</a
+                  ></b
+                >: give employees state-of-the-art tools. Faster onboarding, and
+                a safe way to vibecode against real data.
+              </li>
+              <li>
+                <b
+                  ><a href="https://tlon.io" target="_blank" rel="noopener"
+                    >Tlon</a
+                  ></b
+                >: experimenting with giving agents curated data to work from.
+              </li>
+              <li>
+                <b>Sports analysts</b>: query across data that doesn’t usually
+                sit together.
+              </li>
+              <li>
+                <b>Academic labs</b>: think through hypotheses against real
+                papers, data, and drafts.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- SETUP HELP -->
+      <section class="sec" id="help">
+        <div class="wrap sec-grid">
+          <div class="sec-aside">
+            <span class="tate">助</span>
+            <span class="sec-no">捌 / 08</span>
+          </div>
+          <div>
+            <h2>Setup help</h2>
+            <p class="lead">
+              It’s open source, so you can self-host it today. If you like, we’re
+              happy to help set it up. Just email
+              <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="wrap">
+        <div class="foot">
+          <div class="fl">
+            <a class="brand" href="#top" style="gap: 10px">
+              <span class="seal-sm" style="width: 26px; height: 26px; font-size: 12px">設</span>
+              <span class="name" style="font-size: 14px">SETOKU</span>
+            </a>
+            <a
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >GitHub</a
+            >
+            <a href="#demo">Demo</a>
+            <a href="mailto:hello@setoku.com">Contact</a>
+            <span>Apache-2.0</span>
+          </div>
+          <span class="jp"
+            ><b>設 × 奥</b> ・ set (math) × oku (innermost)</span
+          >
+        </div>
+        <div class="foot-kanji" aria-hidden="true">設奥</div>
+      </div>
+    </footer>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) { return w.trim(); })
+          .filter(Boolean);
+        if (words.length < 2) return;
+
+        var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        var LIFT = "0.72em";
+        var HALF = 240;
+        var HOLD = 2400;
+        var i = 0;
+
+        function widthOf(w) {
+          measure.textContent = w;
+          return measure.getBoundingClientRect().width;
+        }
+
+        box.style.width = widthOf(words[0]) + "px";
+
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next;
+            box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length;
+            return;
+          }
+          word
+            .animate(
+              [
+                { transform: "translateY(0)", opacity: 1 },
+                { transform: "translateY(-" + LIFT + ")", opacity: 0 },
+              ],
+              { duration: HALF, easing: "cubic-bezier(0.4, 0, 1, 1)", fill: "forwards" }
+            )
+            .finished.then(function () {
+              word.textContent = next;
+              box.style.width = widthOf(next) + "px";
+              word.animate(
+                [
+                  { transform: "translateY(" + LIFT + ")", opacity: 0 },
+                  { transform: "translateY(0)", opacity: 1 },
+                ],
+                { duration: HALF, easing: "cubic-bezier(0, 0, 0.2, 1)", fill: "forwards" }
+              );
+              i = (i + 1) % words.length;
+            })
+            .catch(function () {});
+        }
+
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () {
+          box.style.width = widthOf(words[i]) + "px";
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/14-chart.html
+++ b/site/riffs/14-chart.html
@@ -1,0 +1,2031 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · Chart No. 1 — the data lake, sounded and navigated</title>
+    <meta
+      name="description"
+      content="Setoku is an open-source MCP server that gives your AI a read-only view of your company’s data, plus the context to use it correctly. Charted as an antique sea survey."
+    />
+    <style>
+      :root {
+        /* Aged chart paper + engraved ink. */
+        --paper: #f3ead2;
+        --paper-2: #efe3c6;
+        --paper-edge: #e6d8b4;
+        --ink: #2c2417;
+        --ink-soft: #4a3f2c;
+        --ink-faint: #6b5d43;
+        --line: #b9a778;
+        --line-soft: #cdbf99;
+        --water: #cfdcd8;
+        --water-deep: #b7c9c6;
+        --sage: #5f7d63;
+        --sage-d: #3f5a44;
+        --chart-red: #9a4b32;
+        --serif: "Hoefler Text", "Iowan Old Style", "Palatino Linotype",
+          Palatino, "Times New Roman", Georgia, serif;
+        --sans: "Optima", "Gill Sans", "Gill Sans MT", "Century Gothic",
+          system-ui, sans-serif;
+        --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        --w: 900px;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        scroll-behavior: smooth;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family: var(--serif);
+        font-size: 17px;
+        line-height: 1.62;
+        /* Faint foxing + latitude wash so the whole page feels like sheet stock. */
+        background-image: radial-gradient(
+            circle at 18% 12%,
+            rgba(154, 75, 50, 0.05),
+            transparent 42%
+          ),
+          radial-gradient(
+            circle at 82% 78%,
+            rgba(63, 90, 68, 0.05),
+            transparent 46%
+          ),
+          radial-gradient(
+            circle at 60% 30%,
+            rgba(107, 93, 67, 0.045),
+            transparent 30%
+          );
+        background-attachment: fixed;
+      }
+      a {
+        color: var(--chart-red);
+        text-decoration: none;
+        border-bottom: 1px solid rgba(154, 75, 50, 0.35);
+      }
+      a:hover {
+        border-bottom-color: var(--chart-red);
+      }
+      svg {
+        display: block;
+      }
+      code,
+      .mono {
+        font-family: var(--mono);
+      }
+      ::selection {
+        background: var(--sage);
+        color: var(--paper);
+      }
+
+      /* Ruled neat-line border, the way a survey sheet is framed. */
+      .sheet {
+        max-width: 1080px;
+        margin: 22px auto;
+        border: 2px solid var(--ink);
+        outline: 1px solid var(--ink);
+        outline-offset: 4px;
+        background: var(--paper);
+        position: relative;
+        box-shadow: 0 1px 0 rgba(44, 36, 23, 0.15),
+          0 18px 50px rgba(44, 36, 23, 0.14);
+      }
+      /* Lat/long tick rail on the inner frame. */
+      .ticks-top,
+      .ticks-bottom {
+        height: 22px;
+        border-bottom: 1px solid var(--line);
+        background-image: repeating-linear-gradient(
+          to right,
+          var(--line) 0 1px,
+          transparent 1px 40px
+        );
+        background-position: left center;
+        background-size: 40px 9px;
+        background-repeat: repeat-x;
+        position: relative;
+      }
+      .ticks-bottom {
+        border-bottom: none;
+        border-top: 1px solid var(--line);
+      }
+      .ticks-top::after,
+      .ticks-bottom::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background-image: repeating-linear-gradient(
+          to right,
+          transparent 0 199px,
+          var(--ink-faint) 199px 200px
+        );
+        opacity: 0.5;
+      }
+      .frame {
+        border-left: 1px solid var(--line);
+        border-right: 1px solid var(--line);
+        padding: 0;
+        position: relative;
+      }
+      .wrap {
+        max-width: var(--w);
+        margin: 0 auto;
+        padding-inline: 34px;
+      }
+
+      /* ————— top matter / registry line ————— */
+      .registry {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 22px;
+        justify-content: space-between;
+        align-items: baseline;
+        font-family: var(--sans);
+        font-size: 11.5px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        padding: 12px 34px;
+        border-bottom: 1px solid var(--line-soft);
+      }
+      .registry .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        color: var(--ink);
+        border: none;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+      }
+      .registry .brand .mark {
+        width: 17px;
+        height: 17px;
+        color: var(--sage-d);
+      }
+      .registry nav {
+        display: flex;
+        gap: 18px;
+        flex-wrap: wrap;
+      }
+      .registry nav a {
+        color: var(--ink-faint);
+        border: none;
+      }
+      .registry nav a:hover {
+        color: var(--chart-red);
+      }
+      @media (max-width: 620px) {
+        .registry nav a.hideable {
+          display: none;
+        }
+      }
+
+      /* ————— title cartouche ————— */
+      .cartouche-wrap {
+        padding: 46px 20px 30px;
+        text-align: center;
+        position: relative;
+      }
+      .compass-bg {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+        opacity: 0.5;
+      }
+      .compass-bg svg {
+        width: min(560px, 92%);
+        height: auto;
+      }
+      .cartouche {
+        position: relative;
+        display: inline-block;
+        max-width: 680px;
+        padding: 30px 42px 34px;
+        background: color-mix(in srgb, var(--paper) 86%, transparent);
+        border: 1.5px double var(--ink);
+        outline: 4px solid var(--paper);
+        outline-offset: -10px;
+        box-shadow: inset 0 0 0 1px var(--line);
+      }
+      .cartouche .kicker {
+        font-family: var(--sans);
+        font-size: 12px;
+        letter-spacing: 0.34em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+      }
+      .cartouche .chartno {
+        font-family: var(--sans);
+        font-size: 11px;
+        letter-spacing: 0.28em;
+        text-transform: uppercase;
+        color: var(--chart-red);
+        margin-bottom: 12px;
+      }
+      h1 {
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: clamp(30px, 5.2vw, 48px);
+        line-height: 1.12;
+        letter-spacing: 0.01em;
+        margin: 8px 0 6px;
+        font-variant: small-caps;
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        color: var(--chart-red);
+        transition: width 480ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+        will-change: transform, opacity;
+        border-bottom: 2px solid rgba(154, 75, 50, 0.4);
+      }
+      .rotator-measure {
+        position: absolute;
+        left: 0;
+        top: 0;
+        visibility: hidden;
+        pointer-events: none;
+        white-space: nowrap;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .rotator {
+          transition: none;
+        }
+      }
+      .cartouche .sub {
+        font-family: var(--sans);
+        font-size: 12.5px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        margin-top: 10px;
+      }
+      .rule-orn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        margin: 16px auto 4px;
+        color: var(--line);
+      }
+      .rule-orn::before,
+      .rule-orn::after {
+        content: "";
+        height: 1px;
+        width: 60px;
+        background: var(--ink-faint);
+      }
+      .rule-orn span {
+        color: var(--sage-d);
+        font-size: 13px;
+      }
+      .lede {
+        max-width: 40em;
+        margin: 22px auto 0;
+        text-align: left;
+        color: var(--ink-soft);
+        font-size: 17.5px;
+        line-height: 1.68;
+        position: relative;
+      }
+      .actions {
+        margin-top: 24px;
+        display: flex;
+        gap: 12px;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--sans);
+        font-size: 12.5px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        padding: 11px 20px;
+        border: 1.5px solid var(--ink);
+        color: var(--paper);
+        background: var(--ink);
+      }
+      .btn:hover {
+        background: var(--chart-red);
+        border-color: var(--chart-red);
+        color: var(--paper);
+      }
+      .btn.ghost {
+        background: transparent;
+        color: var(--ink);
+        border-color: var(--ink);
+      }
+      .btn.ghost:hover {
+        background: transparent;
+        color: var(--chart-red);
+        border-color: var(--chart-red);
+      }
+
+      /* ————— sections as chart plates ————— */
+      section {
+        padding: 42px 0;
+        border-top: 1px solid var(--line);
+        position: relative;
+      }
+      .plate-no {
+        font-family: var(--sans);
+        font-size: 11px;
+        letter-spacing: 0.28em;
+        text-transform: uppercase;
+        color: var(--chart-red);
+        margin-bottom: 5px;
+      }
+      h2 {
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: 27px;
+        letter-spacing: 0.01em;
+        font-variant: small-caps;
+        margin-bottom: 6px;
+      }
+      .lead {
+        color: var(--ink-soft);
+        max-width: 46em;
+        margin-bottom: 14px;
+      }
+      p {
+        max-width: 46em;
+        color: var(--ink-soft);
+      }
+      section p + p {
+        margin-top: 12px;
+      }
+      b {
+        color: var(--ink);
+        font-weight: 600;
+      }
+      code {
+        font-size: 0.84em;
+        background: rgba(154, 75, 50, 0.08);
+        border: 1px solid var(--line-soft);
+        padding: 1px 5px;
+        border-radius: 2px;
+        color: var(--ink);
+      }
+
+      /* soundings scatter — small depth numbers behind a plate */
+      .sounding {
+        font-family: var(--sans);
+        font-size: 10px;
+        fill: var(--line);
+        opacity: 0.75;
+      }
+
+      pre {
+        background: color-mix(in srgb, var(--paper-2) 70%, var(--paper));
+        border: 1px solid var(--line);
+        border-left: 3px solid var(--sage);
+        padding: 16px 18px;
+        overflow-x: auto;
+        margin: 16px 0;
+      }
+      pre code {
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.8;
+        background: none;
+        border: none;
+        padding: 0;
+        color: var(--ink);
+        white-space: pre;
+      }
+      pre code .c {
+        color: var(--ink-faint);
+        font-style: italic;
+      }
+      .note {
+        font-family: var(--sans);
+        font-size: 13.5px;
+        color: var(--ink-soft);
+        margin-top: 14px;
+        max-width: 46em;
+      }
+      details.manual {
+        margin-top: 14px;
+      }
+      details.manual summary {
+        font-family: var(--sans);
+        font-size: 12px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--chart-red);
+        cursor: pointer;
+      }
+
+      /* ————— key panel (legend) rows ————— */
+      .keypanel {
+        border: 1.5px solid var(--ink);
+        background: color-mix(in srgb, var(--paper-2) 55%, var(--paper));
+        margin-top: 20px;
+      }
+      .keypanel .kp-h {
+        font-family: var(--sans);
+        font-size: 11px;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        color: var(--ink);
+        padding: 10px 16px;
+        border-bottom: 1px solid var(--line);
+        background: color-mix(in srgb, var(--paper-2) 80%, transparent);
+      }
+      .kp-row {
+        display: grid;
+        grid-template-columns: 44px 1fr;
+        gap: 14px;
+        padding: 13px 16px;
+        border-bottom: 1px solid var(--line-soft);
+        align-items: start;
+      }
+      .kp-row:last-child {
+        border-bottom: none;
+      }
+      .kp-sym {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding-top: 2px;
+        color: var(--sage-d);
+      }
+      .kp-row .kp-t {
+        font-family: var(--sans);
+        font-weight: 600;
+        font-size: 14px;
+        color: var(--ink);
+        letter-spacing: 0.02em;
+      }
+      .kp-row .kp-t .abbr {
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--chart-red);
+        letter-spacing: 0.02em;
+        margin-left: 8px;
+        text-transform: none;
+      }
+      .kp-row .kp-d {
+        font-size: 14.5px;
+        color: var(--ink-soft);
+        margin-top: 2px;
+      }
+
+      /* ————— the general chart (architecture) ————— */
+      .plate-figure {
+        margin-top: 22px;
+        border: 1.5px solid var(--ink);
+        background: color-mix(in srgb, var(--water) 26%, var(--paper));
+        padding: 8px;
+      }
+      .plate-figure .scroll {
+        overflow-x: auto;
+      }
+      .plate-figure svg {
+        width: 100%;
+        min-width: 560px;
+        height: auto;
+      }
+      .figcap {
+        font-family: var(--sans);
+        font-size: 12px;
+        letter-spacing: 0.06em;
+        color: var(--ink-faint);
+        text-align: center;
+        margin-top: 10px;
+        font-style: normal;
+      }
+      .figcap b {
+        color: var(--chart-red);
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        font-size: 11px;
+      }
+
+      /* connectors as chart symbol legend */
+      .bom {
+        margin-top: 8px;
+      }
+
+      /* demo margin-note cards */
+      .soundings-grid {
+        display: grid;
+        gap: 14px;
+        margin-top: 16px;
+      }
+      .snd {
+        border: 1px solid var(--line);
+        border-left: 3px solid var(--chart-red);
+        background: color-mix(in srgb, var(--paper-2) 45%, var(--paper));
+        padding: 14px 16px;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 6px 20px;
+        align-items: baseline;
+      }
+      .snd .q {
+        font-family: var(--serif);
+        font-style: italic;
+        font-size: 16.5px;
+        color: var(--ink);
+        grid-column: 1 / -1;
+      }
+      .snd .depth {
+        font-family: var(--sans);
+        font-weight: 700;
+        font-size: 26px;
+        letter-spacing: 0.01em;
+        color: var(--sage-d);
+        white-space: nowrap;
+      }
+      .snd .depth small {
+        display: block;
+        font-family: var(--sans);
+        font-weight: 600;
+        font-size: 9.5px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        text-align: right;
+        margin-top: 2px;
+      }
+      .snd .gloss {
+        font-family: var(--sans);
+        font-size: 13px;
+        line-height: 1.5;
+        color: var(--ink-soft);
+      }
+      .snd.wide {
+        display: block;
+      }
+
+      /* tide/depth plot for the revenue chart */
+      .tideplot {
+        border: 1px solid var(--line);
+        background: color-mix(in srgb, var(--water) 22%, var(--paper));
+        padding: 14px 16px;
+        margin-top: 6px;
+        overflow-x: auto;
+      }
+      .tideplot .cl {
+        font-family: var(--sans);
+        font-size: 12px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        margin-bottom: 10px;
+      }
+      .tideplot svg {
+        width: 100%;
+        min-width: 460px;
+        height: auto;
+      }
+
+      /* steps (demo) */
+      .step {
+        margin-top: 26px;
+      }
+      .step-h {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: 20px;
+        font-variant: small-caps;
+        letter-spacing: 0.02em;
+        margin-bottom: 8px;
+      }
+      .step-n {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 27px;
+        height: 27px;
+        border: 1.5px solid var(--ink);
+        border-radius: 50%;
+        font-family: var(--sans);
+        font-size: 13px;
+        font-weight: 700;
+        color: var(--ink);
+        flex: none;
+      }
+
+      /* why — logbook entries */
+      .why h3 {
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: 18px;
+        font-variant: small-caps;
+        letter-spacing: 0.02em;
+        margin: 22px 0 3px;
+        color: var(--ink);
+      }
+      .why h3::before {
+        content: "❧ ";
+        color: var(--sage-d);
+      }
+      ul.uses {
+        list-style: none;
+        margin-top: 12px;
+        display: grid;
+        gap: 10px;
+      }
+      ul.uses li {
+        color: var(--ink-soft);
+        font-size: 15.5px;
+        line-height: 1.55;
+        padding-left: 22px;
+        position: relative;
+        max-width: 46em;
+      }
+      ul.uses li::before {
+        content: "◈";
+        position: absolute;
+        left: 2px;
+        color: var(--sage);
+        font-size: 11px;
+        top: 3px;
+      }
+
+      /* ————— title-block footer ————— */
+      footer {
+        border-top: 2px solid var(--ink);
+        margin-top: 8px;
+      }
+      .titleblock {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+      }
+      .tb {
+        border-right: 1px solid var(--line);
+        border-top: 1px solid var(--line);
+        padding: 12px 14px;
+        font-family: var(--sans);
+      }
+      .tb:last-child {
+        border-right: none;
+      }
+      .tb .lab {
+        font-size: 9.5px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        margin-bottom: 5px;
+      }
+      .tb .val {
+        font-size: 13px;
+        color: var(--ink);
+      }
+      .tb .val a {
+        display: block;
+        color: var(--chart-red);
+        border: none;
+      }
+      .tb.brandcell {
+        grid-column: 1 / -1;
+        border-right: none;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+      .tb.brandcell .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--serif);
+        font-variant: small-caps;
+        font-size: 20px;
+        letter-spacing: 0.04em;
+        color: var(--ink);
+        border: none;
+      }
+      .tb.brandcell .brand .mark {
+        width: 22px;
+        height: 22px;
+        color: var(--sage-d);
+      }
+      .tb.brandcell .jp {
+        font-family: var(--serif);
+        font-size: 14px;
+        color: var(--ink-soft);
+        font-style: italic;
+      }
+      @media (max-width: 620px) {
+        .titleblock {
+          grid-template-columns: repeat(2, 1fr);
+        }
+        .tb:nth-child(odd) {
+          border-right: 1px solid var(--line);
+        }
+        .wrap {
+          padding-inline: 22px;
+        }
+        .registry {
+          padding-inline: 22px;
+        }
+        .cartouche {
+          padding: 24px 22px 26px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path
+          d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z"
+          fill="currentColor"
+        />
+      </symbol>
+    </svg>
+
+    <div class="sheet" id="top">
+      <div class="ticks-top" aria-hidden="true"></div>
+
+      <div class="registry">
+        <a class="brand" href="#top">
+          <svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+          Setoku Hydrographic Office
+        </a>
+        <nav>
+          <a class="hideable" href="#how">Passage</a>
+          <a class="hideable" href="#apps">Apps</a>
+          <a class="hideable" href="#connectors">Soundings</a>
+          <a
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >GitHub ↗</a
+          >
+        </nav>
+      </div>
+
+      <div class="frame">
+        <!-- ————— TITLE CARTOUCHE ————— -->
+        <div class="cartouche-wrap">
+          <div class="compass-bg" aria-hidden="true">
+            <!-- 32-point compass rose + rhumb lines -->
+            <svg viewBox="0 0 400 400">
+              <g
+                stroke="#b9a778"
+                stroke-width="0.7"
+                fill="none"
+                opacity="0.9"
+              >
+                <circle cx="200" cy="200" r="180" />
+                <circle cx="200" cy="200" r="150" stroke-dasharray="2 4" />
+                <circle cx="200" cy="200" r="118" />
+                <g id="rhumbs">
+                  <!-- 16 rhumb lines from centre -->
+                  <line x1="200" y1="20" x2="200" y2="380" />
+                  <line x1="20" y1="200" x2="380" y2="200" />
+                  <line x1="73" y1="73" x2="327" y2="327" />
+                  <line x1="327" y1="73" x2="73" y2="327" />
+                  <line x1="200" y1="20" x2="118" y2="200" />
+                  <line x1="200" y1="20" x2="282" y2="200" />
+                  <line x1="380" y1="200" x2="200" y2="118" />
+                  <line x1="380" y1="200" x2="200" y2="282" />
+                  <line x1="200" y1="380" x2="282" y2="200" />
+                  <line x1="200" y1="380" x2="118" y2="200" />
+                  <line x1="20" y1="200" x2="200" y2="282" />
+                  <line x1="20" y1="200" x2="200" y2="118" />
+                </g>
+              </g>
+              <!-- compass star -->
+              <g>
+                <polygon
+                  points="200,40 214,200 200,200"
+                  fill="#4a3f2c"
+                  opacity="0.55"
+                />
+                <polygon
+                  points="200,40 186,200 200,200"
+                  fill="#9a4b32"
+                  opacity="0.5"
+                />
+                <polygon
+                  points="360,200 200,214 200,200"
+                  fill="#4a3f2c"
+                  opacity="0.4"
+                />
+                <polygon
+                  points="360,200 200,186 200,200"
+                  fill="#6b5d43"
+                  opacity="0.4"
+                />
+                <polygon
+                  points="200,360 214,200 200,200"
+                  fill="#6b5d43"
+                  opacity="0.4"
+                />
+                <polygon
+                  points="200,360 186,200 200,200"
+                  fill="#4a3f2c"
+                  opacity="0.35"
+                />
+                <polygon
+                  points="40,200 200,214 200,200"
+                  fill="#6b5d43"
+                  opacity="0.4"
+                />
+                <polygon
+                  points="40,200 200,186 200,200"
+                  fill="#4a3f2c"
+                  opacity="0.4"
+                />
+                <text
+                  x="200"
+                  y="32"
+                  text-anchor="middle"
+                  font-family="Optima, 'Gill Sans', sans-serif"
+                  font-size="16"
+                  fill="#9a4b32"
+                >
+                  N
+                </text>
+              </g>
+            </svg>
+          </div>
+
+          <div class="cartouche">
+            <div class="kicker">Open source · MCP Server · Apache-2.0</div>
+            <div class="chartno">Chart No. 1 — Survey of the Data Lake</div>
+            <h1
+              >Make any AI fluent<br />in your <span
+                class="rotator"
+                data-words="company,family,personal"
+                ><span class="rotator-word">company</span
+                ><span class="rotator-measure" aria-hidden="true"></span
+              ></span> data.</h1
+            >
+            <div class="rule-orn"><span>⚓</span></div>
+            <div class="sub">A self-hosted knowledge server, sounded &amp; charted</div>
+          </div>
+
+          <p class="lede">
+            Setoku is a small self-hosted MCP knowledge server + Claude Code
+            skills for hooking up your data. It does two things: it gives your
+            AI a read-only way to query your data, and it remembers what that
+            data means (the metric definitions, the gotchas), getting better
+            the more you use it. The MCP works with whatever AI you already
+            have, and no model runs on the server, so no added inference cost.
+          </p>
+          <div class="actions">
+            <a
+              class="btn"
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >View on GitHub ↗</a
+            >
+            <a class="btn ghost" href="#demo">Try the demo</a>
+          </div>
+        </div>
+
+        <div class="wrap">
+          <!-- ————— QUICKSTART ————— -->
+          <section id="quickstart">
+            <div class="plate-no">Sailing directions I</div>
+            <h2>Quickstart</h2>
+            <p class="lead">
+              Setoku installs as a Claude Code plugin. Add the plugin, then run
+              onboarding from your main project directory, the codebase you want
+              Setoku to learn from:
+            </p>
+            <pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+            <p>
+              Onboarding stands up the server, auths your Claude, wires your
+              database read-only, and generates the first knowledge from your
+              code. You stay in the loop for anything that touches your data. To
+              start onboarding, run <code>/setoku:onboard</code>.
+            </p>
+            <p style="margin-top: 12px">
+              You’ll need somewhere to host it. Something like OVH’s
+              <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener"
+                >VPS-2</a
+              >
+              is plenty.
+            </p>
+            <details class="manual">
+              <summary>Or stand up the server by hand</summary>
+              <pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+              <p class="note">
+                Installs Docker, generates secrets, gets an HTTPS certificate,
+                and prints the connect command. Then add the plugin and run
+                /setoku:onboard from your project; it’ll detect the box you just
+                made.
+              </p>
+            </details>
+          </section>
+
+          <!-- ————— HOW IT WORKS ————— -->
+          <section id="how">
+            <div class="plate-no">Sailing directions II</div>
+            <h2>How it works</h2>
+            <p class="lead">
+              Setoku gives the AI two kinds of MCP tools, and one rule: look up
+              what the data means before you touch it.
+            </p>
+
+            <div class="keypanel">
+              <div class="kp-h">Aids to navigation · what each buoy marks</div>
+              <div class="kp-row">
+                <div class="kp-sym" aria-hidden="true">
+                  <svg width="26" height="26" viewBox="0 0 26 26">
+                    <circle
+                      cx="13"
+                      cy="13"
+                      r="8"
+                      fill="none"
+                      stroke="#3f5a44"
+                      stroke-width="1.6"
+                    />
+                    <circle cx="13" cy="13" r="2.4" fill="#3f5a44" />
+                  </svg>
+                </div>
+                <div>
+                  <div class="kp-t">
+                    Context tools<span class="abbr">find_context · get_metric</span>
+                  </div>
+                  <div class="kp-d">
+                    The AI reads what your data means first: canonical metric
+                    definitions, entity docs, and the gotchas that make a naive
+                    query wrong.
+                  </div>
+                </div>
+              </div>
+              <div class="kp-row">
+                <div class="kp-sym" aria-hidden="true">
+                  <svg width="26" height="26" viewBox="0 0 26 26">
+                    <path
+                      d="M13 4 L21 20 L5 20 Z"
+                      fill="none"
+                      stroke="#3f5a44"
+                      stroke-width="1.6"
+                    />
+                    <line
+                      x1="13"
+                      y1="10"
+                      x2="13"
+                      y2="20"
+                      stroke="#3f5a44"
+                      stroke-width="1.2"
+                    />
+                  </svg>
+                </div>
+                <div>
+                  <div class="kp-t">
+                    Read-only query<span class="abbr"
+                      >get_schema · run_query</span
+                    >
+                  </div>
+                  <div class="kp-d">
+                    Read-only, with a row cap, a statement timeout, a table
+                    allow-list, and an append-only audit log. Enforced by the
+                    database role, not by parsing SQL.
+                  </div>
+                </div>
+              </div>
+              <div class="kp-row">
+                <div class="kp-sym" aria-hidden="true">
+                  <svg width="26" height="26" viewBox="0 0 26 26">
+                    <rect
+                      x="5"
+                      y="7"
+                      width="16"
+                      height="12"
+                      fill="none"
+                      stroke="#9a4b32"
+                      stroke-width="1.6"
+                    />
+                    <path
+                      d="M5 7 L13 14 L21 7"
+                      fill="none"
+                      stroke="#9a4b32"
+                      stroke-width="1.3"
+                    />
+                  </svg>
+                </div>
+                <div>
+                  <div class="kp-t">
+                    Human-approved<span class="abbr">report_correction</span>
+                  </div>
+                  <div class="kp-d">
+                    The AI can only propose changes to what Setoku knows. A
+                    person accepts them on the admin page, outside the agent
+                    loop, so an injected session can’t rewrite the brain.
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <p class="note"><b>You set it up with Claude Code skills:</b></p>
+            <ul class="uses">
+              <li>
+                <code>/setoku:onboard</code> sets Setoku up in a repo for the
+                first time.
+              </li>
+              <li>
+                <code>/setoku:connect</code> adds a data source or custom
+                integration.
+              </li>
+              <li>
+                <code>/setoku:generate</code> writes business context from your
+                code.
+              </li>
+              <li>
+                <code>/setoku:curate</code> reviews and approves pending
+                knowledge.
+              </li>
+            </ul>
+            <p class="note">
+              Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex,
+              or whatever you run. Just ask in plain language, and the tools do
+              the rest.
+            </p>
+          </section>
+
+          <!-- ————— APPS ————— -->
+          <section id="apps">
+            <div class="plate-no">Sailing directions III</div>
+            <h2>Apps: save and share the tools Claude builds you</h2>
+            <p class="lead">
+              Ask Claude to build a dashboard on your data. Then publish it to a
+              link as a Setoku App — the data stays live, and your whole team
+              can view it. Nothing to deploy, no frontend to maintain.
+            </p>
+            <div class="keypanel">
+              <div class="kp-h">Chartwork · four properties of an App</div>
+              <div class="kp-row">
+                <div class="kp-sym mono" style="color: var(--chart-red)">✎</div>
+                <div>
+                  <div class="kp-t">
+                    Built by asking<span class="abbr">publish_app</span>
+                  </div>
+                  <div class="kp-d">
+                    Describe it in plain language; the agent writes the app and
+                    publishes it to a URL. Edit it the same way, just ask for
+                    the change.
+                  </div>
+                </div>
+              </div>
+              <div class="kp-row">
+                <div class="kp-sym mono" style="color: var(--sage-d)">≈</div>
+                <div>
+                  <div class="kp-t">
+                    Backed by live data<span class="abbr">read-only</span>
+                  </div>
+                  <div class="kp-d">
+                    Apps read through the same governed path: row caps, audit, a
+                    SELECT-only database role. They never get write access to
+                    your sources.
+                  </div>
+                </div>
+              </div>
+              <div class="kp-row">
+                <div class="kp-sym mono" style="color: var(--sage-d)">⚓</div>
+                <div>
+                  <div class="kp-t">
+                    App-private state<span class="abbr">no writes to your data</span>
+                  </div>
+                  <div class="kp-d">
+                    Each app keeps its own state (todos, votes, annotations) in
+                    a sandbox that belongs to the app, not your database. Worst
+                    case, an app messes up its own notes.
+                  </div>
+                </div>
+              </div>
+              <div class="kp-row">
+                <div class="kp-sym mono" style="color: var(--chart-red)">⚑</div>
+                <div>
+                  <div class="kp-t">
+                    Share by link<span class="abbr">team or public</span>
+                  </div>
+                  <div class="kp-d">
+                    A team link is login-gated; an admin can flip one public for
+                    a credential-free URL. The page runs in a locked-down
+                    sandbox with no network, so a published app can’t phone
+                    home.
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <!-- ————— ARCHITECTURE ————— -->
+          <section id="architecture">
+            <div class="plate-no">General chart</div>
+            <h2>Architecture</h2>
+            <p class="lead">
+              You can host this on whatever infra you like. We put it all on one
+              small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+              helps you add custom integrations. Only the proxy is public, so
+              your databases aren’t exposed. Queries are read-only, and
+              knowledge changes pass through a person.
+            </p>
+
+            <div class="plate-figure">
+              <div class="scroll">
+                <svg
+                  viewBox="0 0 680 560"
+                  role="img"
+                  aria-label="Setoku architecture charted as a harbour survey: you and your AI approach on the MCP course line into the Setoku gateway (the harbour), which holds a ClickHouse lake, a knowledge store, and a person who approves. Below, your Postgres database is read-only and mirrored into the lake, and your sources are ingested."
+                >
+                  <defs>
+                    <marker
+                      id="ah14"
+                      markerWidth="9"
+                      markerHeight="9"
+                      refX="6"
+                      refY="3"
+                      orient="auto-start-reverse"
+                    >
+                      <path d="M0 0 L6 3 L0 6 Z" fill="#9a4b32" />
+                    </marker>
+                  </defs>
+
+                  <!-- water field with contours -->
+                  <rect x="0" y="0" width="680" height="560" fill="#e7ecdf" />
+                  <g stroke="#b7c9c6" stroke-width="1" fill="none" opacity="0.9">
+                    <path d="M-10 120 Q 200 90 380 130 T 700 120" />
+                    <path d="M-10 175 Q 220 150 400 190 T 700 175" />
+                    <path d="M-10 250 Q 180 225 360 260 T 700 245" />
+                    <path d="M-10 330 Q 240 305 420 345 T 700 330" />
+                    <path d="M-10 420 Q 200 400 380 440 T 700 425" />
+                  </g>
+                  <!-- scattered soundings -->
+                  <g class="sounding">
+                    <text x="70" y="140">7</text>
+                    <text x="150" y="230">12</text>
+                    <text x="590" y="150">9</text>
+                    <text x="610" y="300">15</text>
+                    <text x="60" y="470">4</text>
+                    <text x="470" y="500">6</text>
+                    <text x="330" y="270">18</text>
+                    <text x="560" y="470">11</text>
+                    <text x="120" y="380">8</text>
+                  </g>
+
+                  <!-- small compass mark -->
+                  <g transform="translate(626 60)" opacity="0.8">
+                    <circle
+                      r="20"
+                      fill="none"
+                      stroke="#b9a778"
+                      stroke-width="1"
+                    />
+                    <polygon points="0,-18 4,0 0,4 -4,0" fill="#9a4b32" />
+                    <polygon points="0,18 4,0 0,-4 -4,0" fill="#6b5d43" />
+                    <text
+                      x="0"
+                      y="-24"
+                      text-anchor="middle"
+                      font-family="Optima, sans-serif"
+                      font-size="9"
+                      fill="#9a4b32"
+                      >N</text
+                    >
+                  </g>
+
+                  <!-- YOU + YOUR AI : the approaching vessel -->
+                  <g>
+                    <rect
+                      x="250"
+                      y="18"
+                      width="180"
+                      height="46"
+                      rx="4"
+                      fill="#f3ead2"
+                      stroke="#2c2417"
+                      stroke-width="1.4"
+                    />
+                    <text
+                      x="340"
+                      y="40"
+                      text-anchor="middle"
+                      font-family="Optima, sans-serif"
+                      font-size="13"
+                      fill="#2c2417"
+                      >You + your AI</text
+                    >
+                    <text
+                      x="340"
+                      y="55"
+                      text-anchor="middle"
+                      font-family="ui-monospace, monospace"
+                      font-size="9.5"
+                      fill="#6b5d43"
+                      >the vessel, standing in</text
+                    >
+                  </g>
+                  <!-- MCP course line -->
+                  <path
+                    d="M340 64 L340 150"
+                    stroke="#9a4b32"
+                    stroke-width="1.6"
+                    stroke-dasharray="7 5"
+                    fill="none"
+                    marker-start="url(#ah14)"
+                    marker-end="url(#ah14)"
+                  />
+                  <text
+                    x="350"
+                    y="100"
+                    font-family="ui-monospace, monospace"
+                    font-size="10.5"
+                    fill="#9a4b32"
+                    >MCP · course 180°</text
+                  >
+
+                  <!-- THE HARBOUR (your box) -->
+                  <rect
+                    x="58"
+                    y="120"
+                    width="564"
+                    height="300"
+                    rx="8"
+                    fill="none"
+                    stroke="#4a3f2c"
+                    stroke-width="1.2"
+                    stroke-dasharray="3 5"
+                  />
+                  <text
+                    x="74"
+                    y="140"
+                    font-family="ui-monospace, monospace"
+                    font-size="10"
+                    fill="#6b5d43"
+                    >your box · the harbour</text
+                  >
+
+                  <!-- gateway = harbour master -->
+                  <g>
+                    <rect
+                      x="250"
+                      y="152"
+                      width="180"
+                      height="60"
+                      rx="4"
+                      fill="#f3ead2"
+                      stroke="#2c2417"
+                      stroke-width="1.6"
+                    />
+                    <text
+                      x="340"
+                      y="178"
+                      text-anchor="middle"
+                      font-family="Optima, sans-serif"
+                      font-size="13.5"
+                      fill="#2c2417"
+                      >Setoku gateway</text
+                    >
+                    <text
+                      x="340"
+                      y="196"
+                      text-anchor="middle"
+                      font-family="ui-monospace, monospace"
+                      font-size="9.5"
+                      fill="#6b5d43"
+                      >the harbour entrance · context · query</text
+                    >
+                  </g>
+
+                  <!-- a person -->
+                  <g>
+                    <rect
+                      x="454"
+                      y="156"
+                      width="150"
+                      height="50"
+                      rx="4"
+                      fill="#f3ead2"
+                      stroke="#2c2417"
+                      stroke-width="1.4"
+                    />
+                    <text
+                      x="529"
+                      y="180"
+                      text-anchor="middle"
+                      font-family="Optima, sans-serif"
+                      font-size="13"
+                      fill="#2c2417"
+                      >a person</text
+                    >
+                    <text
+                      x="529"
+                      y="195"
+                      text-anchor="middle"
+                      font-family="ui-monospace, monospace"
+                      font-size="9"
+                      fill="#6b5d43"
+                      >the pilot</text
+                    >
+                  </g>
+
+                  <!-- lake -->
+                  <g>
+                    <rect
+                      x="92"
+                      y="322"
+                      width="184"
+                      height="70"
+                      rx="4"
+                      fill="#cfdcd8"
+                      stroke="#2c2417"
+                      stroke-width="1.4"
+                    />
+                    <text
+                      x="184"
+                      y="350"
+                      text-anchor="middle"
+                      font-family="Optima, sans-serif"
+                      font-size="13"
+                      fill="#2c2417"
+                      >Lake (ClickHouse)</text
+                    >
+                    <text
+                      x="184"
+                      y="367"
+                      text-anchor="middle"
+                      font-family="ui-monospace, monospace"
+                      font-size="9"
+                      fill="#4a3f2c"
+                      >the deep water</text
+                    >
+                    <text
+                      x="184"
+                      y="381"
+                      text-anchor="middle"
+                      font-family="ui-monospace, monospace"
+                      font-size="9"
+                      fill="#4a3f2c"
+                      >logs · events · DB mirror</text
+                    >
+                  </g>
+
+                  <!-- knowledge store -->
+                  <g>
+                    <rect
+                      x="404"
+                      y="322"
+                      width="194"
+                      height="70"
+                      rx="4"
+                      fill="#f3ead2"
+                      stroke="#2c2417"
+                      stroke-width="1.4"
+                    />
+                    <text
+                      x="501"
+                      y="352"
+                      text-anchor="middle"
+                      font-family="Optima, sans-serif"
+                      font-size="13"
+                      fill="#2c2417"
+                      >Knowledge store</text
+                    >
+                    <text
+                      x="501"
+                      y="369"
+                      text-anchor="middle"
+                      font-family="ui-monospace, monospace"
+                      font-size="9"
+                      fill="#4a3f2c"
+                      >the chart itself</text
+                    >
+                  </g>
+
+                  <!-- external -->
+                  <g>
+                    <rect
+                      x="92"
+                      y="452"
+                      width="184"
+                      height="66"
+                      rx="4"
+                      fill="#f3ead2"
+                      stroke="#2c2417"
+                      stroke-width="1.4"
+                    />
+                    <text
+                      x="184"
+                      y="480"
+                      text-anchor="middle"
+                      font-family="Optima, sans-serif"
+                      font-size="13"
+                      fill="#2c2417"
+                      >Your sources</text
+                    >
+                    <text
+                      x="184"
+                      y="497"
+                      text-anchor="middle"
+                      font-family="ui-monospace, monospace"
+                      font-size="9"
+                      fill="#4a3f2c"
+                      >GitHub · Vercel · Slack…</text
+                    >
+                  </g>
+                  <g>
+                    <rect
+                      x="300"
+                      y="452"
+                      width="184"
+                      height="66"
+                      rx="4"
+                      fill="#f3ead2"
+                      stroke="#2c2417"
+                      stroke-width="1.4"
+                    />
+                    <text
+                      x="392"
+                      y="480"
+                      text-anchor="middle"
+                      font-family="Optima, sans-serif"
+                      font-size="13"
+                      fill="#2c2417"
+                      >Your database</text
+                    >
+                    <text
+                      x="392"
+                      y="497"
+                      text-anchor="middle"
+                      font-family="ui-monospace, monospace"
+                      font-size="9"
+                      fill="#4a3f2c"
+                      >Postgres · read-only</text
+                    >
+                  </g>
+
+                  <!-- flows as charted channels -->
+                  <path
+                    d="M414 212 L505 322"
+                    stroke="#6b5d43"
+                    stroke-width="1.3"
+                    fill="none"
+                    marker-start="url(#ah14)"
+                    marker-end="url(#ah14)"
+                  />
+                  <text
+                    x="470"
+                    y="272"
+                    font-family="ui-monospace, monospace"
+                    font-size="9.5"
+                    fill="#6b5d43"
+                    >reads · proposes</text
+                  >
+                  <path
+                    d="M529 206 L512 322"
+                    stroke="#9a4b32"
+                    stroke-width="1.3"
+                    fill="none"
+                    marker-end="url(#ah14)"
+                  />
+                  <text
+                    x="536"
+                    y="270"
+                    font-family="ui-monospace, monospace"
+                    font-size="9.5"
+                    fill="#9a4b32"
+                    >approves</text
+                  >
+                  <path
+                    d="M212 322 L300 214"
+                    stroke="#6b5d43"
+                    stroke-width="1.3"
+                    fill="none"
+                    marker-end="url(#ah14)"
+                  />
+                  <path
+                    d="M184 452 L184 392"
+                    stroke="#3f5a44"
+                    stroke-width="1.3"
+                    fill="none"
+                    marker-end="url(#ah14)"
+                  />
+                  <text
+                    x="192"
+                    y="428"
+                    font-family="ui-monospace, monospace"
+                    font-size="9.5"
+                    fill="#3f5a44"
+                    >ingest</text
+                  >
+                  <path
+                    d="M392 452 L368 214"
+                    stroke="#3f5a44"
+                    stroke-width="1.3"
+                    stroke-dasharray="5 4"
+                    fill="none"
+                    marker-end="url(#ah14)"
+                  />
+                  <text
+                    x="300"
+                    y="300"
+                    font-family="ui-monospace, monospace"
+                    font-size="9.5"
+                    fill="#3f5a44"
+                    >read-only</text
+                  >
+                </svg>
+              </div>
+            </div>
+            <div class="figcap">
+              <b>Chart 1.</b> Setoku architecture, surveyed as a harbour
+              approach. Vessel stands in on the MCP course line; the gateway is
+              the entrance, the lake the deep water, the pilot approves what
+              enters the chart.
+            </div>
+          </section>
+
+          <!-- ————— CONNECTORS ————— -->
+          <section id="connectors">
+            <div class="plate-no">Chart symbols</div>
+            <h2>Connectors</h2>
+            <p class="lead">
+              Point Setoku at the data you already have. Every source lands in a
+              local
+              <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+                >ClickHouse</a
+              >
+              data lake, on purpose: agents write arbitrary queries (scans,
+              GROUP&nbsp;BYs, whole-table aggregations), and a columnar engine
+              answers those in about a second, so the apps and dashboards they
+              build stay quick. Your app database connects read-only and is
+              mirrored in on a cron; the rest is ingested as it happens.
+            </p>
+            <div class="keypanel bom">
+              <div class="kp-h">
+                ⚓ ClickHouse · one anchorage, every source charted
+              </div>
+              <div class="kp-row">
+                <div class="kp-sym mono" style="color: var(--sage-d)">◉</div>
+                <div>
+                  <div class="kp-t">PostgreSQL</div>
+                  <div class="kp-d">app database, mirrored read-only</div>
+                </div>
+              </div>
+              <div class="kp-row">
+                <div class="kp-sym mono" style="color: var(--sage-d)">◐</div>
+                <div>
+                  <div class="kp-t">GitHub</div>
+                  <div class="kp-d">issues, PRs &amp; commits</div>
+                </div>
+              </div>
+              <div class="kp-row">
+                <div class="kp-sym mono" style="color: var(--sage-d)">△</div>
+                <div>
+                  <div class="kp-t">Vercel</div>
+                  <div class="kp-d">deploys &amp; logs</div>
+                </div>
+              </div>
+              <div class="kp-row">
+                <div class="kp-sym mono" style="color: var(--sage-d)">▽</div>
+                <div>
+                  <div class="kp-t">Render</div>
+                  <div class="kp-d">deploys &amp; logs</div>
+                </div>
+              </div>
+              <div class="kp-row">
+                <div class="kp-sym mono" style="color: var(--sage-d)">⌘</div>
+                <div>
+                  <div class="kp-t">Slack</div>
+                  <div class="kp-d">messages</div>
+                </div>
+              </div>
+              <div class="kp-row">
+                <div class="kp-sym mono" style="color: var(--sage-d)">$</div>
+                <div>
+                  <div class="kp-t">Mercury</div>
+                  <div class="kp-d">banking &amp; finance</div>
+                </div>
+              </div>
+            </div>
+            <p class="note">
+              No connector for your source yet? The included setup skills give
+              your coding agent the patterns to wire one up itself. See
+              <a
+                href="https://github.com/Hedgy-Labs/setoku"
+                target="_blank"
+                rel="noopener"
+                >the repo</a
+              >, or open an issue.
+            </p>
+          </section>
+
+          <!-- ————— DEMO ————— -->
+          <section id="demo">
+            <div class="plate-no">Recorded soundings</div>
+            <h2>Try it on real-ish data</h2>
+            <p class="lead">
+              There’s a live demo wired to a fictional pro sports club, the
+              Bonita Bulldogs (ticketing, sponsorship, concessions, payroll,
+              broadcast rights).
+            </p>
+
+            <div class="step">
+              <h3 class="step-h">
+                <span class="step-n">1</span>Connect to the demo MCP server
+              </h3>
+              <p class="note" style="margin-top: 0">
+                In Claude (or any MCP client) open Settings → Connectors → Add
+                custom connector, and paste this URL. The token rides in the
+                URL, so there’s no separate key to enter.
+              </p>
+              <pre><code>https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</code></pre>
+            </div>
+
+            <div class="step">
+              <h3 class="step-h"><span class="step-n">2</span>Ask a question</h3>
+              <p class="note" style="margin-top: 0">
+                Each answer below is a sounding: the depth the survey actually
+                found, with the reduction noted alongside.
+              </p>
+              <div class="soundings-grid">
+                <div class="snd">
+                  <div class="q">“How many unique fans do we have?”</div>
+                  <div class="depth">71,204<small>fathoms sounded</small></div>
+                  <div class="gloss">
+                    deduped by normalized email, internal accounts excluded. Not
+                    the raw 92,118.
+                  </div>
+                </div>
+                <div class="snd">
+                  <div class="q">
+                    “What’s our total annual revenue, and how much is media
+                    rights?”
+                  </div>
+                  <div class="depth">$192M<small>total depth</small></div>
+                  <div class="gloss">
+                    five systems reconciled to the same units. Media rights is
+                    the biggest line, ~$90M.
+                  </div>
+                </div>
+                <div class="snd">
+                  <div class="q">“What was ticket revenue this season?”</div>
+                  <div class="depth">$46.8M<small>reduced</small></div>
+                  <div class="gloss">
+                    cents reconciled to dollars; refunds, exchanges, and comps
+                    excluded.
+                  </div>
+                </div>
+                <div class="snd">
+                  <div class="q">“What’s our total merchandise revenue?”</div>
+                  <div class="depth" style="color: var(--chart-red)">
+                    ⚠<small>unsurveyed</small>
+                  </div>
+                  <div class="gloss">
+                    <b>It flags it.</b> Most merch is sold via Fanatics, not in
+                    this data, so it says so instead of returning a wrong total.
+                  </div>
+                </div>
+              </div>
+
+              <div class="snd wide" style="margin-top: 14px">
+                <div class="q" style="margin-bottom: 10px">“Chart revenue by line.”</div>
+                <div class="tideplot">
+                  <div class="cl">
+                    Annual revenue by line · ~$192M total · depths in $M
+                  </div>
+                  <svg
+                    viewBox="0 0 640 232"
+                    role="img"
+                    aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M."
+                  >
+                    <!-- baseline waterline + depth ticks -->
+                    <g stroke="#b9a778" stroke-width="1">
+                      <line x1="148" y1="6" x2="148" y2="214" />
+                      <line
+                        x1="148"
+                        y1="214"
+                        x2="600"
+                        y2="214"
+                        stroke="#6b5d43"
+                      />
+                    </g>
+                    <g
+                      stroke="#cdbf99"
+                      stroke-width="1"
+                      stroke-dasharray="2 4"
+                    >
+                      <line x1="248" y1="6" x2="248" y2="214" />
+                      <line x1="348" y1="6" x2="348" y2="214" />
+                      <line x1="448" y1="6" x2="448" y2="214" />
+                      <line x1="548" y1="6" x2="548" y2="214" />
+                    </g>
+                    <g fill="#5f7d63">
+                      <rect x="148" y="14" width="400" height="16" />
+                      <rect x="148" y="48" width="209" height="16" />
+                      <rect x="148" y="82" width="124" height="16" />
+                      <rect x="148" y="116" width="62" height="16" />
+                      <rect x="148" y="150" width="36" height="16" />
+                      <rect x="148" y="184" width="22" height="16" />
+                    </g>
+                    <g
+                      font-family="Optima, 'Gill Sans', sans-serif"
+                      font-size="12.5"
+                      fill="#4a3f2c"
+                    >
+                      <text x="8" y="26">Media rights</text>
+                      <text x="8" y="60">Ticketing</text>
+                      <text x="8" y="94">Sponsorship</text>
+                      <text x="8" y="128">Concessions</text>
+                      <text x="8" y="162">Merch</text>
+                      <text x="8" y="196">Other</text>
+                    </g>
+                    <g
+                      font-family="ui-monospace, monospace"
+                      font-size="12"
+                      fill="#2c2417"
+                    >
+                      <text x="555" y="26">$90M</text>
+                      <text x="364" y="60">$47M</text>
+                      <text x="279" y="94">$28M</text>
+                      <text x="217" y="128">$14M</text>
+                      <text x="191" y="162">$8M</text>
+                      <text x="177" y="196">$5M</text>
+                    </g>
+                    <g
+                      font-family="ui-monospace, monospace"
+                      font-size="9.5"
+                      fill="#6b5d43"
+                    >
+                      <text x="240" y="228">25</text>
+                      <text x="340" y="228">50</text>
+                      <text x="440" y="228">75</text>
+                      <text x="540" y="228">100</text>
+                    </g>
+                  </svg>
+                </div>
+              </div>
+            </div>
+
+            <div class="step">
+              <h3 class="step-h">
+                <span class="step-n">3</span>Try an app
+              </h3>
+              <p class="note" style="margin-top: 0">
+                Ask Claude to build a dashboard on the same data, then publish
+                it to a link. Two live examples, running on the demo data right
+                now:
+              </p>
+              <ul class="uses">
+                <li>
+                  <a
+                    href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+                    target="_blank"
+                    rel="noopener"
+                    >Sponsorship pricing table ↗</a
+                  >
+                  — inventory and rates for sponsorship placements.
+                </li>
+                <li>
+                  <a
+                    href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+                    target="_blank"
+                    rel="noopener"
+                    >Fan lifetime value ↗</a
+                  >
+                  — segment fans by spend across tickets, merch, and
+                  concessions.
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          <!-- ————— WHY ————— -->
+          <section id="why" class="why">
+            <div class="plate-no">Log of the survey</div>
+            <h2>Why we built it</h2>
+            <h3>We’re curious.</h3>
+            <p>
+              There are plenty of AI memory stores, and plenty of data
+              gateways. Stapling the two together, and nudging the agent to
+              gather knowledge about the data as it goes, seemed useful and fun
+              to tinker with.
+            </p>
+            <h3>We’re cheap.</h3>
+            <p>
+              We wanted something that runs on one small box, works on a Pro/Max
+              subscription or a cheap model with no added inference cost, mostly
+              sets itself up (no field engineer to pay for), stays portable
+              between providers, and is open source.
+            </p>
+            <h3>We’re paranoid.</h3>
+            <p>
+              HR platforms, CRMs, and clouds are all announcing “context
+              layers.” They’d like the meaning of your business to accumulate on
+              their servers, where it can never leave. Context is deeper
+              lock-in than data, and a hosted context layer has no export
+              button. Setoku exists so that understanding accumulates on a box
+              you own instead. If we disappear tomorrow, your context doesn’t.
+            </p>
+            <h3>We and some friends wanted the same thing.</h3>
+            <ul class="uses">
+              <li>
+                <b
+                  ><a
+                    href="https://www.hedgy.works"
+                    target="_blank"
+                    rel="noopener"
+                    >Hedgy</a
+                  ></b
+                >: keep scaling without hiring. Debug from live logs and data,
+                find growth levers, and match candidates and companies better
+                with more data.
+              </li>
+              <li>
+                <b
+                  ><a href="https://baggu.com" target="_blank" rel="noopener"
+                    >Baggu</a
+                  ></b
+                >: give employees state-of-the-art tools. Faster onboarding, and
+                a safe way to vibecode against real data.
+              </li>
+              <li>
+                <b
+                  ><a href="https://tlon.io" target="_blank" rel="noopener"
+                    >Tlon</a
+                  ></b
+                >: experimenting with giving agents curated data to work from.
+              </li>
+              <li>
+                <b>Sports analysts</b>: query across data that doesn’t usually
+                sit together.
+              </li>
+              <li>
+                <b>Academic labs</b>: think through hypotheses against real
+                papers, data, and drafts.
+              </li>
+            </ul>
+          </section>
+
+          <!-- ————— SETUP HELP ————— -->
+          <section id="help">
+            <div class="plate-no">Notices to mariners</div>
+            <h2>Setup help</h2>
+            <p>
+              It’s open source, so you can self-host it today. If you like,
+              we’re happy to help set it up. Just email
+              <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+            </p>
+          </section>
+        </div>
+
+        <!-- ————— TITLE-BLOCK FOOTER ————— -->
+        <footer>
+          <div class="titleblock">
+            <div class="tb brandcell">
+              <a class="brand" href="#top">
+                <svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+                Setoku
+              </a>
+              <span class="jp">設 × 奥 · set (math) × oku (innermost)</span>
+            </div>
+            <div class="tb">
+              <div class="lab">Chart</div>
+              <div class="val">No. 1 · Survey of the Data Lake</div>
+            </div>
+            <div class="tb">
+              <div class="lab">Repository</div>
+              <div class="val">
+                <a
+                  href="https://github.com/Hedgy-Labs/setoku"
+                  target="_blank"
+                  rel="noopener"
+                  >GitHub</a
+                >
+                <a href="#demo">Demo</a>
+              </div>
+            </div>
+            <div class="tb">
+              <div class="lab">Correspondence</div>
+              <div class="val">
+                <a href="mailto:hello@setoku.com">hello@setoku.com</a>
+              </div>
+            </div>
+            <div class="tb">
+              <div class="lab">License</div>
+              <div class="val">Apache-2.0</div>
+            </div>
+          </div>
+        </footer>
+      </div>
+
+      <div class="ticks-bottom" aria-hidden="true"></div>
+    </div>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) {
+            return w.trim();
+          })
+          .filter(Boolean);
+        if (words.length < 2) return;
+
+        var reduce = window.matchMedia(
+          "(prefers-reduced-motion: reduce)"
+        ).matches;
+        var LIFT = "0.72em";
+        var HALF = 240;
+        var HOLD = 2400;
+        var i = 0;
+
+        function widthOf(w) {
+          measure.textContent = w;
+          return measure.getBoundingClientRect().width;
+        }
+        box.style.width = widthOf(words[0]) + "px";
+
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next;
+            box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length;
+            return;
+          }
+          word
+            .animate(
+              [
+                { transform: "translateY(0)", opacity: 1 },
+                { transform: "translateY(-" + LIFT + ")", opacity: 0 },
+              ],
+              {
+                duration: HALF,
+                easing: "cubic-bezier(0.4, 0, 1, 1)",
+                fill: "forwards",
+              }
+            )
+            .finished.then(function () {
+              word.textContent = next;
+              box.style.width = widthOf(next) + "px";
+              word.animate(
+                [
+                  { transform: "translateY(" + LIFT + ")", opacity: 0 },
+                  { transform: "translateY(0)", opacity: 1 },
+                ],
+                {
+                  duration: HALF,
+                  easing: "cubic-bezier(0, 0, 0.2, 1)",
+                  fill: "forwards",
+                }
+              );
+              i = (i + 1) % words.length;
+            })
+            .catch(function () {});
+        }
+
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () {
+          box.style.width = widthOf(words[i]) + "px";
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/15-ledger.html
+++ b/site/riffs/15-ledger.html
@@ -1,0 +1,802 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · General Ledger</title>
+    <style>
+      :root {
+        --paper: #f7f1e1;
+        --paper-2: #f1e9d4;
+        --ink: #23201a;
+        --ink-soft: #423d33;
+        --ink-faint: #5a5344;
+        --blue: #4a6a86;          /* ledger rule blue */
+        --blue-soft: rgba(74, 106, 134, 0.34);
+        --blue-faint: rgba(74, 106, 134, 0.16);
+        --red: #9c3a2f;           /* ledger margin / correction red */
+        --red-soft: rgba(156, 58, 47, 0.5);
+        --gold: #7a5a1e;
+        --rule: rgba(35, 32, 26, 0.28);
+        --rule-soft: rgba(35, 32, 26, 0.14);
+        --serif: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
+        --script: "Snell Roundhand", "Apple Chancery", "Segoe Script", "Iowan Old Style", cursive;
+        --mono: ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+        --w: 860px;
+      }
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      html { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; scroll-behavior: smooth; }
+      body {
+        background:
+          radial-gradient(120% 60% at 50% -10%, rgba(122, 90, 30, 0.06), transparent 60%),
+          var(--paper);
+        color: var(--ink);
+        font-family: var(--serif);
+        font-size: 17px;
+        line-height: 1.62;
+      }
+      a { color: var(--blue); text-decoration: none; }
+      a:hover { text-decoration: underline; text-underline-offset: 2px; }
+      ::selection { background: var(--blue-soft); color: var(--ink); }
+
+      /* ---- the bound book ---- */
+      .book {
+        max-width: var(--w);
+        margin: 26px auto;
+        background:
+          repeating-linear-gradient(
+            var(--paper) 0px,
+            var(--paper) 33px,
+            var(--blue-faint) 33px,
+            var(--blue-faint) 34px
+          );
+        border: 1px solid var(--rule);
+        box-shadow: 0 1px 0 rgba(255,255,255,0.5) inset, 0 18px 40px rgba(35,32,26,0.16);
+        position: relative;
+      }
+      /* red margin rule + binding gutter */
+      .book::before {
+        content: "";
+        position: absolute;
+        top: 0; bottom: 0; left: 54px;
+        width: 1px;
+        background: var(--red-soft);
+        pointer-events: none;
+      }
+      .book::after {
+        content: "";
+        position: absolute;
+        top: 0; bottom: 0; left: 58px;
+        width: 1px;
+        background: var(--red-soft);
+        pointer-events: none;
+      }
+      @media (max-width: 620px) {
+        .book::before { left: 30px; }
+        .book::after { left: 33px; }
+      }
+
+      .spine {
+        background:
+          repeating-linear-gradient(90deg,
+            #3c4b3f 0px, #3c4b3f 3px,
+            #33413630 3px, #33413630 6px),
+          linear-gradient(180deg, #46543f, #37432f);
+        color: #f3ecd6;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 14px;
+        padding: 12px 22px;
+        border-bottom: 3px double rgba(243, 236, 214, 0.4);
+        position: sticky;
+        top: 0;
+        z-index: 20;
+      }
+      .spine .brand {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+        font-family: var(--script);
+        font-size: 26px;
+        letter-spacing: 0.01em;
+        color: #f6efd9;
+      }
+      .spine .brand .mark { width: 22px; height: 22px; color: #dfe7cf; }
+      .spine .brand:hover { text-decoration: none; }
+      .spine nav { display: flex; gap: 16px; font-family: var(--mono); font-size: 12px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .spine nav a { color: #d8e0c8; }
+      .spine nav a:hover { color: #fff; }
+      @media (max-width: 640px) { .spine nav a.hideable { display: none; } }
+
+      .leaf { padding: 30px 40px 40px 78px; }
+      @media (max-width: 620px) { .leaf { padding: 22px 18px 30px 44px; } }
+
+      /* ---- folio headings ---- */
+      .folio {
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+        margin: 40px 0 8px;
+        padding-bottom: 6px;
+        border-bottom: 2px solid var(--ink);
+      }
+      .folio:first-of-type { margin-top: 4px; }
+      .folio .no {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--red);
+        white-space: nowrap;
+      }
+      .folio h2 {
+        font-family: var(--serif);
+        font-weight: 700;
+        font-size: 25px;
+        letter-spacing: 0.01em;
+        font-variant: small-caps;
+      }
+      .folio .rt {
+        margin-left: auto;
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--ink-faint);
+        letter-spacing: 0.06em;
+      }
+      p { max-width: 60ch; margin-top: 10px; color: var(--ink-soft); }
+      p.lead { color: var(--ink); }
+      strong, b { color: var(--ink); font-weight: 700; }
+      .small { font-size: 14px; }
+
+      /* ---- title page ---- */
+      .titlepage { text-align: center; padding: 30px 0 14px; }
+      .titlepage .est {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+      }
+      .titlepage .rule-orn {
+        display: flex; align-items: center; justify-content: center;
+        gap: 12px; color: var(--gold); margin: 14px 0;
+      }
+      .titlepage .rule-orn::before,
+      .titlepage .rule-orn::after {
+        content: ""; height: 1px; width: 70px; background: var(--gold); opacity: 0.7;
+      }
+      h1 {
+        font-family: var(--serif);
+        font-weight: 700;
+        font-size: clamp(30px, 5.4vw, 46px);
+        line-height: 1.12;
+        letter-spacing: 0.005em;
+        max-width: 14ch;
+        margin: 0 auto;
+      }
+      h1 .roman { font-variant: small-caps; }
+      .rotator {
+        position: relative; display: inline-block; text-align: left;
+        vertical-align: baseline; color: var(--red);
+        font-family: var(--script);
+        font-weight: 400;
+        transition: width 460ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word { display: inline-block; white-space: nowrap; will-change: transform, opacity; padding: 0 0.04em; }
+      .rotator-measure { position: absolute; left: 0; top: 0; visibility: hidden; pointer-events: none; white-space: nowrap; }
+      @media (prefers-reduced-motion: reduce) { .rotator { transition: none; } }
+      .subscription {
+        font-family: var(--script);
+        font-size: 21px;
+        color: var(--ink-soft);
+        margin: 16px auto 0;
+        max-width: 46ch;
+      }
+      .titlepage .imprint {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        margin-top: 18px;
+      }
+      .actions { margin: 20px auto 6px; display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+      .btn {
+        display: inline-flex; align-items: center; gap: 7px;
+        font-family: var(--mono); font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase;
+        padding: 9px 16px; border: 1.5px solid var(--ink); background: var(--ink); color: var(--paper);
+      }
+      .btn:hover { background: var(--blue); border-color: var(--blue); text-decoration: none; }
+      .btn.ghost { background: transparent; color: var(--ink); }
+      .btn.ghost:hover { background: transparent; border-color: var(--red); color: var(--red); }
+
+      /* ---- ledger tables ---- */
+      .scroll { overflow-x: auto; margin: 16px 0; }
+      table.led {
+        width: 100%; border-collapse: collapse; font-size: 15px;
+        background: rgba(255,255,255,0.14);
+      }
+      table.led th {
+        font-family: var(--mono); font-size: 10.5px; font-weight: 600;
+        letter-spacing: 0.09em; text-transform: uppercase; color: var(--ink-faint);
+        text-align: left; padding: 6px 12px; border-bottom: 1.5px solid var(--ink);
+        vertical-align: bottom;
+      }
+      table.led th.amt, table.led td.amt { text-align: right; font-family: var(--mono); white-space: nowrap; }
+      table.led td {
+        padding: 9px 12px; border-bottom: 1px solid var(--rule-soft);
+        color: var(--ink-soft); vertical-align: top;
+      }
+      table.led td.item { color: var(--ink); }
+      table.led .colrule td { border-right: 1px solid var(--blue-faint); }
+      table.led tr.total td {
+        border-top: 1.5px solid var(--ink);
+        border-bottom: 4px double var(--ink);
+        font-weight: 700; color: var(--ink);
+      }
+      table.led td.amt b { font-weight: 700; color: var(--ink); }
+      .marginal { color: var(--red); font-size: 13px; font-style: italic; }
+      .foot-note { font-family: var(--script); color: var(--red); font-size: 16px; }
+
+      /* entries (Q&A ledger lines) */
+      .entry td.q { font-family: var(--serif); font-style: italic; color: var(--ink); }
+
+      code {
+        font-family: var(--mono); font-size: 0.82em;
+        background: var(--paper-2); border: 1px solid var(--rule-soft);
+        padding: 1px 5px; color: var(--red);
+      }
+      pre {
+        background: var(--paper-2);
+        border: 1px solid var(--rule);
+        border-left: 3px solid var(--red-soft);
+        padding: 14px 16px; overflow-x: auto; margin: 14px 0; max-width: 68ch;
+      }
+      pre code {
+        font-family: var(--mono); font-size: 13px; line-height: 1.75;
+        background: none; border: none; padding: 0; color: var(--ink); white-space: pre;
+      }
+      pre code .c { color: var(--ink-faint); }
+      details.manual { margin-top: 10px; }
+      details.manual summary { font-family: var(--mono); font-size: 12px; letter-spacing: 0.05em; text-transform: uppercase; color: var(--blue); cursor: pointer; }
+      details.manual[open] summary { margin-bottom: 6px; }
+
+      ul.reg { list-style: none; margin: 10px 0; max-width: 64ch; }
+      ul.reg li { position: relative; padding: 5px 0 5px 22px; color: var(--ink-soft); border-bottom: 1px dotted var(--rule-soft); }
+      ul.reg li::before { content: "§"; position: absolute; left: 2px; color: var(--red); font-family: var(--serif); }
+      ul.reg b { color: var(--ink); }
+
+      .why h3 {
+        font-family: var(--script); font-size: 23px; color: var(--ink);
+        margin: 22px 0 2px; font-weight: 400;
+      }
+
+      /* architecture as ruled schematic */
+      .diagram { margin: 16px 0; }
+      .diagram svg { width: 100%; height: auto; display: block; }
+      .diagram .node { fill: rgba(255,255,255,0.35); stroke: var(--ink); stroke-width: 1.3; }
+      .diagram .box { fill: none; stroke: var(--blue-soft); stroke-width: 1.1; stroke-dasharray: 3 4; }
+      .diagram .t { font-family: var(--serif); font-size: 13px; fill: var(--ink); font-variant: small-caps; letter-spacing: 0.02em; }
+      .diagram .s { font-family: var(--mono); font-size: 10px; fill: var(--ink-faint); }
+      .diagram .e { font-family: var(--mono); font-size: 10px; fill: var(--red); letter-spacing: 0.03em; }
+      .diagram .arr { stroke: var(--ink-soft); stroke-width: 1.3; fill: none; }
+
+      /* revenue bar figure */
+      .bars { margin-top: 14px; }
+      .bars svg { width: 100%; height: auto; }
+
+      /* colophon / footer */
+      footer {
+        margin-top: 8px;
+        border-top: 3px double var(--ink);
+        padding: 22px 40px 30px 78px;
+        display: flex; flex-wrap: wrap; gap: 14px 26px; align-items: baseline; justify-content: space-between;
+        font-family: var(--mono); font-size: 11.5px; letter-spacing: 0.05em; color: var(--ink-faint);
+      }
+      @media (max-width: 620px) { footer { padding-left: 44px; padding-right: 18px; } }
+      footer a { color: var(--ink-soft); }
+      footer .jp { font-family: var(--serif); font-size: 13px; letter-spacing: 0; font-style: italic; color: var(--ink-soft); }
+      .certified {
+        font-family: var(--script); color: var(--red); font-size: 20px;
+        border: 1.5px solid var(--red-soft); border-radius: 4px;
+        padding: 4px 14px; transform: rotate(-4deg); display: inline-block;
+      }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z" fill="currentColor" />
+        <path d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z" fill="currentColor" />
+        <path d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z" fill="currentColor" />
+      </symbol>
+    </svg>
+
+    <div class="book" id="top">
+      <div class="spine">
+        <a class="brand" href="#top"
+          ><svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+          Setoku</a
+        >
+        <nav>
+          <a class="hideable" href="#how">How it works</a>
+          <a class="hideable" href="#apps">Apps</a>
+          <a class="hideable" href="#connectors">Register</a>
+          <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">GitHub ↗</a>
+        </nav>
+      </div>
+
+      <div class="leaf">
+        <!-- TITLE PAGE -->
+        <div class="titlepage">
+          <div class="est">Open source · MCP server · Apache-2.0</div>
+          <div class="rule-orn">❧</div>
+          <h1>
+            Make any AI fluent<br />in your <span
+              class="rotator"
+              data-words="company,family,personal"
+              ><span class="rotator-word">company</span
+              ><span class="rotator-measure" aria-hidden="true"></span></span>
+            <span class="roman">data.</span>
+          </h1>
+          <p class="subscription">
+            Setoku is a small self-hosted MCP knowledge server + Claude Code
+            skills for hooking up your data. It does two things: it gives your
+            AI a read-only way to query your data, and it remembers what that
+            data means (the metric definitions, the gotchas), getting better the
+            more you use it. The MCP works with whatever AI you already have, and
+            no model runs on the server, so no added inference cost.
+          </p>
+          <div class="actions">
+            <a class="btn" href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">View on GitHub ↗</a>
+            <a class="btn ghost" href="#demo">Try the demo</a>
+          </div>
+          <div class="imprint">Kept by Hedgy Labs · General Ledger · Folios I–VII</div>
+        </div>
+
+        <!-- FOL. I — QUICKSTART -->
+        <section id="quickstart">
+          <div class="folio">
+            <span class="no">Fol. I</span>
+            <h2>Quickstart</h2>
+            <span class="rt">carried forward →</span>
+          </div>
+          <p class="lead">
+            Setoku installs as a Claude Code plugin. Add the plugin, then run
+            onboarding from your main project directory, the codebase you want
+            Setoku to learn from:
+          </p>
+          <pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+          <p>
+            Onboarding stands up the server, auths your Claude, wires your
+            database read-only, and generates the first knowledge from your
+            code. You stay in the loop for anything that touches your data. To
+            start onboarding, run <code>/setoku:onboard</code>.
+          </p>
+          <p>
+            You’ll need somewhere to host it. Something like OVH’s
+            <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener">VPS-2</a>
+            is plenty.
+          </p>
+          <details class="manual">
+            <summary>Or stand up the server by hand</summary>
+            <pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+            <p class="small" style="margin-top: 10px">
+              Installs Docker, generates secrets, gets an HTTPS certificate, and
+              prints the connect command. Then add the plugin and run
+              /setoku:onboard from your project; it’ll detect the box you just
+              made.
+            </p>
+          </details>
+        </section>
+
+        <!-- FOL. II — HOW IT WORKS -->
+        <section id="how">
+          <div class="folio">
+            <span class="no">Fol. II</span>
+            <h2>How it works</h2>
+            <span class="rt">two columns, one rule</span>
+          </div>
+          <p class="lead">
+            Setoku gives the AI two kinds of MCP tools, and one rule: look up
+            what the data means before you touch it.
+          </p>
+          <div class="scroll">
+            <table class="led">
+              <thead>
+                <tr>
+                  <th style="width: 26%">Account</th>
+                  <th style="width: 30%">Instrument</th>
+                  <th>Particulars</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="colrule">
+                  <td class="item"><b>Context tools</b></td>
+                  <td><code>find_context · get_metric</code></td>
+                  <td>
+                    The AI reads what your data means first: canonical metric
+                    definitions, entity docs, and the gotchas that make a naive
+                    query wrong.
+                  </td>
+                </tr>
+                <tr class="colrule">
+                  <td class="item"><b>Read-only query</b></td>
+                  <td><code>get_schema · run_query</code></td>
+                  <td>
+                    Read-only, with a row cap, a statement timeout, a table
+                    allow-list, and an append-only audit log. Enforced by the
+                    database role, not by parsing SQL.
+                  </td>
+                </tr>
+                <tr class="colrule">
+                  <td class="item"><b>Human-approved</b></td>
+                  <td><code>report_correction</code></td>
+                  <td>
+                    The AI can only propose changes to what Setoku knows. A
+                    person accepts them on the admin page, outside the agent
+                    loop, so an injected session can’t rewrite the brain.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="small">
+            You set it up with <b>Claude Code</b> skills:
+          </p>
+          <ul class="reg">
+            <li><code>/setoku:onboard</code> <b>·</b> sets Setoku up in a repo for the first time.</li>
+            <li><code>/setoku:connect</code> <b>·</b> adds a data source or custom integration.</li>
+            <li><code>/setoku:generate</code> <b>·</b> writes business context from your code.</li>
+            <li><code>/setoku:curate</code> <b>·</b> reviews and approves pending knowledge.</li>
+          </ul>
+          <p class="small">
+            Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex, or
+            whatever you run. Just ask in plain language, and the tools do the
+            rest.
+          </p>
+        </section>
+
+        <!-- FOL. III — APPS -->
+        <section id="apps">
+          <div class="folio">
+            <span class="no">Fol. III</span>
+            <h2>Apps: save &amp; share the tools Claude builds you</h2>
+          </div>
+          <p class="lead">
+            Ask Claude to build a dashboard on your data. Then publish it to a
+            link as a Setoku App, the data stays live, and your whole team can
+            view it. Nothing to deploy, no frontend to maintain.
+          </p>
+          <div class="scroll">
+            <table class="led">
+              <thead>
+                <tr>
+                  <th style="width: 26%">Entry</th>
+                  <th style="width: 26%">Warrant</th>
+                  <th>Particulars</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="colrule">
+                  <td class="item"><b>Built by asking</b></td>
+                  <td><code>publish_app</code></td>
+                  <td>Describe it in plain language; the agent writes the app and publishes it to a URL. Edit it the same way, just ask for the change.</td>
+                </tr>
+                <tr class="colrule">
+                  <td class="item"><b>Backed by live data</b></td>
+                  <td><code>read-only</code></td>
+                  <td>Apps read through the same governed path: row caps, audit, a SELECT-only database role. They never get write access to your sources.</td>
+                </tr>
+                <tr class="colrule">
+                  <td class="item"><b>App-private state</b></td>
+                  <td><code>no writes to your data</code></td>
+                  <td>Each app keeps its own state (todos, votes, annotations) in a sandbox that belongs to the app, not your database. Worst case, an app messes up its own notes.</td>
+                </tr>
+                <tr class="colrule">
+                  <td class="item"><b>Share by link</b></td>
+                  <td><code>team or public</code></td>
+                  <td>A team link is login-gated; an admin can flip one public for a credential-free URL. The page runs in a locked-down sandbox with no network, so a published app can’t phone home.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- FOL. IV — ARCHITECTURE -->
+        <section id="architecture">
+          <div class="folio">
+            <span class="no">Fol. IV</span>
+            <h2>Architecture</h2>
+            <span class="rt">schedule of the estate</span>
+          </div>
+          <p class="lead">
+            You can host this on whatever infra you like. We put it all on one
+            small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+            helps you add custom integrations. Only the proxy is public, so your
+            databases aren’t exposed. Queries are read-only, and knowledge
+            changes pass through a person.
+          </p>
+          <div class="diagram scroll">
+            <svg viewBox="0 0 680 520" role="img" aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake, and your sources (GitHub, Vercel, Render, Slack, Mercury) are ingested into the lake.">
+              <defs>
+                <marker id="ah" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto-start-reverse">
+                  <path d="M0 0 L6 3 L0 6 Z" fill="#5a5344" />
+                </marker>
+              </defs>
+              <rect class="node" x="250" y="14" width="180" height="44" />
+              <text class="t" x="340" y="41" text-anchor="middle">You + your AI</text>
+              <path class="arr" d="M340 58 L340 142" marker-start="url(#ah)" marker-end="url(#ah)" />
+              <text class="e" x="348" y="86">MCP</text>
+              <rect class="box" x="60" y="110" width="560" height="300" />
+              <text class="s" x="76" y="130">your box</text>
+              <rect class="node" x="250" y="146" width="180" height="58" />
+              <text class="t" x="340" y="171" text-anchor="middle">Setoku gateway</text>
+              <text class="s" x="340" y="189" text-anchor="middle">context · query tools</text>
+              <rect class="node" x="452" y="150" width="150" height="50" />
+              <text class="t" x="527" y="179" text-anchor="middle">a person</text>
+              <rect class="node" x="92" y="322" width="180" height="66" />
+              <text class="t" x="182" y="350" text-anchor="middle">Lake (ClickHouse)</text>
+              <text class="s" x="182" y="368" text-anchor="middle">logs · events · DB mirror</text>
+              <rect class="node" x="408" y="322" width="190" height="66" />
+              <text class="t" x="503" y="359" text-anchor="middle">Knowledge store</text>
+              <rect class="node" x="92" y="440" width="180" height="64" />
+              <text class="t" x="182" y="468" text-anchor="middle">Your sources</text>
+              <text class="s" x="182" y="486" text-anchor="middle">GitHub · Vercel · Slack…</text>
+              <rect class="node" x="300" y="440" width="180" height="64" />
+              <text class="t" x="390" y="468" text-anchor="middle">Your database</text>
+              <text class="s" x="390" y="486" text-anchor="middle">Postgres · read-only</text>
+              <path class="arr" d="M412 204 L508 322" marker-start="url(#ah)" marker-end="url(#ah)" />
+              <text class="e" x="424" y="266" text-anchor="middle">reads ·</text>
+              <text class="e" x="424" y="282" text-anchor="middle">proposes</text>
+              <path class="arr" d="M527 200 L513 322" marker-end="url(#ah)" />
+              <text class="e" x="534" y="262">approves</text>
+              <path class="arr" d="M210 322 L300 204" marker-end="url(#ah)" />
+              <path class="arr" d="M182 440 L182 388" marker-end="url(#ah)" />
+              <text class="e" x="190" y="420">ingest</text>
+              <path class="arr" d="M388 440 L366 206" marker-end="url(#ah)" />
+              <text class="e" x="300" y="300">read-only</text>
+            </svg>
+          </div>
+        </section>
+
+        <!-- FOL. V — REGISTER OF SOURCES -->
+        <section id="connectors">
+          <div class="folio">
+            <span class="no">Fol. V</span>
+            <h2>Register of accounts &amp; sources</h2>
+          </div>
+          <p class="lead">
+            Point Setoku at the data you already have. Every source lands in a
+            local
+            <a href="https://clickhouse.com/" target="_blank" rel="noopener">ClickHouse</a>
+            data lake, on purpose: agents write arbitrary queries (scans, GROUP
+            BYs, whole-table aggregations), and a columnar engine answers those
+            in about a second, so the apps and dashboards they build stay quick.
+            Your app database connects read-only and is mirrored in on a cron;
+            the rest is ingested as it happens.
+          </p>
+          <div class="scroll">
+            <table class="led">
+              <thead>
+                <tr>
+                  <th style="width: 4%">№</th>
+                  <th style="width: 24%">Source</th>
+                  <th>What lands</th>
+                  <th style="width: 22%">Mode of entry</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="colrule"><td class="amt">1</td><td class="item"><b>PostgreSQL</b></td><td>app database</td><td>mirrored read-only</td></tr>
+                <tr class="colrule"><td class="amt">2</td><td class="item"><b>GitHub</b></td><td>issues, PRs &amp; commits</td><td>ingested</td></tr>
+                <tr class="colrule"><td class="amt">3</td><td class="item"><b>Vercel</b></td><td>deploys &amp; logs</td><td>ingested</td></tr>
+                <tr class="colrule"><td class="amt">4</td><td class="item"><b>Render</b></td><td>deploys &amp; logs</td><td>ingested</td></tr>
+                <tr class="colrule"><td class="amt">5</td><td class="item"><b>Slack</b></td><td>messages</td><td>ingested</td></tr>
+                <tr class="colrule"><td class="amt">6</td><td class="item"><b>Mercury</b></td><td>banking &amp; finance</td><td>ingested</td></tr>
+                <tr class="total"><td class="amt"></td><td>ClickHouse</td><td>one lake, every source</td><td class="amt">6 posted</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="small">
+            No connector for your source yet? The included setup skills give
+            your coding agent the patterns to wire one up itself. See
+            <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">the repo</a>,
+            or open an issue.
+          </p>
+        </section>
+
+        <!-- FOL. VI — DEMO / DAYBOOK -->
+        <section id="demo">
+          <div class="folio">
+            <span class="no">Fol. VI</span>
+            <h2>Daybook: try it on real-ish data</h2>
+          </div>
+          <p class="lead">
+            There’s a live demo wired to a fictional pro sports club, the Bonita
+            Bulldogs (ticketing, sponsorship, concessions, payroll, broadcast
+            rights).
+          </p>
+
+          <p class="small" style="margin-top: 16px"><b>Entry 1 — Connect to the demo MCP server.</b>
+            In Claude (or any MCP client) open Settings → Connectors → Add
+            custom connector, and paste this URL. The token rides in the URL, so
+            there’s no separate key to enter.</p>
+          <pre><code>https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</code></pre>
+
+          <p class="small" style="margin-top: 18px"><b>Entry 2 — Ask a question.</b> Posted to the daybook, with the reconciling note in red:</p>
+          <div class="scroll">
+            <table class="led">
+              <thead>
+                <tr>
+                  <th style="width: 46%">Line item (the question)</th>
+                  <th class="amt" style="width: 16%">Amount</th>
+                  <th style="width: 38%">Reconciling note</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="entry colrule">
+                  <td class="q">“How many unique fans do we have?”</td>
+                  <td class="amt"><b>71,204</b></td>
+                  <td class="marginal">deduped by normalized email, internal accounts excluded. Not the raw 92,118.</td>
+                </tr>
+                <tr class="entry colrule">
+                  <td class="q">“What’s our total annual revenue, and how much is media rights?”</td>
+                  <td class="amt"><b>$192M</b></td>
+                  <td class="marginal">five systems reconciled to the same units. Media rights is the biggest line, ~$90M.</td>
+                </tr>
+                <tr class="entry colrule">
+                  <td class="q">“What was ticket revenue this season?”</td>
+                  <td class="amt"><b>$46.8M</b></td>
+                  <td class="marginal">cents reconciled to dollars; refunds, exchanges, and comps excluded.</td>
+                </tr>
+                <tr class="entry colrule">
+                  <td class="q">“What’s our total merchandise revenue?”</td>
+                  <td class="amt"><b>flagged</b></td>
+                  <td class="marginal">most merch is sold via Fanatics, not in this data, so it says so instead of returning a wrong total.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p class="small" style="margin-top: 18px"><b>“Chart revenue by line.”</b> Posted as a schedule of accounts, ruled off to the grand total:</p>
+          <div class="scroll">
+            <table class="led">
+              <thead>
+                <tr>
+                  <th style="width: 34%">Account</th>
+                  <th class="amt" style="width: 16%">Amount</th>
+                  <th>Proportion of ~$192M total</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="colrule"><td class="item">Media rights</td><td class="amt">$90M</td><td><svg viewBox="0 0 400 14" width="100%" height="14" preserveAspectRatio="none" aria-hidden="true"><rect width="400" height="14" fill="#4a6a86" /></svg></td></tr>
+                <tr class="colrule"><td class="item">Ticketing</td><td class="amt">$47M</td><td><svg viewBox="0 0 400 14" width="100%" height="14" preserveAspectRatio="none" aria-hidden="true"><rect width="209" height="14" fill="#4a6a86" /></svg></td></tr>
+                <tr class="colrule"><td class="item">Sponsorship</td><td class="amt">$28M</td><td><svg viewBox="0 0 400 14" width="100%" height="14" preserveAspectRatio="none" aria-hidden="true"><rect width="124" height="14" fill="#4a6a86" /></svg></td></tr>
+                <tr class="colrule"><td class="item">Concessions</td><td class="amt">$14M</td><td><svg viewBox="0 0 400 14" width="100%" height="14" preserveAspectRatio="none" aria-hidden="true"><rect width="62" height="14" fill="#4a6a86" /></svg></td></tr>
+                <tr class="colrule"><td class="item">Merch</td><td class="amt">$8M</td><td><svg viewBox="0 0 400 14" width="100%" height="14" preserveAspectRatio="none" aria-hidden="true"><rect width="36" height="14" fill="#4a6a86" /></svg></td></tr>
+                <tr class="colrule"><td class="item">Other</td><td class="amt">$5M</td><td><svg viewBox="0 0 400 14" width="100%" height="14" preserveAspectRatio="none" aria-hidden="true"><rect width="22" height="14" fill="#4a6a86" /></svg></td></tr>
+                <tr class="total"><td class="item">Grand total</td><td class="amt">$192M</td><td>Annual revenue by line</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p class="small" style="margin-top: 20px"><b>Entry 3 — Try an app.</b>
+            Ask Claude to build a dashboard on the same data, then publish it to
+            a link. Two live examples, running on the demo data right now:</p>
+          <ul class="reg">
+            <li>
+              <a href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d" target="_blank" rel="noopener">Sponsorship pricing table ↗</a>
+              — inventory and rates for sponsorship placements.
+            </li>
+            <li>
+              <a href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea" target="_blank" rel="noopener">Fan lifetime value ↗</a>
+              — segment fans by spend across tickets, merch, and concessions.
+            </li>
+          </ul>
+        </section>
+
+        <!-- FOL. VII — WHY -->
+        <section id="why" class="why">
+          <div class="folio">
+            <span class="no">Fol. VII</span>
+            <h2>Memoranda: why we built it</h2>
+          </div>
+          <h3>We’re curious.</h3>
+          <p>
+            There are plenty of AI memory stores, and plenty of data gateways.
+            Stapling the two together, and nudging the agent to gather knowledge
+            about the data as it goes, seemed useful and fun to tinker with.
+          </p>
+          <h3>We’re cheap.</h3>
+          <p>
+            We wanted something that runs on one small box, works on a Pro/Max
+            subscription or a cheap model with no added inference cost, mostly
+            sets itself up (no field engineer to pay for), stays portable
+            between providers, and is open source.
+          </p>
+          <h3>We’re paranoid.</h3>
+          <p>
+            HR platforms, CRMs, and clouds are all announcing “context layers.”
+            They’d like the meaning of your business to accumulate on their
+            servers, where it can never leave. Context is deeper lock-in than
+            data, and a hosted context layer has no export button. Setoku exists
+            so that understanding accumulates on a box you own instead. If we
+            disappear tomorrow, your context doesn’t.
+          </p>
+          <h3>We and some friends wanted the same thing.</h3>
+          <ul class="reg">
+            <li><b><a href="https://www.hedgy.works" target="_blank" rel="noopener">Hedgy</a></b>: keep scaling without hiring. Debug from live logs and data, find growth levers, and match candidates and companies better with more data.</li>
+            <li><b><a href="https://baggu.com" target="_blank" rel="noopener">Baggu</a></b>: give employees state-of-the-art tools. Faster onboarding, and a safe way to vibecode against real data.</li>
+            <li><b><a href="https://tlon.io" target="_blank" rel="noopener">Tlon</a></b>: experimenting with giving agents curated data to work from.</li>
+            <li><b>Sports analysts</b>: query across data that doesn’t usually sit together.</li>
+            <li><b>Academic labs</b>: think through hypotheses against real papers, data, and drafts.</li>
+          </ul>
+        </section>
+
+        <!-- SETUP HELP -->
+        <section id="help">
+          <div class="folio">
+            <span class="no">Endpaper</span>
+            <h2>Setup help</h2>
+          </div>
+          <p>
+            It’s open source, so you can self-host it today. If you like, we’re
+            happy to help set it up. Just email
+            <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+          </p>
+          <p style="margin-top: 18px"><span class="certified">Examined &amp; found correct</span></p>
+        </section>
+      </div>
+
+      <footer>
+        <span>Setoku · <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">GitHub</a> · <a href="#demo">Demo</a> · <a href="mailto:hello@setoku.com">Contact</a> · Apache-2.0</span>
+        <span class="jp">設 × 奥 · set (math) × oku (innermost)</span>
+      </footer>
+    </div>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",").map(function (w) { return w.trim(); }).filter(Boolean);
+        if (words.length < 2) return;
+        var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        var LIFT = "0.72em", HALF = 240, HOLD = 2400, i = 0;
+        function widthOf(w) { measure.textContent = w; return measure.getBoundingClientRect().width; }
+        box.style.width = widthOf(words[0]) + "px";
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next; box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length; return;
+          }
+          word.animate(
+            [{ transform: "translateY(0)", opacity: 1 }, { transform: "translateY(-" + LIFT + ")", opacity: 0 }],
+            { duration: HALF, easing: "cubic-bezier(0.4, 0, 1, 1)", fill: "forwards" }
+          ).finished.then(function () {
+            word.textContent = next; box.style.width = widthOf(next) + "px";
+            word.animate(
+              [{ transform: "translateY(" + LIFT + ")", opacity: 0 }, { transform: "translateY(0)", opacity: 1 }],
+              { duration: HALF, easing: "cubic-bezier(0, 0, 0.2, 1)", fill: "forwards" }
+            );
+            i = (i + 1) % words.length;
+          }).catch(function () {});
+        }
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () { box.style.width = widthOf(words[i]) + "px"; });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/16-exhibition.html
+++ b/site/riffs/16-exhibition.html
@@ -1,0 +1,1425 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · An Open Exhibition</title>
+    <style>
+      :root {
+        --plaster: #f4f1ea;
+        --plaster-2: #ece7dc;
+        --wall: #faf8f3;
+        --ink: #1c1c1a;
+        --ink-soft: #45443f;
+        --ink-faint: #6b695f;
+        --line: rgba(28, 28, 26, 0.16);
+        --line-soft: rgba(28, 28, 26, 0.08);
+        --sage: #5f7d63;
+        --sage-d: #3d5741;
+        --serif: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia,
+          "Times New Roman", serif;
+        --sans: ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", Arial,
+          sans-serif;
+        --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        --w: 1080px;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        scroll-behavior: smooth;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+      body {
+        background: var(--plaster);
+        color: var(--ink);
+        font-family: var(--serif);
+        font-size: 17px;
+        line-height: 1.62;
+      }
+      a {
+        color: var(--sage-d);
+        text-decoration: none;
+        border-bottom: 1px solid rgba(61, 87, 65, 0.3);
+      }
+      a:hover {
+        border-bottom-color: var(--sage-d);
+      }
+      svg {
+        display: block;
+      }
+      ::selection {
+        background: var(--sage);
+        color: #fff;
+      }
+      .wrap {
+        max-width: var(--w);
+        margin: 0 auto;
+        padding-inline: clamp(20px, 5vw, 64px);
+      }
+
+      /* Letterspaced small-caps label voice used throughout */
+      .label {
+        font-family: var(--sans);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+      }
+      .accession {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.04em;
+        color: var(--ink-faint);
+      }
+
+      /* ---- Exhibition identity header ---- */
+      header {
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        background: color-mix(in srgb, var(--plaster) 88%, transparent);
+        backdrop-filter: blur(8px);
+        border-bottom: 1px solid var(--line);
+      }
+      .idbar {
+        max-width: var(--w);
+        margin: 0 auto;
+        padding: 12px clamp(20px, 5vw, 64px);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+      }
+      .idbar .who {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+      }
+      .idbar .mark {
+        width: 20px;
+        height: 20px;
+        color: var(--ink);
+      }
+      .idbar .wordmark {
+        font-family: var(--sans);
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-size: 13px;
+        color: var(--ink);
+      }
+      .idbar .meta {
+        display: flex;
+        gap: 22px;
+        align-items: center;
+      }
+      .idbar .meta a {
+        border: none;
+      }
+      @media (max-width: 720px) {
+        .idbar .meta .hideable {
+          display: none;
+        }
+      }
+
+      /* ---- Title wall ---- */
+      .titlewall {
+        background: var(--wall);
+        border-bottom: 1px solid var(--line);
+      }
+      .titlewall .wrap {
+        padding-block: clamp(72px, 13vw, 150px) clamp(56px, 9vw, 104px);
+      }
+      .exhib-kicker {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px 22px;
+        margin-bottom: 40px;
+      }
+      h1.title {
+        font-weight: 400;
+        font-size: clamp(40px, 7.4vw, 92px);
+        line-height: 1.02;
+        letter-spacing: -0.018em;
+        max-width: 15em;
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        font-style: italic;
+        color: var(--sage-d);
+        transition: width 480ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+        will-change: transform, opacity;
+      }
+      .rotator-measure {
+        position: absolute;
+        left: 0;
+        top: 0;
+        visibility: hidden;
+        pointer-events: none;
+        white-space: nowrap;
+        font-style: italic;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .rotator {
+          transition: none;
+        }
+      }
+      .wall-text {
+        margin-top: 40px;
+        max-width: 34em;
+        font-size: clamp(18px, 2.1vw, 21px);
+        color: var(--ink-soft);
+      }
+      .wall-credit {
+        margin-top: 34px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px 20px;
+        align-items: center;
+      }
+      .btn {
+        font-family: var(--sans);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        padding: 12px 22px;
+        border: 1px solid var(--ink);
+        color: var(--ink);
+        background: transparent;
+        transition: background 140ms ease, color 140ms ease;
+      }
+      .btn:hover {
+        background: var(--ink);
+        color: var(--plaster);
+      }
+      .btn.solid {
+        background: var(--ink);
+        color: var(--plaster);
+      }
+      .btn.solid:hover {
+        background: var(--sage-d);
+        border-color: var(--sage-d);
+      }
+
+      /* ---- Gallery rooms ---- */
+      .room {
+        border-top: 1px solid var(--line);
+        padding-block: clamp(52px, 8vw, 96px);
+        scroll-margin-top: 64px;
+      }
+      .room-head {
+        display: grid;
+        grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+        gap: 24px 48px;
+        align-items: baseline;
+        margin-bottom: 48px;
+      }
+      @media (max-width: 720px) {
+        .room-head {
+          grid-template-columns: 1fr;
+          gap: 14px;
+          margin-bottom: 34px;
+        }
+      }
+      .room-no {
+        font-family: var(--sans);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--sage-d);
+        margin-bottom: 14px;
+      }
+      h2.room-title {
+        font-weight: 400;
+        font-size: clamp(27px, 4vw, 40px);
+        line-height: 1.08;
+        letter-spacing: -0.015em;
+        max-width: 12em;
+      }
+      .room-lede {
+        color: var(--ink-soft);
+        font-size: 17px;
+      }
+      .room-lede .accession {
+        display: block;
+        margin-bottom: 12px;
+      }
+
+      /* ---- Wall label (didactic panel) ---- */
+      .labels {
+        display: grid;
+        gap: 22px;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      }
+      .plate {
+        background: var(--wall);
+        border: 1px solid var(--line);
+        padding: 22px 22px 24px;
+      }
+      .plate .obj-no {
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--sage-d);
+        letter-spacing: 0.05em;
+      }
+      .plate h3 {
+        font-weight: 400;
+        font-size: 20px;
+        letter-spacing: -0.01em;
+        margin: 10px 0 4px;
+      }
+      .plate .medium {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--ink-faint);
+        margin-bottom: 12px;
+      }
+      .plate p {
+        color: var(--ink-soft);
+        font-size: 15.5px;
+        line-height: 1.55;
+      }
+
+      /* generic prose block */
+      .didactic {
+        max-width: 42em;
+      }
+      .didactic p {
+        color: var(--ink-soft);
+        margin-top: 14px;
+      }
+      .didactic p:first-child {
+        margin-top: 0;
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 0.84em;
+        background: var(--plaster-2);
+        padding: 2px 6px;
+        border-radius: 3px;
+        color: var(--sage-d);
+        border-bottom: none;
+      }
+      a code {
+        color: var(--sage-d);
+      }
+      pre {
+        background: var(--wall);
+        border: 1px solid var(--line);
+        padding: 20px 22px;
+        overflow-x: auto;
+        margin: 20px 0;
+      }
+      pre code {
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.85;
+        background: none;
+        padding: 0;
+        color: var(--ink);
+        white-space: pre;
+      }
+      pre code .c {
+        color: var(--ink-faint);
+      }
+      details.manual {
+        margin-top: 18px;
+        border-top: 1px solid var(--line-soft);
+        padding-top: 16px;
+      }
+      details.manual summary {
+        cursor: pointer;
+        font-family: var(--sans);
+        font-size: 12px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+      }
+      .note {
+        font-size: 15px;
+        color: var(--ink-soft);
+        margin-top: 16px;
+        max-width: 42em;
+      }
+
+      /* ---- The framed central work (architecture) ---- */
+      .work {
+        margin: 0 auto;
+        max-width: 820px;
+      }
+      .frame {
+        background: var(--wall);
+        border: 1px solid var(--line);
+        padding: clamp(20px, 4vw, 46px);
+        box-shadow: 0 1px 0 rgba(28, 28, 26, 0.05);
+      }
+      .frame .mat {
+        border: 1px solid var(--line-soft);
+        padding: clamp(14px, 3vw, 30px);
+        overflow-x: auto;
+      }
+      .work-label {
+        margin-top: 22px;
+        max-width: 40em;
+      }
+      .work-label .accession {
+        display: block;
+        margin-bottom: 8px;
+      }
+      .work-label h3 {
+        font-weight: 400;
+        font-size: 18px;
+        margin-bottom: 6px;
+      }
+      .work-label p {
+        color: var(--ink-soft);
+        font-size: 15px;
+      }
+      .diagram .node {
+        fill: var(--wall);
+        stroke: var(--ink);
+        stroke-width: 1.3;
+      }
+      .diagram .box {
+        fill: none;
+        stroke: var(--ink-faint);
+        stroke-width: 1.1;
+        stroke-dasharray: 4 5;
+      }
+      .diagram .t {
+        font-family: var(--sans);
+        font-size: 13px;
+        fill: var(--ink);
+      }
+      .diagram .s {
+        font-family: var(--sans);
+        font-size: 10.5px;
+        fill: var(--ink-soft);
+      }
+      .diagram .e {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        fill: var(--ink-soft);
+      }
+      .diagram .arr {
+        stroke: var(--ink-soft);
+        stroke-width: 1.3;
+        fill: none;
+      }
+
+      /* ---- Catalogue of the collection (connectors) ---- */
+      .catalogue {
+        border-top: 1px solid var(--line);
+      }
+      .cat-row {
+        display: grid;
+        grid-template-columns: 44px minmax(120px, 1fr) minmax(0, 2fr) auto;
+        gap: 18px;
+        align-items: baseline;
+        padding: 15px 0;
+        border-bottom: 1px solid var(--line-soft);
+      }
+      .cat-row .n {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--ink-faint);
+      }
+      .cat-row .nm {
+        font-size: 17px;
+      }
+      .cat-row .ds {
+        color: var(--ink-soft);
+        font-size: 15px;
+      }
+      .cat-row .md {
+        font-family: var(--sans);
+        font-size: 10.5px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--sage-d);
+        white-space: nowrap;
+      }
+      @media (max-width: 640px) {
+        .cat-row {
+          grid-template-columns: 34px 1fr;
+          gap: 4px 12px;
+        }
+        .cat-row .ds,
+        .cat-row .md {
+          grid-column: 2;
+        }
+      }
+
+      /* ---- Demo: labeled exhibits ---- */
+      .exhibits {
+        display: grid;
+        gap: 20px;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+      .exhibit {
+        background: var(--wall);
+        border: 1px solid var(--line);
+        padding: 24px 24px 22px;
+        display: flex;
+        flex-direction: column;
+      }
+      .exhibit .q {
+        font-style: italic;
+        color: var(--ink);
+        font-size: 16px;
+        margin-bottom: 18px;
+        max-width: 26em;
+      }
+      .exhibit .figure {
+        font-weight: 400;
+        font-size: clamp(30px, 5vw, 44px);
+        letter-spacing: -0.02em;
+        line-height: 1;
+        color: var(--ink);
+        margin-top: auto;
+      }
+      .exhibit .curator {
+        margin-top: 12px;
+        padding-top: 12px;
+        border-top: 1px solid var(--line-soft);
+        font-family: var(--sans);
+        font-size: 12.5px;
+        line-height: 1.5;
+        color: var(--ink-faint);
+      }
+      .exhibit .curator b {
+        display: block;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-size: 10px;
+        color: var(--sage-d);
+        margin-bottom: 5px;
+        font-weight: 600;
+      }
+      .exhibit.wide {
+        grid-column: 1 / -1;
+      }
+      .chart-wrap {
+        overflow-x: auto;
+      }
+      .chart-cap {
+        font-family: var(--mono);
+        font-size: 11.5px;
+        color: var(--ink-faint);
+        margin-bottom: 14px;
+      }
+
+      /* connect-step blocks in demo */
+      .step {
+        margin-top: 30px;
+      }
+      .step:first-child {
+        margin-top: 0;
+      }
+      .step-h {
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+        margin-bottom: 10px;
+      }
+      .step-n {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--sage-d);
+        letter-spacing: 0.1em;
+      }
+      .step-h h3 {
+        font-weight: 400;
+        font-size: 21px;
+        letter-spacing: -0.01em;
+      }
+      .uses {
+        list-style: none;
+        margin-top: 14px;
+        display: grid;
+        gap: 10px;
+      }
+      .uses li {
+        color: var(--ink-soft);
+        font-size: 15.5px;
+        line-height: 1.55;
+        padding-left: 22px;
+        position: relative;
+        max-width: 44em;
+      }
+      .uses li::before {
+        content: "—";
+        position: absolute;
+        left: 0;
+        color: var(--ink-faint);
+      }
+      .uses b {
+        font-weight: 400;
+        color: var(--ink);
+      }
+
+      /* ---- Statement / rationale room ---- */
+      .statement h3 {
+        font-weight: 400;
+        font-size: 22px;
+        margin: 30px 0 6px;
+        letter-spacing: -0.01em;
+      }
+      .statement h3:first-of-type {
+        margin-top: 0;
+      }
+      .statement p {
+        color: var(--ink-soft);
+        max-width: 44em;
+      }
+
+      /* ---- Footer / colophon ---- */
+      footer {
+        border-top: 1px solid var(--line);
+        background: var(--wall);
+      }
+      footer .wrap {
+        padding-block: 44px 56px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 24px 40px;
+        align-items: baseline;
+        justify-content: space-between;
+      }
+      footer .colo {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 20px;
+        align-items: center;
+      }
+      footer .colo a {
+        border: none;
+        font-family: var(--sans);
+        font-size: 12px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+      }
+      footer .jp {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--ink-faint);
+      }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path
+          d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z"
+          fill="currentColor"
+        />
+      </symbol>
+    </svg>
+
+    <header>
+      <div class="idbar">
+        <a class="who" href="#top" style="border: none">
+          <svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+          <span class="wordmark">Setoku</span>
+        </a>
+        <nav class="meta">
+          <a class="label hideable" href="#g1">Galleries 1–6</a>
+          <a class="label hideable" href="#g5">Live viewings</a>
+          <a
+            class="label"
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >Source ↗</a
+          >
+        </nav>
+      </div>
+    </header>
+
+    <main id="top">
+      <!-- ===================== TITLE WALL ===================== -->
+      <section class="titlewall">
+        <div class="wrap">
+          <div class="exhib-kicker">
+            <span class="label">An Open Exhibition</span>
+            <span class="accession">MCP · Apache-2.0 · Self-hosted</span>
+            <span class="label">Admission Free</span>
+          </div>
+          <h1 class="title">
+            Make any AI fluent in your
+            <span
+              class="rotator"
+              data-words="company,family,personal"
+              ><span class="rotator-word">company</span
+              ><span class="rotator-measure" aria-hidden="true"></span></span>
+            data.
+          </h1>
+          <p class="wall-text">
+            Setoku is a small self-hosted MCP knowledge server + Claude Code
+            skills for hooking up your data. It does two things: it gives your
+            AI a read-only way to query your data, and it remembers what that
+            data means (the metric definitions, the gotchas), getting better the
+            more you use it. The MCP works with whatever AI you already have, and
+            no model runs on the server, so no added inference cost.
+          </p>
+          <div class="wall-credit">
+            <a
+              class="btn solid"
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              style="border: 1px solid var(--ink)"
+              >View on GitHub ↗</a
+            >
+            <a class="btn" href="#g5" style="border: 1px solid var(--ink)"
+              >Try the demo</a
+            >
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== GALLERY 1 · QUICKSTART ===================== -->
+      <section class="room" id="g1">
+        <div class="wrap">
+          <div class="room-head">
+            <div>
+              <div class="room-no">Gallery 1</div>
+              <h2 class="room-title">Quickstart</h2>
+            </div>
+            <div class="room-lede">
+              <span class="accession">Cat. 1.0 · Installation</span>
+              Setoku installs as a Claude Code plugin. Add the plugin, then run
+              onboarding from your main project directory, the codebase you want
+              Setoku to learn from.
+            </div>
+          </div>
+          <div class="didactic">
+            <pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+            <p>
+              Onboarding stands up the server, auths your Claude, wires your
+              database read-only, and generates the first knowledge from your
+              code. You stay in the loop for anything that touches your data. To
+              start onboarding, run <code>/setoku:onboard</code>.
+            </p>
+            <p>
+              You’ll need somewhere to host it. Something like OVH’s
+              <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener"
+                >VPS-2</a
+              >
+              is plenty.
+            </p>
+            <details class="manual">
+              <summary>Or stand up the server by hand</summary>
+              <pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+              <p style="margin-top: 12px; color: var(--ink-soft)">
+                Installs Docker, generates secrets, gets an HTTPS certificate,
+                and prints the connect command. Then add the plugin and run
+                /setoku:onboard from your project; it’ll detect the box you just
+                made.
+              </p>
+            </details>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== GALLERY 2 · HOW IT WORKS ===================== -->
+      <section class="room" id="g2">
+        <div class="wrap">
+          <div class="room-head">
+            <div>
+              <div class="room-no">Gallery 2</div>
+              <h2 class="room-title">How it works</h2>
+            </div>
+            <div class="room-lede">
+              <span class="accession">Cat. 2.0 · Three instruments</span>
+              Setoku gives the AI two kinds of MCP tools, and one rule: look up
+              what the data means before you touch it.
+            </div>
+          </div>
+          <div class="labels">
+            <div class="plate">
+              <div class="obj-no">2.1</div>
+              <h3>Context tools</h3>
+              <div class="medium">find_context · get_metric</div>
+              <p>
+                The AI reads what your data means first: canonical metric
+                definitions, entity docs, and the gotchas that make a naive
+                query wrong.
+              </p>
+            </div>
+            <div class="plate">
+              <div class="obj-no">2.2</div>
+              <h3>Read-only query</h3>
+              <div class="medium">get_schema · run_query</div>
+              <p>
+                Read-only, with a row cap, a statement timeout, a table
+                allow-list, and an append-only audit log. Enforced by the
+                database role, not by parsing SQL.
+              </p>
+            </div>
+            <div class="plate">
+              <div class="obj-no">2.3</div>
+              <h3>Human-approved</h3>
+              <div class="medium">report_correction</div>
+              <p>
+                The AI can only propose changes to what Setoku knows. A person
+                accepts them on the admin page, outside the agent loop, so an
+                injected session can’t rewrite the brain.
+              </p>
+            </div>
+          </div>
+          <p class="note" style="margin-top: 24px">
+            You set it up with <b>Claude Code</b> skills:
+          </p>
+          <ul class="uses">
+            <li>
+              <code>/setoku:onboard</code> sets Setoku up in a repo for the
+              first time.
+            </li>
+            <li>
+              <code>/setoku:connect</code> adds a data source or custom
+              integration.
+            </li>
+            <li>
+              <code>/setoku:generate</code> writes business context from your
+              code.
+            </li>
+            <li>
+              <code>/setoku:curate</code> reviews and approves pending
+              knowledge.
+            </li>
+          </ul>
+          <p class="note">
+            Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex,
+            or whatever you run. Just ask in plain language, and the tools do
+            the rest.
+          </p>
+        </div>
+      </section>
+
+      <!-- ===================== GALLERY 3 · APPS ===================== -->
+      <section class="room" id="g3">
+        <div class="wrap">
+          <div class="room-head">
+            <div>
+              <div class="room-no">Gallery 3</div>
+              <h2 class="room-title">
+                Apps: save and share the tools Claude builds you
+              </h2>
+            </div>
+            <div class="room-lede">
+              <span class="accession">Cat. 3.0 · Editioned works</span>
+              Ask Claude to build a dashboard on your data. Then publish it to a
+              link as a Setoku App, the data stays live, and your whole team can
+              view it. Nothing to deploy, no frontend to maintain.
+            </div>
+          </div>
+          <div class="labels">
+            <div class="plate">
+              <div class="obj-no">3.1</div>
+              <h3>Built by asking</h3>
+              <div class="medium">publish_app</div>
+              <p>
+                Describe it in plain language; the agent writes the app and
+                publishes it to a URL. Edit it the same way, just ask for the
+                change.
+              </p>
+            </div>
+            <div class="plate">
+              <div class="obj-no">3.2</div>
+              <h3>Backed by live data</h3>
+              <div class="medium">read-only</div>
+              <p>
+                Apps read through the same governed path: row caps, audit, a
+                SELECT-only database role. They never get write access to your
+                sources.
+              </p>
+            </div>
+            <div class="plate">
+              <div class="obj-no">3.3</div>
+              <h3>App-private state</h3>
+              <div class="medium">no writes to your data</div>
+              <p>
+                Each app keeps its own state (todos, votes, annotations) in a
+                sandbox that belongs to the app, not your database. Worst case,
+                an app messes up its own notes.
+              </p>
+            </div>
+            <div class="plate">
+              <div class="obj-no">3.4</div>
+              <h3>Share by link</h3>
+              <div class="medium">team or public</div>
+              <p>
+                A team link is login-gated; an admin can flip one public for a
+                credential-free URL. The page runs in a locked-down sandbox with
+                no network, so a published app can’t phone home.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== GALLERY 4 · ARCHITECTURE (central work) ===================== -->
+      <section class="room" id="g4">
+        <div class="wrap">
+          <div class="room-head">
+            <div>
+              <div class="room-no">Gallery 4</div>
+              <h2 class="room-title">Architecture</h2>
+            </div>
+            <div class="room-lede">
+              <span class="accession">Cat. 4.0 · The principal work</span>
+              You can host this on whatever infra you like. We put it all on one
+              small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+              helps you add custom integrations. Only the proxy is public, so
+              your databases aren’t exposed. Queries are read-only, and
+              knowledge changes pass through a person.
+            </div>
+          </div>
+
+          <div class="work">
+            <div class="frame">
+              <div class="mat">
+                <div class="diagram">
+                  <svg
+                    viewBox="0 0 680 520"
+                    role="img"
+                    aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake for analytics, and your sources (GitHub, Vercel, Render, Slack, Mercury) are ingested into the lake."
+                  >
+                    <defs>
+                      <marker
+                        id="ah"
+                        markerWidth="9"
+                        markerHeight="9"
+                        refX="6"
+                        refY="3"
+                        orient="auto-start-reverse"
+                      >
+                        <path d="M0 0 L6 3 L0 6 Z" fill="#6b695f" />
+                      </marker>
+                    </defs>
+                    <rect class="node" x="250" y="14" width="180" height="44" rx="10" />
+                    <text class="t" x="340" y="41" text-anchor="middle">
+                      You + your AI
+                    </text>
+                    <path
+                      class="arr"
+                      d="M340 58 L340 142"
+                      marker-start="url(#ah)"
+                      marker-end="url(#ah)"
+                    />
+                    <text class="e" x="348" y="86">MCP</text>
+                    <rect class="box" x="60" y="110" width="560" height="300" rx="14" />
+                    <text class="e" x="76" y="130" fill="#9a988c">your box</text>
+                    <rect class="node" x="250" y="146" width="180" height="58" rx="10" />
+                    <text class="t" x="340" y="171" text-anchor="middle">
+                      Setoku gateway
+                    </text>
+                    <text class="s" x="340" y="189" text-anchor="middle">
+                      context · query tools
+                    </text>
+                    <rect class="node" x="452" y="150" width="150" height="50" rx="10" />
+                    <text class="t" x="527" y="179" text-anchor="middle">a person</text>
+                    <rect class="node" x="92" y="322" width="180" height="66" rx="10" />
+                    <text class="t" x="182" y="350" text-anchor="middle">
+                      Lake (ClickHouse)
+                    </text>
+                    <text class="s" x="182" y="368" text-anchor="middle">
+                      logs · events · DB mirror
+                    </text>
+                    <rect class="node" x="408" y="322" width="190" height="66" rx="10" />
+                    <text class="t" x="503" y="359" text-anchor="middle">
+                      Knowledge store
+                    </text>
+                    <rect class="node" x="92" y="440" width="180" height="64" rx="10" />
+                    <text class="t" x="182" y="468" text-anchor="middle">
+                      Your sources
+                    </text>
+                    <text class="s" x="182" y="486" text-anchor="middle">
+                      GitHub · Vercel · Slack…
+                    </text>
+                    <rect class="node" x="300" y="440" width="180" height="64" rx="10" />
+                    <text class="t" x="390" y="468" text-anchor="middle">
+                      Your database
+                    </text>
+                    <text class="s" x="390" y="486" text-anchor="middle">
+                      Postgres · read-only
+                    </text>
+                    <path
+                      class="arr"
+                      d="M412 204 L508 322"
+                      marker-start="url(#ah)"
+                      marker-end="url(#ah)"
+                    />
+                    <text class="e" x="424" y="266" text-anchor="middle">reads ·</text>
+                    <text class="e" x="424" y="282" text-anchor="middle">proposes</text>
+                    <path class="arr" d="M527 200 L513 322" marker-end="url(#ah)" />
+                    <text class="e" x="534" y="262">approves</text>
+                    <path class="arr" d="M210 322 L300 204" marker-end="url(#ah)" />
+                    <path class="arr" d="M182 440 L182 388" marker-end="url(#ah)" />
+                    <text class="e" x="190" y="420">ingest</text>
+                    <path class="arr" d="M388 440 L366 206" marker-end="url(#ah)" />
+                    <text class="e" x="300" y="300">read-only</text>
+                  </svg>
+                </div>
+              </div>
+            </div>
+            <div class="work-label">
+              <span class="accession"
+                >Cat. 4.1 · Architecture and data flow · MCP over HTTPS ·
+                single VPS</span
+              >
+              <h3>Setoku, general arrangement</h3>
+              <p>
+                One <code>docker compose</code> on one box. Only the proxy faces
+                the internet; the databases never do. The person in the upper
+                right is load-bearing: authority changes pass through a human,
+                never through the agent loop.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== GALLERY 5 · CONNECTORS ===================== -->
+      <section class="room" id="connectors">
+        <div class="wrap">
+          <div class="room-head">
+            <div>
+              <div class="room-no">Gallery 5</div>
+              <h2 class="room-title">Connectors</h2>
+            </div>
+            <div class="room-lede">
+              <span class="accession">Cat. 5.0 · Catalogue of the collection</span>
+              Point Setoku at the data you already have. Every source lands in a
+              local
+              <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+                >ClickHouse</a
+              >
+              data lake, on purpose: agents write arbitrary queries (scans,
+              GROUP&nbsp;BYs, whole-table aggregations), and a columnar engine
+              answers those in about a second, so the apps and dashboards they
+              build stay quick. Your app database connects read-only and is
+              mirrored in on a cron; the rest is ingested as it happens.
+            </div>
+          </div>
+
+          <div class="catalogue">
+            <div class="cat-row">
+              <span class="n">5.1</span>
+              <span class="nm">PostgreSQL</span>
+              <span class="ds">App database, mirrored read-only</span>
+              <span class="md">Mirror · cron</span>
+            </div>
+            <div class="cat-row">
+              <span class="n">5.2</span>
+              <span class="nm">GitHub</span>
+              <span class="ds">Issues, PRs &amp; commits</span>
+              <span class="md">Ingest</span>
+            </div>
+            <div class="cat-row">
+              <span class="n">5.3</span>
+              <span class="nm">Vercel</span>
+              <span class="ds">Deploys &amp; logs</span>
+              <span class="md">Ingest</span>
+            </div>
+            <div class="cat-row">
+              <span class="n">5.4</span>
+              <span class="nm">Render</span>
+              <span class="ds">Deploys &amp; logs</span>
+              <span class="md">Ingest</span>
+            </div>
+            <div class="cat-row">
+              <span class="n">5.5</span>
+              <span class="nm">Slack</span>
+              <span class="ds">Messages</span>
+              <span class="md">Ingest</span>
+            </div>
+            <div class="cat-row">
+              <span class="n">5.6</span>
+              <span class="nm">Mercury</span>
+              <span class="ds">Banking &amp; finance</span>
+              <span class="md">Ingest</span>
+            </div>
+          </div>
+          <p class="note">
+            No connector for your source yet? The included setup skills give
+            your coding agent the patterns to wire one up itself. See
+            <a
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >the repo</a
+            >, or open an issue.
+          </p>
+        </div>
+      </section>
+
+      <!-- ===================== GALLERY 6 · DEMO (live viewings) ===================== -->
+      <section class="room" id="g5">
+        <div class="wrap">
+          <div class="room-head">
+            <div>
+              <div class="room-no">Gallery 6</div>
+              <h2 class="room-title">Try it on real-ish data</h2>
+            </div>
+            <div class="room-lede">
+              <span class="accession">Cat. 6.0 · Live viewings, on loan</span>
+              There’s a live demo wired to a fictional pro sports club, the
+              Bonita Bulldogs (ticketing, sponsorship, concessions, payroll,
+              broadcast rights).
+            </div>
+          </div>
+
+          <div class="step">
+            <div class="step-h">
+              <span class="step-n">6.1</span>
+              <h3>Connect to the demo MCP server</h3>
+            </div>
+            <p class="note" style="margin-top: 0">
+              In Claude (or any MCP client) open Settings → Connectors → Add
+              custom connector, and paste this URL. The token rides in the URL,
+              so there’s no separate key to enter.
+            </p>
+            <pre><code>https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</code></pre>
+          </div>
+
+          <div class="step">
+            <div class="step-h">
+              <span class="step-n">6.2</span>
+              <h3>Ask a question</h3>
+            </div>
+            <div class="exhibits">
+              <div class="exhibit">
+                <div class="q">“How many unique fans do we have?”</div>
+                <div class="figure">71,204</div>
+                <div class="curator">
+                  <b>Curator’s note</b>
+                  Deduped by normalized email, internal accounts excluded. Not
+                  the raw 92,118.
+                </div>
+              </div>
+              <div class="exhibit">
+                <div class="q">
+                  “What’s our total annual revenue, and how much is media
+                  rights?”
+                </div>
+                <div class="figure">$192M</div>
+                <div class="curator">
+                  <b>Curator’s note</b>
+                  Five systems reconciled to the same units. Media rights is the
+                  biggest line, ~$90M.
+                </div>
+              </div>
+              <div class="exhibit">
+                <div class="q">“What was ticket revenue this season?”</div>
+                <div class="figure">$46.8M</div>
+                <div class="curator">
+                  <b>Curator’s note</b>
+                  Cents reconciled to dollars; refunds, exchanges, and comps
+                  excluded.
+                </div>
+              </div>
+              <div class="exhibit">
+                <div class="q">“What’s our total merchandise revenue?”</div>
+                <div class="figure" style="font-size: clamp(22px, 3.4vw, 30px)">
+                  It flags it
+                </div>
+                <div class="curator">
+                  <b>Curator’s note</b>
+                  Most merch is sold via Fanatics, not in this data, so it says
+                  so instead of returning a wrong total.
+                </div>
+              </div>
+
+              <div class="exhibit wide">
+                <div class="q">“Chart revenue by line.”</div>
+                <div class="chart-cap">
+                  Annual revenue by line · ~$192M total
+                </div>
+                <div class="chart-wrap">
+                  <svg
+                    viewBox="0 0 640 214"
+                    role="img"
+                    aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M."
+                    style="width: 100%; height: auto"
+                  >
+                    <g fill="#5f7d63">
+                      <rect x="148" y="14" width="400" height="16" rx="2" />
+                      <rect x="148" y="48" width="209" height="16" rx="2" />
+                      <rect x="148" y="82" width="124" height="16" rx="2" />
+                      <rect x="148" y="116" width="62" height="16" rx="2" />
+                      <rect x="148" y="150" width="36" height="16" rx="2" />
+                      <rect x="148" y="184" width="22" height="16" rx="2" />
+                    </g>
+                    <g
+                      font-family="ui-sans-serif, system-ui, sans-serif"
+                      font-size="12.5"
+                      fill="#45443f"
+                    >
+                      <text x="8" y="26">Media rights</text>
+                      <text x="8" y="60">Ticketing</text>
+                      <text x="8" y="94">Sponsorship</text>
+                      <text x="8" y="128">Concessions</text>
+                      <text x="8" y="162">Merch</text>
+                      <text x="8" y="196">Other</text>
+                    </g>
+                    <g
+                      font-family="ui-monospace, Menlo, monospace"
+                      font-size="12"
+                      fill="#1c1c1a"
+                    >
+                      <text x="555" y="26">$90M</text>
+                      <text x="364" y="60">$47M</text>
+                      <text x="279" y="94">$28M</text>
+                      <text x="217" y="128">$14M</text>
+                      <text x="191" y="162">$8M</text>
+                      <text x="177" y="196">$5M</text>
+                    </g>
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="step">
+            <div class="step-h">
+              <span class="step-n">6.3</span>
+              <h3>Try an app</h3>
+            </div>
+            <p class="note" style="margin-top: 0">
+              Ask Claude to build a dashboard on the same data, then publish it
+              to a link. Two live examples, running on the demo data right now:
+            </p>
+            <ul class="uses">
+              <li>
+                <a
+                  href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+                  target="_blank"
+                  rel="noopener"
+                  >Sponsorship pricing table ↗</a
+                >
+                — inventory and rates for sponsorship placements.
+              </li>
+              <li>
+                <a
+                  href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+                  target="_blank"
+                  rel="noopener"
+                  >Fan lifetime value ↗</a
+                >
+                — segment fans by spend across tickets, merch, and concessions.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== ARTIST'S STATEMENT · WHY ===================== -->
+      <section class="room statement" id="why">
+        <div class="wrap">
+          <div class="room-head">
+            <div>
+              <div class="room-no">Curatorial statement</div>
+              <h2 class="room-title">Why we built it</h2>
+            </div>
+            <div class="room-lede">
+              <span class="accession">On the wall · Hedgy Labs</span>
+              Four notes on motive, in the makers’ own words.
+            </div>
+          </div>
+          <div class="didactic" style="max-width: none">
+            <h3>We’re curious.</h3>
+            <p>
+              There are plenty of AI memory stores, and plenty of data gateways.
+              Stapling the two together, and nudging the agent to gather
+              knowledge about the data as it goes, seemed useful and fun to
+              tinker with.
+            </p>
+            <h3>We’re cheap.</h3>
+            <p>
+              We wanted something that runs on one small box, works on a Pro/Max
+              subscription or a cheap model with no added inference cost, mostly
+              sets itself up (no field engineer to pay for), stays portable
+              between providers, and is open source.
+            </p>
+            <h3>We’re paranoid.</h3>
+            <p>
+              HR platforms, CRMs, and clouds are all announcing “context
+              layers.” They’d like the meaning of your business to accumulate on
+              their servers, where it can never leave. Context is deeper lock-in
+              than data, and a hosted context layer has no export button. Setoku
+              exists so that understanding accumulates on a box you own instead.
+              If we disappear tomorrow, your context doesn’t.
+            </p>
+            <h3>We and some friends wanted the same thing.</h3>
+            <ul class="uses">
+              <li>
+                <b
+                  ><a href="https://www.hedgy.works" target="_blank" rel="noopener"
+                    >Hedgy</a
+                  ></b
+                >: keep scaling without hiring. Debug from live logs and data,
+                find growth levers, and match candidates and companies better
+                with more data.
+              </li>
+              <li>
+                <b
+                  ><a href="https://baggu.com" target="_blank" rel="noopener"
+                    >Baggu</a
+                  ></b
+                >: give employees state-of-the-art tools. Faster onboarding, and
+                a safe way to vibecode against real data.
+              </li>
+              <li>
+                <b
+                  ><a href="https://tlon.io" target="_blank" rel="noopener"
+                    >Tlon</a
+                  ></b
+                >: experimenting with giving agents curated data to work from.
+              </li>
+              <li>
+                <b>Sports analysts</b>: query across data that doesn’t usually
+                sit together.
+              </li>
+              <li>
+                <b>Academic labs</b>: think through hypotheses against real
+                papers, data, and drafts.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== INFORMATION DESK · HELP ===================== -->
+      <section class="room" id="help">
+        <div class="wrap">
+          <div class="room-head">
+            <div>
+              <div class="room-no">Information desk</div>
+              <h2 class="room-title">Setup help</h2>
+            </div>
+            <div class="room-lede">
+              <span class="accession">Docent on request</span>
+              It’s open source, so you can self-host it today.
+            </div>
+          </div>
+          <div class="didactic">
+            <p>
+              If you like, we’re happy to help set it up. Just email
+              <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="wrap">
+        <div class="colo">
+          <a class="who" href="#top" style="border: none; display: flex; align-items: center; gap: 8px">
+            <svg class="mark" viewBox="0 0 64 64" style="width: 17px; height: 17px"><use href="#clover" /></svg>
+            <span class="wordmark">Setoku</span>
+          </a>
+          <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">GitHub</a>
+          <a href="#g5">Demo</a>
+          <a href="mailto:hello@setoku.com">Contact</a>
+          <span class="label" style="color: var(--ink-faint)">Apache-2.0</span>
+        </div>
+        <span class="jp">設 × 奥 · set (math) × oku (innermost)</span>
+      </div>
+    </footer>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) { return w.trim(); })
+          .filter(Boolean);
+        if (words.length < 2) return;
+
+        var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        var LIFT = "0.72em";
+        var HALF = 240;
+        var HOLD = 2400;
+        var i = 0;
+
+        function widthOf(w) {
+          measure.textContent = w;
+          return measure.getBoundingClientRect().width;
+        }
+        box.style.width = widthOf(words[0]) + "px";
+
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next;
+            box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length;
+            return;
+          }
+          word
+            .animate(
+              [
+                { transform: "translateY(0)", opacity: 1 },
+                { transform: "translateY(-" + LIFT + ")", opacity: 0 },
+              ],
+              { duration: HALF, easing: "cubic-bezier(0.4, 0, 1, 1)", fill: "forwards" }
+            )
+            .finished.then(function () {
+              word.textContent = next;
+              box.style.width = widthOf(next) + "px";
+              word.animate(
+                [
+                  { transform: "translateY(" + LIFT + ")", opacity: 0 },
+                  { transform: "translateY(0)", opacity: 1 },
+                ],
+                { duration: HALF, easing: "cubic-bezier(0, 0, 0.2, 1)", fill: "forwards" }
+              );
+              i = (i + 1) % words.length;
+            })
+            .catch(function () {});
+        }
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () {
+          box.style.width = widthOf(words[i]) + "px";
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/2-whitepaper.html
+++ b/site/riffs/2-whitepaper.html
@@ -1,0 +1,1469 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · A self-hosted context and query membrane for AI over company data</title>
+    <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
+    <meta
+      name="description"
+      content="Setoku is an open-source MCP server that gives your AI a read-only view of your company’s data, plus the context to use it correctly."
+    />
+    <style>
+      :root {
+        --paper: #faf7ef;
+        --paper-2: #f2ecdd;
+        --white: #fffdf7;
+        --ink: #1c211d;
+        --ink-soft: #3a423c;
+        --ink-faint: #565e57;
+        --rule: rgba(28, 33, 29, 0.24);
+        --rule-soft: rgba(28, 33, 29, 0.12);
+        --sage: #4f7a5c;
+        --sage-d: #33543d;
+        --serif: Charter, "Iowan Old Style", Iowan, "Palatino Linotype",
+          Palatino, "Book Antiqua", Georgia, serif;
+        --mono: "SF Mono", "SFMono-Regular", ui-monospace, "Cascadia Mono",
+          "DejaVu Sans Mono", Menlo, Consolas, monospace;
+        --measure: 720px;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+        scroll-behavior: smooth;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family: var(--serif);
+        font-size: 17.5px;
+        line-height: 1.58;
+        font-feature-settings: "kern" 1, "liga" 1, "onum" 1;
+      }
+      a {
+        color: var(--sage-d);
+        text-decoration: none;
+        border-bottom: 1px solid rgba(51, 84, 61, 0.35);
+      }
+      a:hover {
+        border-bottom-color: var(--sage-d);
+      }
+      sup {
+        font-size: 0.66em;
+        line-height: 0;
+      }
+      sup a {
+        border-bottom: none;
+      }
+      code,
+      kbd,
+      pre {
+        font-family: var(--mono);
+      }
+      ::selection {
+        background: rgba(79, 122, 92, 0.24);
+      }
+
+      /* running header */
+      .runhead {
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        background: color-mix(in srgb, var(--paper) 90%, transparent);
+        backdrop-filter: blur(6px);
+        border-bottom: 1px solid var(--rule);
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.04em;
+        color: var(--ink-faint);
+      }
+      .runhead .rh {
+        max-width: 1040px;
+        margin: 0 auto;
+        padding: 8px 40px;
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        text-transform: uppercase;
+      }
+      .runhead a {
+        color: var(--ink-faint);
+        border: none;
+      }
+      .runhead a:hover {
+        color: var(--ink);
+      }
+      .runhead .rh .right {
+        display: flex;
+        gap: 20px;
+      }
+      @media (max-width: 620px) {
+        .runhead .rh {
+          padding: 8px 20px;
+        }
+        .runhead .rh .right a.opt {
+          display: none;
+        }
+      }
+
+      .page {
+        max-width: var(--measure);
+        margin: 0 auto;
+        padding: 0 40px 40px;
+      }
+      @media (max-width: 620px) {
+        .page {
+          padding: 0 22px 32px;
+        }
+      }
+
+      /* title block */
+      .titleblock {
+        padding: 64px 0 30px;
+        border-bottom: 2px solid var(--ink);
+        text-align: center;
+      }
+      .desig {
+        font-family: var(--mono);
+        font-size: 11.5px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+      }
+      h1.doc-title {
+        font-weight: 700;
+        font-size: clamp(28px, 4.6vw, 40px);
+        line-height: 1.12;
+        letter-spacing: -0.012em;
+        margin: 18px auto 0;
+        max-width: 15em;
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        font-style: italic;
+        color: var(--sage-d);
+        transition: width 460ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+        will-change: transform, opacity;
+      }
+      .rotator-measure {
+        position: absolute;
+        left: 0;
+        top: 0;
+        visibility: hidden;
+        pointer-events: none;
+        white-space: nowrap;
+        font-style: italic;
+      }
+      .subtitle {
+        font-style: italic;
+        font-size: 18px;
+        color: var(--ink-soft);
+        margin: 14px auto 0;
+        max-width: 34em;
+      }
+      .byline {
+        margin-top: 22px;
+        font-size: 16px;
+      }
+      .byline .auth {
+        font-variant: small-caps;
+        letter-spacing: 0.04em;
+        font-size: 17px;
+      }
+      .byline .affil {
+        font-style: italic;
+        color: var(--ink-faint);
+        font-size: 14px;
+        margin-top: 3px;
+      }
+      .meta-line {
+        margin-top: 16px;
+        font-family: var(--mono);
+        font-size: 11.5px;
+        letter-spacing: 0.03em;
+        color: var(--ink-faint);
+      }
+      .meta-line a {
+        color: var(--ink-faint);
+        border-bottom-color: var(--rule);
+      }
+      .doi {
+        margin-top: 4px;
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--ink-faint);
+        letter-spacing: 0.02em;
+      }
+
+      /* abstract */
+      .abstract {
+        margin: 30px auto 8px;
+        max-width: 40em;
+        padding: 0 6px;
+      }
+      .abstract .lab {
+        text-align: center;
+        font-variant: small-caps;
+        letter-spacing: 0.12em;
+        font-size: 14px;
+        color: var(--ink);
+        font-weight: 700;
+        margin-bottom: 8px;
+      }
+      .abstract p {
+        font-size: 15.5px;
+        line-height: 1.55;
+        color: var(--ink-soft);
+      }
+      .kw {
+        margin-top: 12px;
+        font-size: 13.5px;
+        color: var(--ink-faint);
+        text-align: center;
+      }
+      .kw b {
+        font-variant: small-caps;
+        letter-spacing: 0.06em;
+        color: var(--ink);
+        font-weight: 700;
+      }
+
+      /* section headings */
+      section {
+        padding-top: 34px;
+        scroll-margin-top: 56px;
+      }
+      h2 {
+        font-size: 21px;
+        font-weight: 700;
+        letter-spacing: -0.005em;
+        margin-bottom: 4px;
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+      }
+      h2 .num {
+        font-family: var(--mono);
+        font-size: 15px;
+        font-weight: 500;
+        color: var(--sage-d);
+        flex: 0 0 auto;
+      }
+      h3.sub {
+        font-size: 16px;
+        font-weight: 700;
+        margin: 20px 0 2px;
+        display: flex;
+        align-items: baseline;
+        gap: 10px;
+      }
+      h3.sub .num {
+        font-family: var(--mono);
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--sage-d);
+      }
+      p {
+        margin-top: 10px;
+      }
+      p.lead {
+        margin-top: 8px;
+      }
+      strong,
+      b {
+        font-weight: 700;
+      }
+
+      /* two-column measure for dense prose */
+      .cols {
+        columns: 2;
+        column-gap: 34px;
+        margin-top: 12px;
+      }
+      .cols p {
+        margin-top: 0;
+        margin-bottom: 11px;
+        break-inside: avoid;
+        text-indent: 1.1em;
+      }
+      .cols p:first-child {
+        text-indent: 0;
+      }
+      .cols p:first-child::first-letter {
+        font-size: 3.1em;
+        line-height: 0.82;
+        float: left;
+        padding: 0.02em 0.08em 0 0;
+        font-weight: 700;
+      }
+      @media (max-width: 620px) {
+        .cols {
+          columns: 1;
+        }
+      }
+
+      /* footnotes-as-asides */
+      .fnrule {
+        margin: 26px 0 0;
+        border: 0;
+        border-top: 1px solid var(--rule);
+        width: 40%;
+      }
+      .footnotes {
+        margin-top: 8px;
+        font-size: 13px;
+        line-height: 1.5;
+        color: var(--ink-faint);
+      }
+      .footnotes p {
+        margin-top: 5px;
+      }
+      .footnotes .fnum {
+        font-family: var(--mono);
+        font-size: 11px;
+        vertical-align: super;
+        line-height: 0;
+        margin-right: 5px;
+      }
+
+      /* listing / code */
+      .listing {
+        margin: 16px 0;
+        background: var(--white);
+        border: 1px solid var(--rule);
+        border-left: 3px solid var(--rule);
+      }
+      .listing .cap {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.03em;
+        color: var(--ink-faint);
+        padding: 8px 16px;
+        border-bottom: 1px solid var(--rule-soft);
+        text-transform: uppercase;
+      }
+      pre {
+        overflow-x: auto;
+        padding: 14px 16px;
+      }
+      pre code {
+        font-size: 13px;
+        line-height: 1.75;
+        color: var(--ink);
+        white-space: pre;
+      }
+      pre code .c {
+        color: var(--ink-faint);
+        font-style: italic;
+      }
+      code.inl {
+        font-size: 0.82em;
+        background: var(--paper-2);
+        padding: 1px 5px;
+        border-radius: 3px;
+        color: var(--sage-d);
+      }
+      details.manual {
+        margin-top: 14px;
+      }
+      details.manual summary {
+        cursor: pointer;
+        font-style: italic;
+        font-size: 15px;
+        color: var(--sage-d);
+      }
+      details.manual summary:hover {
+        text-decoration: underline;
+      }
+      .note {
+        font-size: 14.5px;
+        color: var(--ink-soft);
+        margin-top: 12px;
+      }
+
+      /* figures */
+      figure {
+        margin: 22px 0 6px;
+        border: 1px solid var(--rule);
+        background: var(--white);
+      }
+      figure .frame {
+        padding: 18px 18px 8px;
+      }
+      figure svg {
+        width: 100%;
+        height: auto;
+        display: block;
+      }
+      figcaption {
+        font-size: 13.5px;
+        line-height: 1.45;
+        color: var(--ink-soft);
+        padding: 10px 18px 14px;
+        border-top: 1px solid var(--rule-soft);
+      }
+      figcaption b {
+        font-weight: 700;
+      }
+      .diagram .node {
+        fill: var(--white);
+        stroke: var(--ink);
+        stroke-width: 1.3;
+      }
+      .diagram .box {
+        fill: none;
+        stroke: var(--ink-faint);
+        stroke-width: 1.1;
+        stroke-dasharray: 4 5;
+      }
+      .diagram .t {
+        font-family: var(--serif);
+        font-size: 13px;
+        fill: var(--ink);
+      }
+      .diagram .s {
+        font-family: var(--serif);
+        font-style: italic;
+        font-size: 10.5px;
+        fill: var(--ink-soft);
+      }
+      .diagram .e {
+        font-family: var(--mono);
+        font-size: 10px;
+        fill: var(--ink-soft);
+      }
+      .diagram .arr {
+        stroke: var(--ink-soft);
+        stroke-width: 1.3;
+        fill: none;
+      }
+
+      /* definition-style tables (how it works, apps) */
+      .deftable {
+        margin-top: 14px;
+        border-top: 1px solid var(--ink);
+      }
+      .deftable .drow {
+        display: grid;
+        grid-template-columns: 210px 1fr;
+        gap: 22px;
+        padding: 13px 0;
+        border-bottom: 1px solid var(--rule-soft);
+        align-items: baseline;
+      }
+      .deftable .term {
+        font-weight: 700;
+        font-size: 15.5px;
+      }
+      .deftable .term .op {
+        display: block;
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--sage-d);
+        font-weight: 500;
+        margin-top: 4px;
+        letter-spacing: 0.01em;
+      }
+      .deftable .def {
+        color: var(--ink-soft);
+        font-size: 15px;
+      }
+      @media (max-width: 560px) {
+        .deftable .drow {
+          grid-template-columns: 1fr;
+          gap: 4px;
+        }
+      }
+
+      ol.skills,
+      ul.plain {
+        margin: 12px 0 0 1.4em;
+      }
+      ol.skills li,
+      ul.plain li {
+        margin-bottom: 7px;
+        color: var(--ink-soft);
+        font-size: 15px;
+        padding-left: 4px;
+      }
+      ul.plain li b,
+      ol.skills li b {
+        color: var(--ink);
+        font-weight: 700;
+      }
+
+      /* connectors register */
+      .register {
+        margin-top: 14px;
+        border: 1px solid var(--rule);
+        background: var(--white);
+      }
+      .register .rcap {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        padding: 9px 16px;
+        border-bottom: 1px solid var(--rule-soft);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .register .dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--sage);
+      }
+      .register table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14.5px;
+      }
+      .register td {
+        padding: 9px 16px;
+        border-top: 1px solid var(--rule-soft);
+        vertical-align: baseline;
+      }
+      .register td.src {
+        font-weight: 700;
+        width: 34%;
+        white-space: nowrap;
+      }
+      .register td.desc {
+        color: var(--ink-faint);
+        font-style: italic;
+      }
+
+      /* worked examples (demo) */
+      .example {
+        margin-top: 16px;
+        padding-top: 14px;
+        border-top: 1px solid var(--rule-soft);
+      }
+      .example .exlab {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--sage-d);
+      }
+      .example .q {
+        font-style: italic;
+        font-size: 16px;
+        color: var(--ink);
+        margin-top: 4px;
+      }
+      .example .a {
+        margin-top: 8px;
+        padding-left: 16px;
+        border-left: 2px solid var(--rule);
+      }
+      .example .a .val {
+        font-weight: 700;
+        font-size: 22px;
+        letter-spacing: -0.02em;
+      }
+      .example .a .exp {
+        display: block;
+        margin-top: 4px;
+        color: var(--ink-soft);
+        font-size: 14px;
+      }
+      .token {
+        display: block;
+        overflow-x: auto;
+        background: var(--white);
+        border: 1px solid var(--rule);
+        padding: 11px 14px;
+        margin-top: 10px;
+        font-family: var(--mono);
+        font-size: 12.5px;
+        color: var(--ink);
+      }
+
+      /* references / why */
+      .whyblock h3.sub {
+        font-style: italic;
+      }
+      .references {
+        margin-top: 12px;
+      }
+      .references .ref {
+        display: grid;
+        grid-template-columns: 32px 1fr;
+        gap: 6px;
+        font-size: 14.5px;
+        color: var(--ink-soft);
+        margin-bottom: 9px;
+        line-height: 1.45;
+      }
+      .references .ref .n {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        color: var(--ink-faint);
+      }
+      .references .ref b {
+        color: var(--ink);
+      }
+
+      /* colophon / footer */
+      footer {
+        margin-top: 46px;
+        border-top: 2px solid var(--ink);
+        padding-top: 18px;
+      }
+      .colophon {
+        display: flex;
+        justify-content: space-between;
+        gap: 18px;
+        flex-wrap: wrap;
+        align-items: baseline;
+        font-family: var(--mono);
+        font-size: 11.5px;
+        letter-spacing: 0.02em;
+        color: var(--ink-faint);
+      }
+      .colophon a {
+        color: var(--ink-soft);
+        border-bottom-color: var(--rule-soft);
+      }
+      .colophon .l {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+      .glyphmark {
+        margin-top: 26px;
+        text-align: center;
+        font-family: var(--serif);
+        font-size: 15px;
+        color: var(--ink-faint);
+        letter-spacing: 0.02em;
+        padding-bottom: 6px;
+      }
+      .glyphmark .cjk {
+        font-size: 30px;
+        color: var(--ink);
+        letter-spacing: 0.14em;
+        display: block;
+        margin-bottom: 6px;
+      }
+    </style>
+  </head>
+  <body id="top">
+    <div class="runhead">
+      <div class="rh">
+        <span>Setoku · Hedgy Labs · Technical Report HL&#8202;–&#8202;01</span>
+        <span class="right">
+          <a class="opt" href="#s2">Architecture</a>
+          <a class="opt" href="#s5">Evaluation</a>
+          <a
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >Source ↗</a
+          >
+        </span>
+      </div>
+    </div>
+
+    <main class="page">
+      <!-- TITLE BLOCK -->
+      <div class="titleblock">
+        <div class="desig">
+          Hedgy Labs · Technical Report · Open source (Apache&#8202;-&#8202;2.0)
+        </div>
+        <h1 class="doc-title">
+          Make any AI fluent in your <span
+            class="rotator"
+            data-words="company,family,personal"
+            ><span class="rotator-word">company</span
+            ><span class="rotator-measure" aria-hidden="true"></span></span>
+          data
+        </h1>
+        <div class="subtitle">
+          A self-hosted context and query membrane between your AI and the data
+          it is allowed to see
+        </div>
+        <div class="byline">
+          <div class="auth">Hedgy Labs</div>
+          <div class="affil">and friends who wanted the same thing</div>
+        </div>
+        <div class="meta-line">
+          Correspondence:
+          <a href="mailto:hello@setoku.com">hello@setoku.com</a> ·
+          <a
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >github.com/Hedgy-Labs/setoku</a
+          >
+        </div>
+        <div class="doi">MCP&#8202;/&#8202;streamable-http · no server-side inference · v1</div>
+      </div>
+
+      <!-- ABSTRACT -->
+      <div class="abstract">
+        <div class="lab">Abstract</div>
+        <p>
+          Setoku is a small self-hosted MCP knowledge server plus Claude Code
+          skills for hooking up your data. It does two things: it gives your AI
+          a read-only way to query your data, and it remembers what that data
+          means (the metric definitions, the gotchas), getting better the more
+          you use it.<sup><a href="#fn1" id="r1">1</a></sup> The MCP works with
+          whatever AI you already have, and no model runs on the server, so
+          there is no added inference cost.
+        </p>
+        <div class="kw">
+          <b>Keywords:</b> MCP · read-only query · curated context ·
+          human-in-the-loop · self-hosted · governed data access
+        </div>
+      </div>
+
+      <!-- 1. INSTALLATION -->
+      <section id="s1">
+        <h2><span class="num">1</span> Installation and first run</h2>
+        <p class="lead">
+          Setoku installs as a Claude Code plugin. Add the plugin, then run
+          onboarding from your main project directory, the codebase you want
+          Setoku to learn from.
+        </p>
+        <div class="listing">
+          <div class="cap">Listing 1 · plugin install and onboarding</div>
+          <pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+        </div>
+        <p>
+          Onboarding stands up the server, auths your Claude, wires your
+          database read-only, and generates the first knowledge from your code.
+          You stay in the loop for anything that touches your data. To start
+          onboarding, run <code class="inl">/setoku:onboard</code>.
+        </p>
+        <p>
+          You’ll need somewhere to host it. Something like OVH’s
+          <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener"
+            >VPS-2</a
+          >
+          is plenty.
+        </p>
+        <details class="manual">
+          <summary>Appendix A. Standing up the server by hand</summary>
+          <div class="listing" style="margin-top: 10px">
+            <div class="cap">Listing 2 · manual bootstrap on a fresh VPS</div>
+            <pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+          </div>
+          <p class="note">
+            Installs Docker, generates secrets, gets an HTTPS certificate, and
+            prints the connect command. Then add the plugin and run
+            <code class="inl">/setoku:onboard</code> from your project; it’ll
+            detect the box you just made.
+          </p>
+        </details>
+      </section>
+
+      <!-- 2. ARCHITECTURE -->
+      <section id="s2">
+        <h2><span class="num">2</span> System architecture</h2>
+        <p class="lead">
+          You can host this on whatever infra you like. We put it all on one
+          small box (a ~$12/mo VPS). The
+          <code class="inl">/setoku:connect</code> skill helps you add custom
+          integrations. Only the proxy is public, so your databases aren’t
+          exposed. Queries are read-only, and knowledge changes pass through a
+          person.
+        </p>
+
+        <figure class="diagram">
+          <div class="frame">
+            <svg
+              viewBox="0 0 680 520"
+              role="img"
+              aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake for analytics, and your sources (GitHub, Vercel, Render, Slack, Mercury) are ingested into the lake."
+            >
+              <defs>
+                <marker
+                  id="ah"
+                  markerWidth="9"
+                  markerHeight="9"
+                  refX="6"
+                  refY="3"
+                  orient="auto-start-reverse"
+                >
+                  <path d="M0 0 L6 3 L0 6 Z" fill="#565e57" />
+                </marker>
+              </defs>
+              <rect class="node" x="250" y="14" width="180" height="44" rx="4" />
+              <text class="t" x="340" y="41" text-anchor="middle">
+                You + your AI
+              </text>
+              <path
+                class="arr"
+                d="M340 58 L340 142"
+                marker-start="url(#ah)"
+                marker-end="url(#ah)"
+              />
+              <text class="e" x="348" y="86">MCP</text>
+              <rect class="box" x="60" y="110" width="560" height="300" rx="6" />
+              <text class="e" x="76" y="130" fill="#8E968C">your box</text>
+              <rect
+                class="node"
+                x="250"
+                y="146"
+                width="180"
+                height="58"
+                rx="4"
+              />
+              <text class="t" x="340" y="171" text-anchor="middle">
+                Setoku gateway
+              </text>
+              <text class="s" x="340" y="189" text-anchor="middle">
+                context · query tools
+              </text>
+              <rect
+                class="node"
+                x="452"
+                y="150"
+                width="150"
+                height="50"
+                rx="4"
+              />
+              <text class="t" x="527" y="179" text-anchor="middle">
+                a person
+              </text>
+              <rect class="node" x="92" y="322" width="180" height="66" rx="4" />
+              <text class="t" x="182" y="350" text-anchor="middle">
+                Lake (ClickHouse)
+              </text>
+              <text class="s" x="182" y="368" text-anchor="middle">
+                logs · events · DB mirror
+              </text>
+              <rect
+                class="node"
+                x="408"
+                y="322"
+                width="190"
+                height="66"
+                rx="4"
+              />
+              <text class="t" x="503" y="359" text-anchor="middle">
+                Knowledge store
+              </text>
+              <rect class="node" x="92" y="440" width="180" height="64" rx="4" />
+              <text class="t" x="182" y="468" text-anchor="middle">
+                Your sources
+              </text>
+              <text class="s" x="182" y="486" text-anchor="middle">
+                GitHub · Vercel · Slack…
+              </text>
+              <rect
+                class="node"
+                x="300"
+                y="440"
+                width="180"
+                height="64"
+                rx="4"
+              />
+              <text class="t" x="390" y="468" text-anchor="middle">
+                Your database
+              </text>
+              <text class="s" x="390" y="486" text-anchor="middle">
+                Postgres · read-only
+              </text>
+              <path
+                class="arr"
+                d="M412 204 L508 322"
+                marker-start="url(#ah)"
+                marker-end="url(#ah)"
+              />
+              <text class="e" x="424" y="266" text-anchor="middle">reads ·</text>
+              <text class="e" x="424" y="282" text-anchor="middle">proposes</text>
+              <path class="arr" d="M527 200 L513 322" marker-end="url(#ah)" />
+              <text class="e" x="534" y="262">approves</text>
+              <path class="arr" d="M210 322 L300 204" marker-end="url(#ah)" />
+              <path class="arr" d="M182 440 L182 388" marker-end="url(#ah)" />
+              <text class="e" x="190" y="420">ingest</text>
+              <path class="arr" d="M388 440 L366 206" marker-end="url(#ah)" />
+              <text class="e" x="300" y="300">read-only</text>
+            </svg>
+          </div>
+          <figcaption>
+            <b>Figure 1.</b> Setoku architecture and data flow. You and your AI
+            connect over MCP to the gateway on your box, which holds a ClickHouse
+            lake, a knowledge store, and a person who approves. Your Postgres
+            database is queried read-only and mirrored into the lake for
+            analytics; other sources are ingested as they happen. Everything runs
+            as one process group on a single VPS, and only the proxy faces the
+            internet.
+          </figcaption>
+        </figure>
+      </section>
+
+      <!-- 3. METHOD -->
+      <section id="s3">
+        <h2><span class="num">3</span> Method: two tool classes, one rule</h2>
+        <p class="lead">
+          Setoku gives the AI two kinds of MCP tools, and one rule: look up what
+          the data means before you touch it.
+        </p>
+        <div class="deftable">
+          <div class="drow">
+            <div class="term">
+              Context tools<span class="op">find_context · get_metric</span>
+            </div>
+            <div class="def">
+              The AI reads what your data means first: canonical metric
+              definitions, entity docs, and the gotchas that make a naive query
+              wrong.
+            </div>
+          </div>
+          <div class="drow">
+            <div class="term">
+              Read-only query<span class="op">get_schema · run_query</span>
+            </div>
+            <div class="def">
+              Read-only, with a row cap, a statement timeout, a table allow-list,
+              and an append-only audit log. Enforced by the database role, not by
+              parsing SQL.<sup><a href="#fn2" id="r2">2</a></sup>
+            </div>
+          </div>
+          <div class="drow">
+            <div class="term">
+              Human-approved<span class="op">report_correction</span>
+            </div>
+            <div class="def">
+              The AI can only propose changes to what Setoku knows. A person
+              accepts them on the admin page, outside the agent loop, so an
+              injected session can’t rewrite the brain.
+            </div>
+          </div>
+        </div>
+
+        <h3 class="sub"><span class="num">3.1</span> Setup skills</h3>
+        <p>You set it up with <b>Claude Code</b> skills:</p>
+        <ul class="plain">
+          <li>
+            <code class="inl">/setoku:onboard</code> sets Setoku up in a repo for
+            the first time.
+          </li>
+          <li>
+            <code class="inl">/setoku:connect</code> adds a data source or custom
+            integration.
+          </li>
+          <li>
+            <code class="inl">/setoku:generate</code> writes business context
+            from your code.
+          </li>
+          <li>
+            <code class="inl">/setoku:curate</code> reviews and approves pending
+            knowledge.
+          </li>
+        </ul>
+        <p class="note">
+          Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex, or
+          whatever you run. Just ask in plain language, and the tools do the
+          rest.
+        </p>
+      </section>
+
+      <!-- 4. APPS -->
+      <section id="s4">
+        <h2><span class="num">4</span> Apps: save and share the tools Claude builds you</h2>
+        <p class="lead">
+          Ask Claude to build a dashboard on your data. Then publish it to a link
+          as a Setoku App: the data stays live, and your whole team can view it.
+          Nothing to deploy, no frontend to maintain.
+        </p>
+        <div class="deftable">
+          <div class="drow">
+            <div class="term">
+              Built by asking<span class="op">publish_app</span>
+            </div>
+            <div class="def">
+              Describe it in plain language; the agent writes the app and
+              publishes it to a URL. Edit it the same way, just ask for the
+              change.
+            </div>
+          </div>
+          <div class="drow">
+            <div class="term">
+              Backed by live data<span class="op">read-only</span>
+            </div>
+            <div class="def">
+              Apps read through the same governed path: row caps, audit, a
+              SELECT-only database role. They never get write access to your
+              sources.
+            </div>
+          </div>
+          <div class="drow">
+            <div class="term">
+              App-private state<span class="op">no writes to your data</span>
+            </div>
+            <div class="def">
+              Each app keeps its own state (todos, votes, annotations) in a
+              sandbox that belongs to the app, not your database. Worst case, an
+              app messes up its own notes.
+            </div>
+          </div>
+          <div class="drow">
+            <div class="term">
+              Share by link<span class="op">team or public</span>
+            </div>
+            <div class="def">
+              A team link is login-gated; an admin can flip one public for a
+              credential-free URL. The page runs in a locked-down sandbox with no
+              network, so a published app can’t phone home.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 5. CONNECTORS -->
+      <section id="s5">
+        <h2><span class="num">5</span> Connectors and the data lake</h2>
+        <p class="lead">
+          Point Setoku at the data you already have. Every source lands in a
+          local
+          <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+            >ClickHouse</a
+          >
+          data lake, on purpose: agents write arbitrary queries (scans, GROUP
+          BYs, whole-table aggregations), and a columnar engine answers those in
+          about a second, so the apps and dashboards they build stay quick. Your
+          app database connects read-only and is mirrored in on a cron; the rest
+          is ingested as it happens.
+        </p>
+        <div class="register">
+          <div class="rcap"><span class="dot"></span>Table 1 · ClickHouse, one lake, every source</div>
+          <div style="overflow-x: auto">
+            <table>
+              <tr>
+                <td class="src">PostgreSQL</td>
+                <td class="desc">app database, mirrored read-only</td>
+              </tr>
+              <tr>
+                <td class="src">GitHub</td>
+                <td class="desc">issues, PRs &amp; commits</td>
+              </tr>
+              <tr>
+                <td class="src">Vercel</td>
+                <td class="desc">deploys &amp; logs</td>
+              </tr>
+              <tr>
+                <td class="src">Render</td>
+                <td class="desc">deploys &amp; logs</td>
+              </tr>
+              <tr>
+                <td class="src">Slack</td>
+                <td class="desc">messages</td>
+              </tr>
+              <tr>
+                <td class="src">Mercury</td>
+                <td class="desc">banking &amp; finance</td>
+              </tr>
+            </table>
+          </div>
+        </div>
+        <p class="note">
+          No connector for your source yet? The included setup skills give your
+          coding agent the patterns to wire one up itself. See
+          <a
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >the repo</a
+          >, or open an issue.
+        </p>
+      </section>
+
+      <!-- 6. EVALUATION / DEMO -->
+      <section id="s6">
+        <h2><span class="num">6</span> Evaluation on real-ish data</h2>
+        <p class="lead">
+          There’s a live demo wired to a fictional pro sports club, the Bonita
+          Bulldogs (ticketing, sponsorship, concessions, payroll, broadcast
+          rights).
+        </p>
+
+        <h3 class="sub"><span class="num">6.1</span> Connecting to the demo server</h3>
+        <p class="note">
+          In Claude (or any MCP client) open Settings → Connectors → Add custom
+          connector, and paste this URL. The token rides in the URL, so there’s
+          no separate key to enter.
+        </p>
+        <code class="token"
+          >https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</code
+        >
+
+        <h3 class="sub"><span class="num">6.2</span> Worked examples</h3>
+
+        <div class="example">
+          <div class="exlab">Example 1 · counting</div>
+          <div class="q">“How many unique fans do we have?”</div>
+          <div class="a">
+            <span class="val">71,204</span>
+            <span class="exp"
+              >deduped by normalized email, internal accounts excluded. Not the
+              raw 92,118.</span
+            >
+          </div>
+        </div>
+
+        <div class="example">
+          <div class="exlab">Example 2 · reconciliation across systems</div>
+          <div class="q">
+            “What’s our total annual revenue, and how much is media rights?”
+          </div>
+          <div class="a">
+            <span class="val">$192M</span>
+            <span class="exp"
+              >five systems reconciled to the same units. Media rights is the
+              biggest line, ~$90M.</span
+            >
+          </div>
+        </div>
+
+        <div class="example">
+          <div class="exlab">Example 3 · units and exclusions</div>
+          <div class="q">“What was ticket revenue this season?”</div>
+          <div class="a">
+            <span class="val">$46.8M</span>
+            <span class="exp"
+              >cents reconciled to dollars; refunds, exchanges, and comps
+              excluded.</span
+            >
+          </div>
+        </div>
+
+        <div class="example">
+          <div class="exlab">Example 4 · abstaining when out of scope</div>
+          <div class="q">“What’s our total merchandise revenue?”</div>
+          <div class="a">
+            <span class="val">It flags it</span>
+            <span class="exp"
+              >most merch is sold via Fanatics, not in this data, so it says so
+              instead of returning a wrong total.</span
+            >
+          </div>
+        </div>
+
+        <div class="example">
+          <div class="exlab">Example 5 · visualization</div>
+          <div class="q">“Chart revenue by line.”</div>
+          <div class="a">
+            <figure style="margin: 10px 0 0">
+              <div class="frame">
+                <div
+                  style="
+                    font-family: var(--mono);
+                    font-size: 11px;
+                    letter-spacing: 0.05em;
+                    text-transform: uppercase;
+                    color: var(--ink-faint);
+                    margin-bottom: 10px;
+                  "
+                >
+                  Annual revenue by line · ~$192M total
+                </div>
+                <svg
+                  viewBox="0 0 640 214"
+                  role="img"
+                  aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M."
+                >
+                  <g fill="#4f7a5c">
+                    <rect x="148" y="14" width="400" height="16" rx="1" />
+                    <rect x="148" y="48" width="209" height="16" rx="1" />
+                    <rect x="148" y="82" width="124" height="16" rx="1" />
+                    <rect x="148" y="116" width="62" height="16" rx="1" />
+                    <rect x="148" y="150" width="36" height="16" rx="1" />
+                    <rect x="148" y="184" width="22" height="16" rx="1" />
+                  </g>
+                  <g
+                    font-family="Charter, Georgia, serif"
+                    font-size="12.5"
+                    fill="#3a423c"
+                  >
+                    <text x="8" y="26">Media rights</text>
+                    <text x="8" y="60">Ticketing</text>
+                    <text x="8" y="94">Sponsorship</text>
+                    <text x="8" y="128">Concessions</text>
+                    <text x="8" y="162">Merch</text>
+                    <text x="8" y="196">Other</text>
+                  </g>
+                  <g
+                    font-family="ui-monospace, monospace"
+                    font-size="12"
+                    fill="#1c211d"
+                  >
+                    <text x="555" y="26">$90M</text>
+                    <text x="364" y="60">$47M</text>
+                    <text x="279" y="94">$28M</text>
+                    <text x="217" y="128">$14M</text>
+                    <text x="191" y="162">$8M</text>
+                    <text x="177" y="196">$5M</text>
+                  </g>
+                </svg>
+              </div>
+              <figcaption>
+                <b>Figure 2.</b> Annual revenue by line, reconciled across five
+                systems to the same units (~$192M total). Produced by the demo
+                agent in response to the plain-language prompt above.
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+
+        <h3 class="sub"><span class="num">6.3</span> Published apps on the demo data</h3>
+        <p class="note">
+          Ask Claude to build a dashboard on the same data, then publish it to a
+          link. Two live examples, running on the demo data right now:
+        </p>
+        <ul class="plain">
+          <li>
+            <a
+              href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+              target="_blank"
+              rel="noopener"
+              >Sponsorship pricing table ↗</a
+            >
+            — inventory and rates for sponsorship placements.
+          </li>
+          <li>
+            <a
+              href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+              target="_blank"
+              rel="noopener"
+              >Fan lifetime value ↗</a
+            >
+            — segment fans by spend across tickets, merch, and concessions.
+          </li>
+        </ul>
+      </section>
+
+      <!-- 7. MOTIVATION / WHY -->
+      <section id="s7" class="whyblock">
+        <h2><span class="num">7</span> Motivation</h2>
+
+        <h3 class="sub"><span class="num">7.1</span> We’re curious.</h3>
+        <div class="cols">
+          <p>
+            There are plenty of AI memory stores, and plenty of data gateways.
+            Stapling the two together, and nudging the agent to gather knowledge
+            about the data as it goes, seemed useful and fun to tinker with.
+          </p>
+          <p>
+            We wanted something that runs on one small box, works on a Pro/Max
+            subscription or a cheap model with no added inference cost, mostly
+            sets itself up (no field engineer to pay for), stays portable between
+            providers, and is open source. That last list is why we call
+            ourselves cheap.
+          </p>
+        </div>
+
+        <h3 class="sub"><span class="num">7.2</span> We’re paranoid.</h3>
+        <p>
+          HR platforms, CRMs, and clouds are all announcing “context layers.”
+          They’d like the meaning of your business to accumulate on their
+          servers, where it can never leave. Context is deeper lock-in than data,
+          and a hosted context layer has no export button. Setoku exists so that
+          understanding accumulates on a box you own instead. If we disappear
+          tomorrow, your context doesn’t.
+        </p>
+
+        <h3 class="sub"><span class="num">7.3</span> We and some friends wanted the same thing.</h3>
+        <div class="references">
+          <div class="ref">
+            <span class="n">[1]</span>
+            <span
+              ><b
+                ><a href="https://www.hedgy.works" target="_blank" rel="noopener"
+                  >Hedgy</a
+                ></b
+              >: keep scaling without hiring. Debug from live logs and data, find
+              growth levers, and match candidates and companies better with more
+              data.</span
+            >
+          </div>
+          <div class="ref">
+            <span class="n">[2]</span>
+            <span
+              ><b
+                ><a href="https://baggu.com" target="_blank" rel="noopener"
+                  >Baggu</a
+                ></b
+              >: give employees state-of-the-art tools. Faster onboarding, and a
+              safe way to vibecode against real data.</span
+            >
+          </div>
+          <div class="ref">
+            <span class="n">[3]</span>
+            <span
+              ><b
+                ><a href="https://tlon.io" target="_blank" rel="noopener"
+                  >Tlon</a
+                ></b
+              >: experimenting with giving agents curated data to work
+              from.</span
+            >
+          </div>
+          <div class="ref">
+            <span class="n">[4]</span>
+            <span
+              ><b>Sports analysts</b>: query across data that doesn’t usually sit
+              together.</span
+            >
+          </div>
+          <div class="ref">
+            <span class="n">[5]</span>
+            <span
+              ><b>Academic labs</b>: think through hypotheses against real papers,
+              data, and drafts.</span
+            >
+          </div>
+        </div>
+      </section>
+
+      <!-- 8. HELP -->
+      <section id="s8">
+        <h2><span class="num">8</span> Setup help</h2>
+        <p class="lead">
+          It’s open source, so you can self-host it today. If you like, we’re
+          happy to help set it up. Just email
+          <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+        </p>
+      </section>
+
+      <!-- FOOTNOTES -->
+      <hr class="fnrule" />
+      <div class="footnotes">
+        <p id="fn1">
+          <span class="fnum">1</span>The knowledge store is the load-bearing
+          idea: metric definitions, entity docs, and gotchas accumulate over
+          time, so answers improve with use rather than resetting each session.
+          <a href="#r1">↩</a>
+        </p>
+        <p id="fn2">
+          <span class="fnum">2</span>Access is enforced by the database engine
+          through per-role GRANTs, never by parsing SQL in our code. No model
+          runs on the server, so there is no added inference cost and nothing to
+          prompt-inject on the write path. <a href="#r2">↩</a>
+        </p>
+      </div>
+    </main>
+
+    <footer class="page">
+      <div class="colophon">
+        <div class="l">
+          <a href="#top">Setoku</a>
+          <a
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >GitHub</a
+          >
+          <a href="#s6">Demo</a>
+          <a href="mailto:hello@setoku.com">Contact</a>
+          <span>Apache-2.0</span>
+        </div>
+        <span>Set in Charter · Hedgy Labs · MMXXVI</span>
+      </div>
+      <div class="glyphmark">
+        <span class="cjk">設 × 奥</span>
+        set (math) × oku (innermost)
+      </div>
+    </footer>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) {
+            return w.trim();
+          })
+          .filter(Boolean);
+        if (words.length < 2) return;
+
+        var reduce = window.matchMedia(
+          "(prefers-reduced-motion: reduce)"
+        ).matches;
+        var LIFT = "0.6em";
+        var HALF = 240;
+        var HOLD = 2600;
+        var i = 0;
+
+        function widthOf(w) {
+          measure.textContent = w;
+          return measure.getBoundingClientRect().width;
+        }
+        box.style.width = widthOf(words[0]) + "px";
+
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next;
+            box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length;
+            return;
+          }
+          word
+            .animate(
+              [
+                { transform: "translateY(0)", opacity: 1 },
+                { transform: "translateY(-" + LIFT + ")", opacity: 0 },
+              ],
+              {
+                duration: HALF,
+                easing: "cubic-bezier(0.4, 0, 1, 1)",
+                fill: "forwards",
+              }
+            )
+            .finished.then(function () {
+              word.textContent = next;
+              box.style.width = widthOf(next) + "px";
+              word.animate(
+                [
+                  { transform: "translateY(" + LIFT + ")", opacity: 0 },
+                  { transform: "translateY(0)", opacity: 1 },
+                ],
+                {
+                  duration: HALF,
+                  easing: "cubic-bezier(0, 0, 0.2, 1)",
+                  fill: "forwards",
+                }
+              );
+              i = (i + 1) % words.length;
+            })
+            .catch(function () {});
+        }
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () {
+          box.style.width = widthOf(words[i]) + "px";
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/3-blueprint.html
+++ b/site/riffs/3-blueprint.html
@@ -1,0 +1,1670 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · drawing no. MCP-001 · open-source MCP server for company data</title>
+    <meta
+      name="description"
+      content="Setoku is an open-source MCP server that gives your AI a read-only view of your company’s data, plus the context to use it correctly."
+    />
+    <style>
+      :root {
+        --ground: #eef0ec;
+        --sheet: #f5f4ef;
+        --ink: #1f2b34;
+        --ink-soft: #3f4c55;
+        --ink-faint: #61707a;
+        --line: rgba(31, 43, 52, 0.24);
+        --line-soft: rgba(31, 43, 52, 0.12);
+        --grid-fine: rgba(31, 43, 52, 0.05);
+        --grid-coarse: rgba(31, 43, 52, 0.1);
+        --rev: #9a4636; /* drafting revision red, muted brick */
+        --sans: ui-sans-serif, -apple-system, "Segoe UI", Roboto, Helvetica,
+          Arial, sans-serif;
+        --mono: ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono",
+          monospace;
+        --w: 940px;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        scroll-behavior: smooth;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+      body {
+        background-color: var(--ground);
+        background-image: linear-gradient(var(--grid-fine) 1px, transparent 1px),
+          linear-gradient(90deg, var(--grid-fine) 1px, transparent 1px),
+          linear-gradient(var(--grid-coarse) 1px, transparent 1px),
+          linear-gradient(90deg, var(--grid-coarse) 1px, transparent 1px);
+        background-size: 22px 22px, 22px 22px, 110px 110px, 110px 110px;
+        color: var(--ink);
+        font-family: var(--sans);
+        font-size: 16px;
+        line-height: 1.62;
+      }
+      a {
+        color: var(--ink);
+        text-decoration: none;
+        border-bottom: 1px solid var(--line);
+      }
+      a:hover {
+        border-bottom-color: var(--ink);
+      }
+      svg {
+        display: block;
+      }
+      .mono {
+        font-family: var(--mono);
+      }
+
+      /* the drawing sheet */
+      .sheet {
+        max-width: var(--w);
+        margin: 26px auto;
+        background: var(--sheet);
+        border: 1.5px solid var(--ink);
+        box-shadow: 0 1px 0 var(--line), 3px 4px 0 rgba(31, 43, 52, 0.06);
+        position: relative;
+      }
+      /* inner drawing frame */
+      .frame {
+        border: 1px solid var(--line);
+        margin: 9px;
+      }
+      .pad {
+        padding: 26px 34px;
+      }
+      @media (max-width: 620px) {
+        .pad {
+          padding: 20px 18px;
+        }
+      }
+
+      /* title strip / running header */
+      .titlestrip {
+        display: flex;
+        justify-content: space-between;
+        align-items: stretch;
+        border-bottom: 1px solid var(--ink);
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        position: sticky;
+        top: 0;
+        background: var(--sheet);
+        z-index: 20;
+      }
+      .titlestrip .cell {
+        padding: 8px 14px;
+        border-right: 1px solid var(--line);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 2px;
+      }
+      .titlestrip .cell:last-child {
+        border-right: none;
+      }
+      .titlestrip .cap {
+        font-size: 8.5px;
+        color: var(--ink-faint);
+        letter-spacing: 0.12em;
+      }
+      .titlestrip .val {
+        color: var(--ink);
+        font-size: 12px;
+      }
+      .titlestrip .brand {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        border: none;
+        color: var(--ink);
+        font-size: 14px;
+        letter-spacing: 0.02em;
+      }
+      .titlestrip .brand:hover {
+        border: none;
+      }
+      .titlestrip .brand svg {
+        width: 19px;
+        height: 19px;
+      }
+      .titlestrip .grow {
+        flex: 1;
+      }
+      .navcell {
+        display: flex;
+        gap: 0;
+      }
+      .navcell a {
+        border: none;
+        border-left: 1px solid var(--line);
+        padding: 0 13px;
+        display: flex;
+        align-items: center;
+        color: var(--ink-soft);
+        font-size: 10.5px;
+      }
+      .navcell a:hover {
+        color: var(--ink);
+        background: rgba(31, 43, 52, 0.05);
+      }
+      @media (max-width: 760px) {
+        .titlestrip .hideable {
+          display: none;
+        }
+        .navcell a {
+          padding: 0 10px;
+        }
+      }
+
+      /* section = a numbered drawing block */
+      section {
+        border-top: 1px solid var(--line);
+        position: relative;
+      }
+      .sechead {
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
+        font-family: var(--mono);
+        letter-spacing: 0.04em;
+        margin-bottom: 6px;
+      }
+      .secno {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 30px;
+        height: 30px;
+        border: 1.4px solid var(--ink);
+        border-radius: 50%;
+        font-size: 12px;
+        color: var(--ink);
+        flex: none;
+      }
+      h2 {
+        font-family: var(--sans);
+        font-weight: 700;
+        font-size: 22px;
+        letter-spacing: -0.01em;
+        line-height: 1.15;
+      }
+      .figtag {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--rev);
+        border: 1px solid var(--rev);
+        padding: 1px 7px;
+        border-radius: 2px;
+        white-space: nowrap;
+      }
+      .lead {
+        color: var(--ink-soft);
+        max-width: 46em;
+        margin: 6px 0 4px;
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 0.85em;
+        background: rgba(31, 43, 52, 0.06);
+        border: 1px solid var(--line-soft);
+        padding: 1px 5px;
+        border-radius: 3px;
+        color: var(--ink);
+      }
+      ::selection {
+        background: var(--ink);
+        color: var(--sheet);
+      }
+
+      /* HERO */
+      .hero {
+        padding: 40px 34px 34px;
+        position: relative;
+      }
+      @media (max-width: 620px) {
+        .hero {
+          padding: 26px 18px;
+        }
+      }
+      .eyebrow {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        display: inline-flex;
+        gap: 10px;
+        align-items: center;
+      }
+      .eyebrow::before {
+        content: "";
+        width: 26px;
+        height: 1px;
+        background: var(--ink);
+      }
+      h1 {
+        font-family: var(--sans);
+        font-weight: 800;
+        font-size: clamp(32px, 5.4vw, 52px);
+        line-height: 1.04;
+        letter-spacing: -0.025em;
+        margin: 18px 0 0;
+        max-width: 15em;
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        color: var(--rev);
+        transition: width 480ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+        will-change: transform, opacity;
+        border-bottom: 2px solid rgba(154, 70, 54, 0.45);
+        padding-bottom: 0.02em;
+      }
+      .rotator-measure {
+        position: absolute;
+        left: 0;
+        top: 0;
+        visibility: hidden;
+        pointer-events: none;
+        white-space: nowrap;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .rotator {
+          transition: none;
+        }
+      }
+      .lede {
+        color: var(--ink-soft);
+        font-size: 17.5px;
+        margin-top: 20px;
+        max-width: 42em;
+      }
+      /* dimension line under the hero headline */
+      .dim {
+        display: flex;
+        align-items: center;
+        gap: 0;
+        margin-top: 22px;
+        color: var(--ink-faint);
+        font-family: var(--mono);
+        font-size: 10px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        max-width: 520px;
+      }
+      .dim .tick {
+        width: 1px;
+        height: 11px;
+        background: var(--ink-faint);
+        flex: none;
+      }
+      .dim .rule {
+        flex: 1;
+        height: 1px;
+        background: var(--ink-faint);
+      }
+      .dim .lbl {
+        padding: 0 10px;
+        white-space: nowrap;
+      }
+      .actions {
+        margin-top: 26px;
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--mono);
+        font-size: 12.5px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        padding: 10px 16px;
+        border: 1.4px solid var(--ink);
+        background: var(--ink);
+        color: var(--sheet);
+      }
+      .btn:hover {
+        background: var(--sheet);
+        color: var(--ink);
+      }
+      .btn.ghost {
+        background: transparent;
+        color: var(--ink);
+      }
+      .btn.ghost:hover {
+        background: var(--ink);
+        color: var(--sheet);
+      }
+
+      /* code blocks = procedure notes */
+      pre {
+        background: #fbfbf8;
+        border: 1px solid var(--line);
+        padding: 15px 17px;
+        overflow-x: auto;
+        margin: 15px 0;
+        position: relative;
+      }
+      pre::before {
+        content: "PROCEDURE";
+        position: absolute;
+        top: -1px;
+        right: -1px;
+        font-family: var(--mono);
+        font-size: 8.5px;
+        letter-spacing: 0.14em;
+        color: var(--ink-faint);
+        border: 1px solid var(--line);
+        border-top: none;
+        border-right: none;
+        padding: 2px 7px;
+        background: var(--sheet);
+      }
+      pre code {
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.85;
+        background: none;
+        border: none;
+        padding: 0;
+        color: var(--ink);
+        white-space: pre;
+      }
+      pre code .c {
+        color: var(--ink-faint);
+      }
+      .note {
+        font-size: 14.5px;
+        color: var(--ink-soft);
+        margin-top: 13px;
+        max-width: 46em;
+      }
+      details.manual {
+        margin-top: 16px;
+        border-top: 1px dashed var(--line);
+        padding-top: 10px;
+      }
+      details.manual summary {
+        cursor: pointer;
+        font-family: var(--mono);
+        font-size: 11.5px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+      }
+      details.manual summary:hover {
+        color: var(--ink);
+      }
+
+      /* detail boxes (how it works / apps) */
+      .details {
+        margin-top: 20px;
+        display: grid;
+        gap: 0;
+        border: 1px solid var(--line);
+      }
+      .drow {
+        display: grid;
+        grid-template-columns: 210px 1fr;
+        border-top: 1px solid var(--line);
+      }
+      .drow:first-child {
+        border-top: none;
+      }
+      .drow .k {
+        padding: 14px 16px;
+        border-right: 1px solid var(--line);
+        background: rgba(31, 43, 52, 0.03);
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+      }
+      .drow .k b {
+        font-weight: 700;
+        font-size: 14.5px;
+      }
+      .drow .k .t {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        letter-spacing: 0.03em;
+        color: var(--rev);
+      }
+      .drow .v {
+        padding: 14px 18px;
+        color: var(--ink-soft);
+        font-size: 15px;
+      }
+      @media (max-width: 560px) {
+        .drow {
+          grid-template-columns: 1fr;
+        }
+        .drow .k {
+          border-right: none;
+          border-bottom: 1px solid var(--line);
+        }
+      }
+      .uses {
+        list-style: none;
+        margin-top: 14px;
+        display: grid;
+        gap: 8px;
+      }
+      .uses li {
+        color: var(--ink-soft);
+        font-size: 15px;
+        line-height: 1.5;
+        padding-left: 22px;
+        position: relative;
+        max-width: 46em;
+      }
+      .uses li::before {
+        content: "▸";
+        position: absolute;
+        left: 2px;
+        color: var(--rev);
+        font-size: 11px;
+        top: 2px;
+      }
+      .uses b {
+        color: var(--ink);
+        font-weight: 700;
+      }
+
+      /* general arrangement drawing */
+      .ga {
+        margin-top: 18px;
+        border: 1px solid var(--line);
+        background: #fbfbf8;
+        padding: 10px;
+        overflow-x: auto;
+      }
+      .ga svg {
+        width: 100%;
+        min-width: 560px;
+        height: auto;
+        margin: 0 auto;
+      }
+      .ga .node {
+        fill: #fff;
+        stroke: var(--ink);
+        stroke-width: 1.3;
+      }
+      .ga .box {
+        fill: none;
+        stroke: var(--ink-faint);
+        stroke-width: 1;
+        stroke-dasharray: 5 4;
+      }
+      .ga .t {
+        font-family: var(--sans);
+        font-weight: 600;
+        font-size: 13px;
+        fill: var(--ink);
+      }
+      .ga .s {
+        font-family: var(--sans);
+        font-size: 10.5px;
+        fill: var(--ink-soft);
+      }
+      .ga .e {
+        font-family: var(--mono);
+        font-size: 10px;
+        fill: var(--ink-soft);
+        letter-spacing: 0.02em;
+      }
+      .ga .arr {
+        stroke: var(--ink-soft);
+        stroke-width: 1.3;
+        fill: none;
+      }
+      .ga .dimln {
+        stroke: var(--rev);
+        stroke-width: 0.8;
+        fill: none;
+      }
+      .ga .dimtx {
+        font-family: var(--mono);
+        font-size: 9.5px;
+        fill: var(--rev);
+        letter-spacing: 0.04em;
+      }
+      .ga .cno {
+        fill: #fff;
+        stroke: var(--rev);
+        stroke-width: 1.1;
+      }
+      .ga .cnt {
+        font-family: var(--mono);
+        font-size: 10px;
+        fill: var(--rev);
+        font-weight: 700;
+      }
+      .galegend {
+        margin-top: 12px;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+        gap: 6px 22px;
+        font-size: 12.5px;
+        color: var(--ink-soft);
+      }
+      .galegend .li {
+        display: flex;
+        gap: 9px;
+        align-items: baseline;
+      }
+      .galegend .n {
+        font-family: var(--mono);
+        color: var(--rev);
+        border: 1px solid var(--rev);
+        border-radius: 50%;
+        width: 18px;
+        height: 18px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 10px;
+        flex: none;
+      }
+
+      /* bill of materials (connectors) */
+      .bom {
+        margin-top: 18px;
+        width: 100%;
+        border-collapse: collapse;
+        border: 1px solid var(--ink);
+        font-size: 14px;
+      }
+      .bom caption {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        text-align: left;
+        padding: 8px 2px;
+      }
+      .bom th {
+        font-family: var(--mono);
+        font-size: 10px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        text-align: left;
+        padding: 8px 12px;
+        border-bottom: 1px solid var(--ink);
+        background: rgba(31, 43, 52, 0.03);
+      }
+      .bom td {
+        padding: 9px 12px;
+        border-bottom: 1px solid var(--line-soft);
+        vertical-align: top;
+        color: var(--ink-soft);
+      }
+      .bom tr:last-child td {
+        border-bottom: none;
+      }
+      .bom .item {
+        font-family: var(--mono);
+        color: var(--ink-faint);
+        white-space: nowrap;
+      }
+      .bom .part {
+        color: var(--ink);
+        font-weight: 600;
+      }
+      .bom .lakerow td {
+        background: rgba(154, 70, 54, 0.05);
+        color: var(--ink);
+        font-weight: 600;
+      }
+
+      /* demo detail views */
+      .step {
+        margin-top: 24px;
+        border: 1px solid var(--line);
+        background: #fbfbf8;
+      }
+      .step-h {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-family: var(--mono);
+        font-size: 12px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--ink);
+        padding: 11px 15px;
+        border-bottom: 1px solid var(--line);
+        background: rgba(31, 43, 52, 0.03);
+      }
+      .step-n {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+        border: 1.3px solid var(--ink);
+        border-radius: 50%;
+        font-size: 11px;
+        flex: none;
+      }
+      .step-body {
+        padding: 15px;
+      }
+      .examples {
+        display: grid;
+        gap: 12px;
+        margin-top: 4px;
+      }
+      .ex {
+        border: 1px solid var(--line);
+        display: grid;
+        grid-template-columns: 1fr;
+      }
+      .ex .q {
+        font-family: var(--mono);
+        font-size: 13px;
+        color: var(--ink);
+        padding: 11px 14px 6px;
+      }
+      .ex .a {
+        padding: 4px 14px 12px;
+        color: var(--ink-soft);
+        font-size: 14px;
+        display: flex;
+        gap: 10px;
+        align-items: baseline;
+        flex-wrap: wrap;
+      }
+      .ex .a b {
+        font-family: var(--sans);
+        font-weight: 800;
+        font-size: 20px;
+        color: var(--ink);
+        border-bottom: 2px solid var(--rev);
+        line-height: 1.1;
+      }
+      .ex .a span {
+        flex: 1;
+        min-width: 220px;
+      }
+      .chart {
+        border-top: 1px dashed var(--line);
+        margin-top: 4px;
+        padding: 12px 14px 14px;
+      }
+      .chart .cl {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        margin-bottom: 10px;
+      }
+      .chart svg {
+        width: 100%;
+        height: auto;
+      }
+
+      /* why */
+      .why h3 {
+        font-family: var(--sans);
+        font-weight: 700;
+        font-size: 16px;
+        margin: 22px 0 3px;
+        color: var(--ink);
+        display: flex;
+        align-items: baseline;
+        gap: 10px;
+      }
+      .why h3::before {
+        content: "REV";
+        font-family: var(--mono);
+        font-size: 9px;
+        letter-spacing: 0.1em;
+        color: var(--rev);
+        border: 1px solid var(--rev);
+        padding: 1px 5px;
+        border-radius: 2px;
+        position: relative;
+        top: -2px;
+      }
+      .why p {
+        color: var(--ink-soft);
+        max-width: 46em;
+      }
+
+      /* footer / title block */
+      footer {
+        border-top: 1.5px solid var(--ink);
+      }
+      .titleblock {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr 1fr;
+        border-top: 1px solid var(--line);
+      }
+      .titleblock .tb {
+        border-right: 1px solid var(--line);
+        padding: 12px 15px;
+      }
+      .titleblock .tb:last-child {
+        border-right: none;
+      }
+      .titleblock .cap {
+        font-family: var(--mono);
+        font-size: 8.5px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        margin-bottom: 4px;
+      }
+      .titleblock .val {
+        font-size: 13px;
+        color: var(--ink);
+      }
+      .titleblock .val a {
+        border: none;
+        color: var(--ink-soft);
+        display: inline-block;
+        margin-right: 12px;
+      }
+      .titleblock .val a:hover {
+        color: var(--ink);
+      }
+      .titleblock .jp {
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--ink-soft);
+      }
+      @media (max-width: 560px) {
+        .titleblock {
+          grid-template-columns: 1fr;
+        }
+        .titleblock .tb {
+          border-right: none;
+          border-bottom: 1px solid var(--line);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path
+          d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z"
+          fill="currentColor"
+        />
+      </symbol>
+      <marker
+        id="ah"
+        markerWidth="9"
+        markerHeight="9"
+        refX="6"
+        refY="3"
+        orient="auto-start-reverse"
+      >
+        <path d="M0 0 L6 3 L0 6 Z" fill="#3f4c55" />
+      </marker>
+    </svg>
+
+    <div class="sheet" id="top">
+      <div class="frame">
+        <!-- RUNNING TITLE STRIP -->
+        <div class="titlestrip">
+          <a class="cell brand" href="#top"
+            ><svg viewBox="0 0 64 64"><use href="#clover" /></svg> Setoku</a
+          >
+          <div class="cell hideable">
+            <span class="cap">Drawing no.</span
+            ><span class="val">MCP-001</span>
+          </div>
+          <div class="cell hideable">
+            <span class="cap">Rev.</span><span class="val">A · Apache-2.0</span>
+          </div>
+          <div class="grow"></div>
+          <div class="navcell">
+            <a class="hideable" href="#how">How</a>
+            <a class="hideable" href="#apps">Apps</a>
+            <a class="hideable" href="#connectors">Parts</a>
+            <a
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >GitHub ↗</a
+            >
+          </div>
+        </div>
+
+        <!-- HERO -->
+        <div class="hero">
+          <span class="eyebrow">Open source · MCP server · Apache-2.0</span>
+          <h1>
+            Make any AI fluent in your <span
+              class="rotator"
+              data-words="company,family,personal"
+              ><span class="rotator-word">company</span
+              ><span class="rotator-measure" aria-hidden="true"></span></span>
+            data.
+          </h1>
+          <div class="dim" aria-hidden="true">
+            <span class="tick"></span><span class="rule"></span
+            ><span class="lbl">1 small box</span><span class="rule"></span
+            ><span class="tick"></span>
+          </div>
+          <p class="lede">
+            Setoku is a small self-hosted MCP knowledge server + Claude Code
+            skills for hooking up your data. It does two things: it gives your AI
+            a read-only way to query your data, and it remembers what that data
+            means (the metric definitions, the gotchas), getting better the more
+            you use it. The MCP works with whatever AI you already have, and no
+            model runs on the server, so no added inference cost.
+          </p>
+          <div class="actions">
+            <a
+              class="btn"
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >View on GitHub ↗</a
+            >
+            <a class="btn ghost" href="#demo">Try the demo</a>
+          </div>
+        </div>
+
+        <!-- QUICKSTART -->
+        <section id="quickstart">
+          <div class="pad">
+            <div class="sechead">
+              <span class="secno">1</span>
+              <h2>Quickstart</h2>
+            </div>
+            <p class="lead">
+              Setoku installs as a Claude Code plugin. Add the plugin, then run
+              onboarding from your main project directory, the codebase you want
+              Setoku to learn from:
+            </p>
+            <pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+            <p class="note">
+              Onboarding stands up the server, auths your Claude, wires your
+              database read-only, and generates the first knowledge from your
+              code. You stay in the loop for anything that touches your data. To
+              start onboarding, run <code>/setoku:onboard</code>.
+            </p>
+            <p class="note">
+              You’ll need somewhere to host it. Something like OVH’s
+              <a
+                href="https://us.ovhcloud.com/vps/"
+                target="_blank"
+                rel="noopener"
+                >VPS-2</a
+              >
+              is plenty.
+            </p>
+            <details class="manual">
+              <summary>Or stand up the server by hand</summary>
+              <pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+              <p class="note">
+                Installs Docker, generates secrets, gets an HTTPS certificate,
+                and prints the connect command. Then add the plugin and run
+                /setoku:onboard from your project; it’ll detect the box you just
+                made.
+              </p>
+            </details>
+          </div>
+        </section>
+
+        <!-- HOW IT WORKS -->
+        <section id="how">
+          <div class="pad">
+            <div class="sechead">
+              <span class="secno">2</span>
+              <h2>How it works</h2>
+              <span class="figtag">Detail A</span>
+            </div>
+            <p class="lead">
+              Setoku gives the AI two kinds of MCP tools, and one rule: look up
+              what the data means before you touch it.
+            </p>
+            <div class="details">
+              <div class="drow">
+                <div class="k">
+                  <b>Context tools</b
+                  ><span class="t">find_context · get_metric</span>
+                </div>
+                <div class="v">
+                  The AI reads what your data means first: canonical metric
+                  definitions, entity docs, and the gotchas that make a naive
+                  query wrong.
+                </div>
+              </div>
+              <div class="drow">
+                <div class="k">
+                  <b>Read-only query</b
+                  ><span class="t">get_schema · run_query</span>
+                </div>
+                <div class="v">
+                  Read-only, with a row cap, a statement timeout, a table
+                  allow-list, and an append-only audit log. Enforced by the
+                  database role, not by parsing SQL.
+                </div>
+              </div>
+              <div class="drow">
+                <div class="k">
+                  <b>Human-approved</b
+                  ><span class="t">report_correction</span>
+                </div>
+                <div class="v">
+                  The AI can only propose changes to what Setoku knows. A person
+                  accepts them on the admin page, outside the agent loop, so an
+                  injected session can’t rewrite the brain.
+                </div>
+              </div>
+            </div>
+            <p class="note"><b>You set it up with Claude Code skills:</b></p>
+            <ul class="uses">
+              <li>
+                <code>/setoku:onboard</code> sets Setoku up in a repo for the
+                first time.
+              </li>
+              <li>
+                <code>/setoku:connect</code> adds a data source or custom
+                integration.
+              </li>
+              <li>
+                <code>/setoku:generate</code> writes business context from your
+                code.
+              </li>
+              <li>
+                <code>/setoku:curate</code> reviews and approves pending
+                knowledge.
+              </li>
+            </ul>
+            <p class="note">
+              Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex,
+              or whatever you run. Just ask in plain language, and the tools do
+              the rest.
+            </p>
+          </div>
+        </section>
+
+        <!-- APPS -->
+        <section id="apps">
+          <div class="pad">
+            <div class="sechead">
+              <span class="secno">3</span>
+              <h2>Apps: save and share the tools Claude builds you</h2>
+              <span class="figtag">Detail B</span>
+            </div>
+            <p class="lead">
+              Ask Claude to build a dashboard on your data. Then publish it to a
+              link as a Setoku App, the data stays live, and your whole team can
+              view it. Nothing to deploy, no frontend to maintain.
+            </p>
+            <div class="details">
+              <div class="drow">
+                <div class="k">
+                  <b>Built by asking</b><span class="t">publish_app</span>
+                </div>
+                <div class="v">
+                  Describe it in plain language; the agent writes the app and
+                  publishes it to a URL. Edit it the same way, just ask for the
+                  change.
+                </div>
+              </div>
+              <div class="drow">
+                <div class="k">
+                  <b>Backed by live data</b><span class="t">read-only</span>
+                </div>
+                <div class="v">
+                  Apps read through the same governed path: row caps, audit, a
+                  SELECT-only database role. They never get write access to your
+                  sources.
+                </div>
+              </div>
+              <div class="drow">
+                <div class="k">
+                  <b>App-private state</b
+                  ><span class="t">no writes to your data</span>
+                </div>
+                <div class="v">
+                  Each app keeps its own state (todos, votes, annotations) in a
+                  sandbox that belongs to the app, not your database. Worst case,
+                  an app messes up its own notes.
+                </div>
+              </div>
+              <div class="drow">
+                <div class="k">
+                  <b>Share by link</b><span class="t">team or public</span>
+                </div>
+                <div class="v">
+                  A team link is login-gated; an admin can flip one public for a
+                  credential-free URL. The page runs in a locked-down sandbox
+                  with no network, so a published app can’t phone home.
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- ARCHITECTURE -->
+        <section id="architecture">
+          <div class="pad">
+            <div class="sechead">
+              <span class="secno">4</span>
+              <h2>Architecture</h2>
+              <span class="figtag">Fig. 1 · General arrangement</span>
+            </div>
+            <p class="lead">
+              You can host this on whatever infra you like. We put it all on one
+              small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+              helps you add custom integrations. Only the proxy is public, so
+              your databases aren’t exposed. Queries are read-only, and knowledge
+              changes pass through a person.
+            </p>
+            <div class="ga">
+              <svg
+                viewBox="0 0 720 560"
+                role="img"
+                aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake for analytics, and your sources are ingested into the lake."
+              >
+                <!-- dimension line: overall box width -->
+                <path class="dimln" d="M60 96 L60 84 M660 96 L660 84" />
+                <path class="dimln" d="M60 90 L660 90" marker-start="url(#ah)" marker-end="url(#ah)" />
+                <text class="dimtx" x="360" y="82" text-anchor="middle">
+                  YOUR BOX · 1× VPS
+                </text>
+
+                <!-- you + your AI -->
+                <rect class="node" x="270" y="20" width="180" height="44" rx="8" />
+                <text class="t" x="360" y="47" text-anchor="middle">
+                  You + your AI
+                </text>
+                <path
+                  class="arr"
+                  d="M360 64 L360 152"
+                  marker-start="url(#ah)"
+                  marker-end="url(#ah)"
+                />
+                <text class="e" x="368" y="112">MCP</text>
+                <circle class="cno" cx="392" cy="108" r="9" />
+                <text class="cnt" x="392" y="111.5" text-anchor="middle">1</text>
+
+                <!-- the box -->
+                <rect class="box" x="60" y="100" width="600" height="320" rx="10" />
+
+                <rect class="node" x="270" y="156" width="180" height="58" rx="8" />
+                <text class="t" x="360" y="181" text-anchor="middle">
+                  Setoku gateway
+                </text>
+                <text class="s" x="360" y="199" text-anchor="middle">
+                  context · query tools
+                </text>
+                <circle class="cno" cx="284" cy="170" r="9" />
+                <text class="cnt" x="284" y="173.5" text-anchor="middle">2</text>
+
+                <rect class="node" x="486" y="160" width="150" height="50" rx="8" />
+                <text class="t" x="561" y="189" text-anchor="middle">
+                  A person
+                </text>
+                <circle class="cno" cx="500" cy="174" r="9" />
+                <text class="cnt" x="500" y="177.5" text-anchor="middle">3</text>
+
+                <rect class="node" x="96" y="330" width="184" height="66" rx="8" />
+                <text class="t" x="188" y="358" text-anchor="middle">
+                  Lake (ClickHouse)
+                </text>
+                <text class="s" x="188" y="376" text-anchor="middle">
+                  logs · events · DB mirror
+                </text>
+                <circle class="cno" cx="110" cy="344" r="9" />
+                <text class="cnt" x="110" y="347.5" text-anchor="middle">4</text>
+
+                <rect class="node" x="430" y="330" width="190" height="66" rx="8" />
+                <text class="t" x="525" y="367" text-anchor="middle">
+                  Knowledge store
+                </text>
+                <circle class="cno" cx="444" cy="344" r="9" />
+                <text class="cnt" x="444" y="347.5" text-anchor="middle">5</text>
+
+                <!-- external data below box -->
+                <rect class="node" x="96" y="466" width="184" height="66" rx="8" />
+                <text class="t" x="188" y="494" text-anchor="middle">
+                  Your sources
+                </text>
+                <text class="s" x="188" y="512" text-anchor="middle">
+                  GitHub · Vercel · Slack…
+                </text>
+                <circle class="cno" cx="110" cy="480" r="9" />
+                <text class="cnt" x="110" y="483.5" text-anchor="middle">6</text>
+
+                <rect class="node" x="430" y="466" width="190" height="66" rx="8" />
+                <text class="t" x="525" y="494" text-anchor="middle">
+                  Your database
+                </text>
+                <text class="s" x="525" y="512" text-anchor="middle">
+                  Postgres · read-only
+                </text>
+                <circle class="cno" cx="444" cy="480" r="9" />
+                <text class="cnt" x="444" y="483.5" text-anchor="middle">7</text>
+
+                <!-- flows -->
+                <path
+                  class="arr"
+                  d="M430 214 L520 330"
+                  marker-start="url(#ah)"
+                  marker-end="url(#ah)"
+                />
+                <text class="e" x="446" y="272" text-anchor="middle">reads ·</text>
+                <text class="e" x="446" y="286" text-anchor="middle">proposes</text>
+
+                <path class="arr" d="M561 210 L530 330" marker-end="url(#ah)" />
+                <text class="e" x="566" y="270">approves</text>
+
+                <path class="arr" d="M216 330 L318 214" marker-end="url(#ah)" />
+
+                <path class="arr" d="M188 466 L188 396" marker-end="url(#ah)" />
+                <text class="e" x="196" y="436">ingest</text>
+
+                <path class="arr" d="M470 466 L400 216" marker-end="url(#ah)" />
+                <text class="e" x="330" y="330">read-only</text>
+              </svg>
+            </div>
+            <div class="galegend">
+              <div class="li"><span class="n">1</span> You and your AI talk to the box over MCP.</div>
+              <div class="li"><span class="n">2</span> Gateway serves context + query tools.</div>
+              <div class="li"><span class="n">3</span> A person approves knowledge changes.</div>
+              <div class="li"><span class="n">4</span> ClickHouse lake: logs, events, DB mirror.</div>
+              <div class="li"><span class="n">5</span> Knowledge store: the durable brain.</div>
+              <div class="li"><span class="n">6</span> Sources ingested as they happen.</div>
+              <div class="li"><span class="n">7</span> App database, mirrored in read-only.</div>
+            </div>
+          </div>
+        </section>
+
+        <!-- CONNECTORS -->
+        <section id="connectors">
+          <div class="pad">
+            <div class="sechead">
+              <span class="secno">5</span>
+              <h2>Connectors</h2>
+              <span class="figtag">Bill of materials</span>
+            </div>
+            <p class="lead">
+              Point Setoku at the data you already have. Every source lands in a
+              local
+              <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+                >ClickHouse</a
+              >
+              data lake, on purpose: agents write arbitrary queries (scans,
+              GROUP BYs, whole-table aggregations), and a columnar engine answers
+              those in about a second, so the apps and dashboards they build stay
+              quick. Your app database connects read-only and is mirrored in on a
+              cron; the rest is ingested as it happens.
+            </p>
+            <table class="bom">
+              <caption>Parts list · one lake, every source</caption>
+              <thead>
+                <tr>
+                  <th>Item</th>
+                  <th>Part</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="lakerow">
+                  <td class="item">00</td>
+                  <td class="part">ClickHouse</td>
+                  <td>One lake, every source lands here</td>
+                </tr>
+                <tr>
+                  <td class="item">01</td>
+                  <td class="part">PostgreSQL</td>
+                  <td>App database, mirrored read-only</td>
+                </tr>
+                <tr>
+                  <td class="item">02</td>
+                  <td class="part">GitHub</td>
+                  <td>Issues, PRs &amp; commits</td>
+                </tr>
+                <tr>
+                  <td class="item">03</td>
+                  <td class="part">Vercel</td>
+                  <td>Deploys &amp; logs</td>
+                </tr>
+                <tr>
+                  <td class="item">04</td>
+                  <td class="part">Render</td>
+                  <td>Deploys &amp; logs</td>
+                </tr>
+                <tr>
+                  <td class="item">05</td>
+                  <td class="part">Slack</td>
+                  <td>Messages</td>
+                </tr>
+                <tr>
+                  <td class="item">06</td>
+                  <td class="part">Mercury</td>
+                  <td>Banking &amp; finance</td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="note">
+              No connector for your source yet? The included setup skills give
+              your coding agent the patterns to wire one up itself. See
+              <a
+                href="https://github.com/Hedgy-Labs/setoku"
+                target="_blank"
+                rel="noopener"
+                >the repo</a
+              >, or open an issue.
+            </p>
+          </div>
+        </section>
+
+        <!-- DEMO -->
+        <section id="demo">
+          <div class="pad">
+            <div class="sechead">
+              <span class="secno">6</span>
+              <h2>Try it on real-ish data</h2>
+              <span class="figtag">Detail views</span>
+            </div>
+            <p class="lead">
+              There’s a live demo wired to a fictional pro sports club, the
+              Bonita Bulldogs (ticketing, sponsorship, concessions, payroll,
+              broadcast rights).
+            </p>
+
+            <div class="step">
+              <div class="step-h">
+                <span class="step-n">1</span>Connect to the demo MCP server
+              </div>
+              <div class="step-body">
+                <p class="note" style="margin-top: 0">
+                  In Claude (or any MCP client) open Settings → Connectors → Add
+                  custom connector, and paste this URL. The token rides in the
+                  URL, so there’s no separate key to enter.
+                </p>
+                <pre><code>https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</code></pre>
+              </div>
+            </div>
+
+            <div class="step">
+              <div class="step-h"><span class="step-n">2</span>Ask a question</div>
+              <div class="step-body">
+                <div class="examples">
+                  <div class="ex">
+                    <div class="q">“How many unique fans do we have?”</div>
+                    <div class="a">
+                      <b>71,204</b>
+                      <span
+                        >deduped by normalized email, internal accounts
+                        excluded. Not the raw 92,118.</span
+                      >
+                    </div>
+                  </div>
+                  <div class="ex">
+                    <div class="q">
+                      “What’s our total annual revenue, and how much is media
+                      rights?”
+                    </div>
+                    <div class="a">
+                      <b>$192M</b>
+                      <span
+                        >five systems reconciled to the same units. Media rights
+                        is the biggest line, ~$90M.</span
+                      >
+                    </div>
+                  </div>
+                  <div class="ex">
+                    <div class="q">“What was ticket revenue this season?”</div>
+                    <div class="a">
+                      <b>$46.8M</b>
+                      <span
+                        >cents reconciled to dollars; refunds, exchanges, and
+                        comps excluded.</span
+                      >
+                    </div>
+                  </div>
+                  <div class="ex">
+                    <div class="q">“What’s our total merchandise revenue?”</div>
+                    <div class="a">
+                      <b>It flags it</b>
+                      <span
+                        >most merch is sold via Fanatics, not in this data, so
+                        it says so instead of returning a wrong total.</span
+                      >
+                    </div>
+                  </div>
+                  <div class="ex">
+                    <div class="q">“Chart revenue by line.”</div>
+                    <div class="a" style="display: block">
+                      <div class="chart">
+                        <div class="cl">
+                          Fig. 2 · Annual revenue by line · ~$192M total
+                        </div>
+                        <svg
+                          viewBox="0 0 640 236"
+                          role="img"
+                          aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M."
+                        >
+                          <!-- axis + ticks -->
+                          <line
+                            x1="148"
+                            y1="8"
+                            x2="148"
+                            y2="212"
+                            stroke="#61707a"
+                            stroke-width="1"
+                          />
+                          <g stroke="rgba(31,43,52,0.12)" stroke-width="1">
+                            <line x1="148" y1="8" x2="148" y2="212" />
+                            <line x1="238" y1="8" x2="238" y2="212" />
+                            <line x1="328" y1="8" x2="328" y2="212" />
+                            <line x1="418" y1="8" x2="418" y2="212" />
+                            <line x1="508" y1="8" x2="508" y2="212" />
+                          </g>
+                          <g fill="#1f2b34">
+                            <rect x="148" y="14" width="400" height="15" />
+                            <rect x="148" y="48" width="209" height="15" />
+                            <rect x="148" y="82" width="124" height="15" />
+                            <rect x="148" y="116" width="62" height="15" />
+                            <rect x="148" y="150" width="36" height="15" />
+                            <rect x="148" y="184" width="22" height="15" />
+                          </g>
+                          <g
+                            font-family="ui-sans-serif, system-ui, sans-serif"
+                            font-size="12.5"
+                            fill="#3f4c55"
+                          >
+                            <text x="8" y="26">Media rights</text>
+                            <text x="8" y="60">Ticketing</text>
+                            <text x="8" y="94">Sponsorship</text>
+                            <text x="8" y="128">Concessions</text>
+                            <text x="8" y="162">Merch</text>
+                            <text x="8" y="196">Other</text>
+                          </g>
+                          <g
+                            font-family="ui-monospace, monospace"
+                            font-size="12"
+                            fill="#9a4636"
+                          >
+                            <text x="555" y="26">$90M</text>
+                            <text x="364" y="60">$47M</text>
+                            <text x="279" y="94">$28M</text>
+                            <text x="217" y="128">$14M</text>
+                            <text x="191" y="162">$8M</text>
+                            <text x="177" y="196">$5M</text>
+                          </g>
+                          <g
+                            font-family="ui-monospace, monospace"
+                            font-size="9.5"
+                            fill="#61707a"
+                          >
+                            <text x="148" y="228" text-anchor="middle">0</text>
+                            <text x="238" y="228" text-anchor="middle">20</text>
+                            <text x="328" y="228" text-anchor="middle">40</text>
+                            <text x="418" y="228" text-anchor="middle">60</text>
+                            <text x="508" y="228" text-anchor="middle">80 ($M)</text>
+                          </g>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="step">
+              <div class="step-h"><span class="step-n">3</span>Try an app</div>
+              <div class="step-body">
+                <p class="note" style="margin-top: 0">
+                  Ask Claude to build a dashboard on the same data, then publish
+                  it to a link. Two live examples, running on the demo data right
+                  now:
+                </p>
+                <ul class="uses">
+                  <li>
+                    <a
+                      href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+                      target="_blank"
+                      rel="noopener"
+                      >Sponsorship pricing table ↗</a
+                    >
+                    — inventory and rates for sponsorship placements.
+                  </li>
+                  <li>
+                    <a
+                      href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+                      target="_blank"
+                      rel="noopener"
+                      >Fan lifetime value ↗</a
+                    >
+                    — segment fans by spend across tickets, merch, and
+                    concessions.
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- WHY -->
+        <section id="why" class="why">
+          <div class="pad">
+            <div class="sechead">
+              <span class="secno">7</span>
+              <h2>Why we built it</h2>
+              <span class="figtag">Design notes</span>
+            </div>
+            <h3>We’re curious.</h3>
+            <p>
+              There are plenty of AI memory stores, and plenty of data gateways.
+              Stapling the two together, and nudging the agent to gather
+              knowledge about the data as it goes, seemed useful and fun to
+              tinker with.
+            </p>
+            <h3>We’re cheap.</h3>
+            <p>
+              We wanted something that runs on one small box, works on a Pro/Max
+              subscription or a cheap model with no added inference cost, mostly
+              sets itself up (no field engineer to pay for), stays portable
+              between providers, and is open source.
+            </p>
+            <h3>We’re paranoid.</h3>
+            <p>
+              HR platforms, CRMs, and clouds are all announcing “context
+              layers.” They’d like the meaning of your business to accumulate on
+              their servers, where it can never leave. Context is deeper lock-in
+              than data, and a hosted context layer has no export button. Setoku
+              exists so that understanding accumulates on a box you own instead.
+              If we disappear tomorrow, your context doesn’t.
+            </p>
+            <h3>We and some friends wanted the same thing.</h3>
+            <ul class="uses">
+              <li>
+                <b><a href="https://www.hedgy.works" target="_blank" rel="noopener">Hedgy</a></b>: keep scaling without hiring. Debug from live
+                logs and data, find growth levers, and match candidates and
+                companies better with more data.
+              </li>
+              <li>
+                <b><a href="https://baggu.com" target="_blank" rel="noopener">Baggu</a></b>: give employees state-of-the-art tools. Faster
+                onboarding, and a safe way to vibecode against real data.
+              </li>
+              <li>
+                <b><a href="https://tlon.io" target="_blank" rel="noopener">Tlon</a></b>: experimenting with giving agents curated data to
+                work from.
+              </li>
+              <li>
+                <b>Sports analysts</b>: query across data that doesn’t usually
+                sit together.
+              </li>
+              <li>
+                <b>Academic labs</b>: think through hypotheses against real
+                papers, data, and drafts.
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <!-- SETUP HELP -->
+        <section id="help">
+          <div class="pad">
+            <div class="sechead">
+              <span class="secno">8</span>
+              <h2>Setup help</h2>
+            </div>
+            <p class="lead">
+              It’s open source, so you can self-host it today. If you like, we’re
+              happy to help set it up. Just email
+              <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+            </p>
+          </div>
+        </section>
+
+        <!-- FOOTER / TITLE BLOCK -->
+        <footer>
+          <div class="titleblock">
+            <div class="tb">
+              <div class="cap">Project</div>
+              <div class="val">
+                <a class="brand" href="#top">Setoku</a> · open-source MCP server
+              </div>
+            </div>
+            <div class="tb">
+              <div class="cap">Sheet index</div>
+              <div class="val">
+                <a
+                  href="https://github.com/Hedgy-Labs/setoku"
+                  target="_blank"
+                  rel="noopener"
+                  >GitHub</a
+                ><a href="#demo">Demo</a
+                ><a href="mailto:hello@setoku.com">Contact</a>
+              </div>
+            </div>
+            <div class="tb">
+              <div class="cap">Nomenclature</div>
+              <div class="val jp">設 × 奥 · set (math) × oku (innermost)</div>
+              <div class="cap" style="margin-top: 8px">License · Rev A</div>
+              <div class="val">Apache-2.0</div>
+            </div>
+          </div>
+        </footer>
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) {
+            return w.trim();
+          })
+          .filter(Boolean);
+        if (words.length < 2) return;
+
+        var reduce = window.matchMedia(
+          "(prefers-reduced-motion: reduce)"
+        ).matches;
+        var LIFT = "0.72em";
+        var HALF = 240;
+        var HOLD = 2400;
+        var i = 0;
+
+        function widthOf(w) {
+          measure.textContent = w;
+          return measure.getBoundingClientRect().width;
+        }
+
+        box.style.width = widthOf(words[0]) + "px";
+
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next;
+            box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length;
+            return;
+          }
+          word
+            .animate(
+              [
+                { transform: "translateY(0)", opacity: 1 },
+                { transform: "translateY(-" + LIFT + ")", opacity: 0 },
+              ],
+              {
+                duration: HALF,
+                easing: "cubic-bezier(0.4, 0, 1, 1)",
+                fill: "forwards",
+              }
+            )
+            .finished.then(function () {
+              word.textContent = next;
+              box.style.width = widthOf(next) + "px";
+              word.animate(
+                [
+                  { transform: "translateY(" + LIFT + ")", opacity: 0 },
+                  { transform: "translateY(0)", opacity: 1 },
+                ],
+                {
+                  duration: HALF,
+                  easing: "cubic-bezier(0, 0, 0.2, 1)",
+                  fill: "forwards",
+                }
+              );
+              i = (i + 1) % words.length;
+            })
+            .catch(function () {});
+        }
+
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () {
+          box.style.width = widthOf(words[i]) + "px";
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/4-spreadsheet.html
+++ b/site/riffs/4-spreadsheet.html
@@ -1,0 +1,1739 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · open-source MCP server for company data</title>
+    <meta
+      name="description"
+      content="Setoku is an open-source MCP server that gives your AI a read-only view of your company’s data, plus the context to use it correctly."
+    />
+    <style>
+      :root {
+        --paper: #ffffff;
+        --cream: #faf6ec;
+        --cream-2: #f1eadb;
+        --head-bg: #f4f0e5;
+        --ink: #212e26;
+        --ink-soft: #3f4a43;
+        --ink-faint: #6b716a;
+        --grid: rgba(33, 46, 38, 0.13);
+        --grid-soft: rgba(33, 46, 38, 0.055);
+        --sage: #5f8c6b;
+        --sage-d: #33543d;
+        --gut: 46px;
+        --cols: repeat(8, minmax(0, 1fr));
+        --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+          Arial, sans-serif;
+        --mono: "SF Mono", ui-monospace, "Menlo", "Consolas", monospace;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+        scroll-behavior: smooth;
+      }
+      body {
+        background: var(--cream-2);
+        color: var(--ink);
+        font-family: var(--sans);
+        font-size: 15px;
+        line-height: 1.62;
+        counter-reset: rownum;
+      }
+      a {
+        color: var(--sage-d);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+        text-underline-offset: 3px;
+      }
+      svg {
+        display: block;
+      }
+      code {
+        font-family: var(--mono);
+      }
+      ::selection {
+        background: var(--sage);
+        color: #fff;
+      }
+
+      /* ---- app frame ---- */
+      .app {
+        max-width: 1160px;
+        margin: 0 auto;
+        background: var(--paper);
+        min-height: 100vh;
+        border-left: 1px solid var(--grid);
+        border-right: 1px solid var(--grid);
+      }
+
+      /* sticky chrome: toolbar + formula bar + column header */
+      .chrome {
+        position: sticky;
+        top: 0;
+        z-index: 30;
+        background: var(--paper);
+      }
+      .toolbar {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 8px 14px;
+        background: var(--head-bg);
+        border-bottom: 1px solid var(--grid);
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        color: var(--ink);
+        font-weight: 700;
+        font-size: 16px;
+        letter-spacing: -0.02em;
+      }
+      .brand:hover {
+        text-decoration: none;
+      }
+      .brand .mark {
+        width: 20px;
+        height: 20px;
+        color: #1a1a19;
+      }
+      .menu {
+        display: flex;
+        gap: 15px;
+        font-size: 13px;
+        color: var(--ink-faint);
+      }
+      .menu span {
+        cursor: default;
+      }
+      .toolbar .spacer {
+        flex: 1;
+      }
+      .toolbar .gh {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--ink-soft);
+      }
+      .toolbar .share {
+        font-size: 13px;
+        font-weight: 600;
+        color: #fff;
+        background: var(--sage-d);
+        padding: 5px 12px;
+        border-radius: 6px;
+      }
+      .toolbar .share:hover {
+        text-decoration: none;
+        background: var(--ink);
+      }
+
+      /* formula bar */
+      .fbar {
+        display: flex;
+        align-items: stretch;
+        border-bottom: 1px solid var(--grid);
+        background: var(--paper);
+        height: 34px;
+      }
+      .namebox {
+        width: var(--gut);
+        min-width: var(--gut);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--ink-soft);
+        background: var(--head-bg);
+        border-right: 1px solid var(--grid);
+      }
+      .fx {
+        display: flex;
+        align-items: center;
+        padding: 0 12px;
+        font-style: italic;
+        font-family: "Times New Roman", Georgia, serif;
+        font-size: 15px;
+        color: var(--ink-faint);
+        border-right: 1px solid var(--grid);
+      }
+      .formula {
+        display: flex;
+        align-items: center;
+        padding: 0 12px;
+        font-family: var(--mono);
+        font-size: 13px;
+        color: var(--ink);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .formula .fn {
+        color: var(--sage-d);
+        font-weight: 600;
+      }
+      .formula .str {
+        color: var(--ink-soft);
+      }
+
+      /* column header */
+      .colhead {
+        display: grid;
+        grid-template-columns: var(--gut) var(--cols);
+        background: var(--head-bg);
+        border-bottom: 1px solid var(--grid);
+      }
+      .colhead .cc {
+        text-align: center;
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--ink-faint);
+        padding: 4px 0;
+        border-right: 1px solid var(--grid);
+      }
+      .colhead .corner {
+        position: relative;
+        border-right: 1px solid var(--grid);
+      }
+      .colhead .corner::after {
+        content: "";
+        position: absolute;
+        right: 4px;
+        bottom: 4px;
+        border-style: solid;
+        border-width: 0 0 8px 8px;
+        border-color: transparent transparent var(--ink-faint) transparent;
+        opacity: 0.55;
+      }
+
+      /* ---- grid body ---- */
+      .grid {
+        position: relative;
+      }
+      .grid::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: var(--gut);
+        right: 0;
+        background: repeating-linear-gradient(
+          to right,
+          var(--grid-soft),
+          var(--grid-soft) 1px,
+          transparent 1px,
+          transparent calc(100% / 8)
+        );
+        pointer-events: none;
+        z-index: 0;
+      }
+      .r {
+        position: relative;
+        z-index: 1;
+        display: grid;
+        grid-template-columns: var(--gut) var(--cols);
+      }
+      /* row-number gutter */
+      .g {
+        counter-increment: rownum;
+        background: var(--head-bg);
+        border-right: 1px solid var(--grid);
+        border-bottom: 1px solid var(--grid-soft);
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--ink-faint);
+        text-align: right;
+        padding: 8px 8px 0 0;
+      }
+      .g::before {
+        content: counter(rownum);
+      }
+      .g.blank {
+        counter-increment: none;
+      }
+      .g.blank::before {
+        content: "";
+      }
+      .c {
+        grid-column: 2 / -1;
+        border-right: 1px solid var(--grid-soft);
+        border-bottom: 1px solid var(--grid-soft);
+        padding: 12px 16px;
+        min-width: 0;
+      }
+      .c:last-child {
+        border-right: none;
+      }
+
+      /* cell text roles */
+      .eyebrow {
+        font-family: var(--mono);
+        font-size: 11.5px;
+        letter-spacing: 0.05em;
+        color: var(--sage-d);
+      }
+      .prose {
+        color: var(--ink-soft);
+        max-width: 46em;
+      }
+      .prose.tight {
+        padding-top: 4px;
+      }
+      .lead {
+        color: var(--ink-soft);
+        font-size: 16px;
+        max-width: 46em;
+      }
+      .sechead {
+        background: var(--cream);
+        border-bottom: 1px solid var(--grid);
+      }
+      .sechead h2 {
+        font-size: 21px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        color: var(--ink);
+      }
+      .subhead {
+        font-weight: 700;
+        font-size: 15px;
+        color: var(--ink);
+      }
+
+      /* selected cell (hero) */
+      .sel {
+        box-shadow: inset 0 0 0 2px var(--sage);
+        position: relative;
+        z-index: 2;
+      }
+      .sel::after {
+        content: "";
+        position: absolute;
+        right: -4px;
+        bottom: -4px;
+        width: 8px;
+        height: 8px;
+        background: var(--sage);
+        border: 1.5px solid #fff;
+        z-index: 3;
+      }
+      .hero {
+        padding: 30px 20px 34px;
+      }
+      h1 {
+        font-size: clamp(30px, 5vw, 47px);
+        line-height: 1.06;
+        font-weight: 800;
+        letter-spacing: -0.025em;
+        margin: 12px 0 0;
+        max-width: 15em;
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        color: var(--sage-d);
+        transition: width 460ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+        will-change: transform, opacity;
+        border-bottom: 0.06em solid rgba(51, 84, 61, 0.3);
+        padding-bottom: 0.02em;
+      }
+      .rotator-measure {
+        position: absolute;
+        left: 0;
+        top: 0;
+        visibility: hidden;
+        pointer-events: none;
+        white-space: nowrap;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .rotator {
+          transition: none;
+        }
+      }
+      .hero .lede {
+        color: var(--ink-soft);
+        font-size: 16.5px;
+        margin-top: 16px;
+        max-width: 44em;
+      }
+      .actions {
+        margin-top: 20px;
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        font-size: 14px;
+        font-weight: 600;
+        padding: 9px 15px;
+        border-radius: 7px;
+        border: 1px solid var(--ink);
+        background: var(--ink);
+        color: var(--cream);
+      }
+      .btn:hover {
+        background: var(--sage-d);
+        border-color: var(--sage-d);
+        text-decoration: none;
+      }
+      .btn.ghost {
+        background: transparent;
+        color: var(--ink);
+        border-color: var(--grid);
+      }
+      .btn.ghost:hover {
+        background: transparent;
+        border-color: var(--sage);
+        color: var(--sage-d);
+      }
+
+      /* key/value + table rows */
+      .kv .k {
+        grid-column: 2 / span 3;
+        border-right: 1px solid var(--grid-soft);
+        border-bottom: 1px solid var(--grid-soft);
+        padding: 12px 16px;
+        font-weight: 600;
+        color: var(--ink);
+      }
+      .kv .k .t {
+        display: block;
+        font-family: var(--mono);
+        font-size: 11.5px;
+        font-weight: 400;
+        color: var(--ink-faint);
+        margin-top: 3px;
+      }
+      .kv .v {
+        grid-column: 5 / -1;
+        border-bottom: 1px solid var(--grid-soft);
+        padding: 12px 16px;
+        color: var(--ink-soft);
+      }
+
+      /* connectors table */
+      .th .c,
+      .th .k,
+      .th .v {
+        background: var(--head-bg);
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        font-weight: 400;
+      }
+      .cx .src {
+        grid-column: 2 / span 2;
+        border-right: 1px solid var(--grid-soft);
+        border-bottom: 1px solid var(--grid-soft);
+        padding: 10px 16px;
+        font-weight: 600;
+        color: var(--ink);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--sage);
+        flex: none;
+      }
+      .cx .lands {
+        grid-column: 4 / span 4;
+        border-right: 1px solid var(--grid-soft);
+        border-bottom: 1px solid var(--grid-soft);
+        padding: 10px 16px;
+        color: var(--ink-soft);
+      }
+      .cx .mode {
+        grid-column: 8 / -1;
+        border-bottom: 1px solid var(--grid-soft);
+        padding: 10px 16px;
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--ink-faint);
+      }
+
+      /* code cells */
+      .codecell {
+        grid-column: 2 / -1;
+        border-bottom: 1px solid var(--grid-soft);
+        padding: 0;
+      }
+      pre {
+        background: var(--cream);
+        border: 1px solid var(--grid);
+        border-radius: 8px;
+        margin: 12px 16px;
+        padding: 14px 16px;
+        overflow-x: auto;
+      }
+      pre code {
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.75;
+        color: var(--ink);
+        white-space: pre;
+      }
+      pre code .c {
+        color: var(--ink-faint);
+      }
+      details.manual {
+        margin: 0 16px 14px;
+        font-size: 14px;
+      }
+      details.manual summary {
+        cursor: pointer;
+        color: var(--sage-d);
+        font-weight: 600;
+        padding: 2px 0;
+      }
+
+      /* object (diagram / chart) */
+      .object {
+        grid-column: 2 / -1;
+        border-bottom: 1px solid var(--grid-soft);
+        padding: 18px 16px 22px;
+      }
+      .objframe {
+        background: var(--paper);
+        border: 1px solid var(--grid);
+        border-radius: 10px;
+        box-shadow: 0 1px 0 rgba(33, 46, 38, 0.05),
+          0 8px 24px -14px rgba(33, 46, 38, 0.35);
+        padding: 16px 18px;
+        position: relative;
+      }
+      .objframe .otag {
+        position: absolute;
+        top: -9px;
+        left: 14px;
+        background: var(--head-bg);
+        border: 1px solid var(--grid);
+        border-radius: 5px;
+        font-family: var(--mono);
+        font-size: 10px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        padding: 2px 7px;
+      }
+      /* selection handles on an embedded object */
+      .objframe::before,
+      .objframe::after {
+        content: "";
+        position: absolute;
+        width: 7px;
+        height: 7px;
+        background: #fff;
+        border: 1.5px solid var(--sage);
+      }
+      .objframe::before {
+        left: -4px;
+        top: -4px;
+      }
+      .objframe::after {
+        right: -4px;
+        bottom: -4px;
+      }
+      .diagram svg {
+        width: 100%;
+        height: auto;
+      }
+      .diagram .node {
+        fill: #fff;
+        stroke: var(--ink);
+        stroke-width: 1.4;
+      }
+      .diagram .box {
+        fill: none;
+        stroke: var(--ink-faint);
+        stroke-width: 1.2;
+        stroke-dasharray: 4 5;
+      }
+      .diagram .t {
+        font-family: var(--sans);
+        font-size: 13px;
+        fill: var(--ink);
+      }
+      .diagram .s {
+        font-family: var(--sans);
+        font-size: 10.5px;
+        fill: var(--ink-soft);
+      }
+      .diagram .e {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        fill: var(--ink-soft);
+      }
+      .diagram .arr {
+        stroke: var(--ink-soft);
+        stroke-width: 1.4;
+        fill: none;
+      }
+      .cl {
+        font-family: var(--mono);
+        font-size: 11.5px;
+        color: var(--ink-faint);
+        margin-bottom: 10px;
+      }
+
+      /* demo Q&A */
+      .qa .q {
+        grid-column: 2 / span 4;
+        border-right: 1px solid var(--grid-soft);
+        border-bottom: 1px solid var(--grid-soft);
+        padding: 13px 16px;
+        color: var(--ink);
+        font-style: italic;
+      }
+      .qa .a {
+        grid-column: 6 / -1;
+        border-bottom: 1px solid var(--grid-soft);
+        padding: 13px 16px;
+        position: relative;
+      }
+      /* cell-comment triangle */
+      .a.note::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        right: 0;
+        border-style: solid;
+        border-width: 8px 8px 0 0;
+        border-color: var(--sage) transparent transparent transparent;
+      }
+      .a .val {
+        font-family: var(--mono);
+        font-weight: 700;
+        font-size: 17px;
+        color: var(--ink);
+        letter-spacing: -0.01em;
+      }
+      .a .cmt {
+        display: block;
+        margin-top: 6px;
+        font-size: 13px;
+        color: var(--ink-soft);
+        background: var(--cream);
+        border: 1px solid var(--grid);
+        border-left: 3px solid var(--sage);
+        border-radius: 0 6px 6px 6px;
+        padding: 7px 10px;
+        box-shadow: 1px 2px 6px -3px rgba(33, 46, 38, 0.4);
+        max-width: 30em;
+      }
+
+      .step-n {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        border-radius: 5px;
+        background: var(--ink);
+        color: var(--cream);
+        font-family: var(--mono);
+        font-size: 12px;
+        font-weight: 600;
+        margin-right: 9px;
+      }
+      .uses {
+        list-style: none;
+        display: grid;
+        gap: 8px;
+      }
+      .uses li {
+        color: var(--ink-soft);
+        padding-left: 16px;
+        position: relative;
+        max-width: 46em;
+      }
+      .uses li::before {
+        content: "–";
+        position: absolute;
+        left: 2px;
+        color: var(--ink-faint);
+      }
+      .uses b {
+        color: var(--ink);
+        font-weight: 600;
+      }
+      .token {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        color: var(--sage-d);
+        word-break: break-all;
+      }
+
+      /* ---- sheet tab bar + status ---- */
+      .tabbar {
+        position: sticky;
+        bottom: 0;
+        z-index: 25;
+        display: flex;
+        align-items: stretch;
+        background: var(--head-bg);
+        border-top: 1px solid var(--grid);
+        border-bottom: 1px solid var(--grid);
+        font-size: 12.5px;
+      }
+      .tabs {
+        display: flex;
+        overflow-x: auto;
+        scrollbar-width: none;
+      }
+      .tabs::-webkit-scrollbar {
+        display: none;
+      }
+      .tab {
+        white-space: nowrap;
+        padding: 7px 14px;
+        color: var(--ink-faint);
+        border-right: 1px solid var(--grid);
+        background: var(--cream-2);
+      }
+      .tab:hover {
+        text-decoration: none;
+        color: var(--ink);
+      }
+      .tab.active {
+        background: var(--paper);
+        color: var(--ink);
+        font-weight: 600;
+        box-shadow: inset 0 2px 0 var(--sage);
+      }
+      .tab.plus {
+        color: var(--ink-faint);
+        font-family: var(--mono);
+      }
+      .status {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 0 14px;
+        font-family: var(--mono);
+        font-size: 11.5px;
+        color: var(--ink-faint);
+        white-space: nowrap;
+      }
+      .status .rdy::before {
+        content: "";
+        display: inline-block;
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--sage);
+        margin-right: 6px;
+        vertical-align: middle;
+      }
+
+      footer {
+        padding: 18px 16px 28px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px 18px;
+        align-items: center;
+        font-size: 13px;
+        color: var(--ink-faint);
+        background: var(--paper);
+      }
+      footer a {
+        color: var(--ink-soft);
+      }
+      footer .jp {
+        margin-left: auto;
+        font-family: var(--mono);
+        font-size: 11.5px;
+      }
+
+      /* ---- mobile: collapse the grid to a single stacked column ---- */
+      @media (max-width: 700px) {
+        :root {
+          --gut: 30px;
+        }
+        .grid::before {
+          display: none;
+        }
+        .menu,
+        .fx {
+          display: none;
+        }
+        .formula {
+          font-size: 12px;
+        }
+        .colhead .cc {
+          display: none;
+        }
+        .r {
+          grid-template-columns: var(--gut) 1fr;
+        }
+        .c,
+        .kv .k,
+        .kv .v,
+        .cx .src,
+        .cx .lands,
+        .cx .mode,
+        .qa .q,
+        .qa .a,
+        .codecell,
+        .object {
+          grid-column: 2 / -1 !important;
+          border-right: none !important;
+        }
+        .a.note::before {
+          display: none;
+        }
+        footer .jp {
+          margin-left: 0;
+          width: 100%;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path
+          d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z"
+          fill="currentColor"
+        />
+      </symbol>
+    </svg>
+
+    <div class="app" id="top">
+      <div class="chrome">
+        <div class="toolbar">
+          <a class="brand" href="#top"
+            ><svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+            Setoku</a
+          >
+          <nav class="menu" aria-hidden="true">
+            <span>File</span><span>Edit</span><span>View</span
+            ><span>Insert</span><span>Data</span>
+          </nav>
+          <span class="spacer"></span>
+          <a
+            class="gh"
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >GitHub ↗</a
+          >
+          <a class="share" href="#demo">Try the demo</a>
+        </div>
+        <div class="fbar">
+          <div class="namebox">A1</div>
+          <div class="fx">fx</div>
+          <div class="formula">
+            <span>=</span><span class="fn">SETOKU</span>(<span class="str"
+              >“make any AI fluent in your company data”</span
+            >)
+          </div>
+        </div>
+        <div class="colhead" aria-hidden="true">
+          <div class="corner"></div>
+          <div class="cc">A</div>
+          <div class="cc">B</div>
+          <div class="cc">C</div>
+          <div class="cc">D</div>
+          <div class="cc">E</div>
+          <div class="cc">F</div>
+          <div class="cc">G</div>
+          <div class="cc">H</div>
+        </div>
+      </div>
+
+      <main class="grid">
+        <!-- OVERVIEW -->
+        <section id="overview">
+          <div class="r">
+            <div class="g"></div>
+            <div class="c hero sel">
+              <span class="eyebrow"
+                >Open source · MCP server · Apache-2.0</span
+              >
+              <h1>
+                Make any AI fluent in your
+                <span
+                  class="rotator"
+                  data-words="company,family,personal"
+                  ><span class="rotator-word">company</span
+                  ><span class="rotator-measure" aria-hidden="true"></span></span>
+                data.
+              </h1>
+              <p class="lede">
+                Setoku is a small self-hosted MCP knowledge server + Claude Code
+                skills for hooking up your data. It does two things: it gives
+                your AI a read-only way to query your data, and it remembers what
+                that data means (the metric definitions, the gotchas), getting
+                better the more you use it. The MCP works with whatever AI you
+                already have, and no model runs on the server, so no added
+                inference cost.
+              </p>
+              <div class="actions">
+                <a
+                  class="btn"
+                  href="https://github.com/Hedgy-Labs/setoku"
+                  target="_blank"
+                  rel="noopener"
+                  >View on GitHub ↗</a
+                >
+                <a class="btn ghost" href="#demo">Try the demo</a>
+              </div>
+            </div>
+          </div>
+
+          <!-- QUICKSTART -->
+          <div class="r">
+            <div class="g"></div>
+            <div class="c sechead"><h2>Quickstart</h2></div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c prose">
+              Setoku installs as a Claude Code plugin. Add the plugin, then run
+              onboarding from your main project directory, the codebase you want
+              Setoku to learn from:
+            </div>
+          </div>
+          <div class="r">
+            <div class="g blank"></div>
+            <div class="codecell">
+              <pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+            </div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c prose">
+              Onboarding stands up the server, auths your Claude, wires your
+              database read-only, and generates the first knowledge from your
+              code. You stay in the loop for anything that touches your data. To
+              start onboarding, run <code>/setoku:onboard</code>.
+            </div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c prose">
+              You’ll need somewhere to host it. Something like OVH’s
+              <a
+                href="https://us.ovhcloud.com/vps/"
+                target="_blank"
+                rel="noopener"
+                >VPS-2</a
+              >
+              is plenty.
+            </div>
+          </div>
+          <div class="r">
+            <div class="g blank"></div>
+            <div class="codecell">
+              <details class="manual">
+                <summary>Or stand up the server by hand</summary>
+                <pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+                <p style="margin-top: 10px; color: var(--ink-soft)">
+                  Installs Docker, generates secrets, gets an HTTPS certificate,
+                  and prints the connect command. Then add the plugin and run
+                  /setoku:onboard from your project; it’ll detect the box you
+                  just made.
+                </p>
+              </details>
+            </div>
+          </div>
+        </section>
+
+        <!-- HOW IT WORKS -->
+        <section id="how">
+          <div class="r">
+            <div class="g"></div>
+            <div class="c sechead"><h2>How it works</h2></div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c lead">
+              Setoku gives the AI two kinds of MCP tools, and one rule: look up
+              what the data means before you touch it.
+            </div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k">
+              Context tools<span class="t">find_context · get_metric</span>
+            </div>
+            <div class="v">
+              The AI reads what your data means first: canonical metric
+              definitions, entity docs, and the gotchas that make a naive query
+              wrong.
+            </div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k">
+              Read-only query<span class="t">get_schema · run_query</span>
+            </div>
+            <div class="v">
+              Read-only, with a row cap, a statement timeout, a table allow-list,
+              and an append-only audit log. Enforced by the database role, not by
+              parsing SQL.
+            </div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k">
+              Human-approved<span class="t">report_correction</span>
+            </div>
+            <div class="v">
+              The AI can only propose changes to what Setoku knows. A person
+              accepts them on the admin page, outside the agent loop, so an
+              injected session can’t rewrite the brain.
+            </div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c prose">
+              You set it up with <b>Claude Code</b> skills:
+            </div>
+          </div>
+          <div class="r kv th">
+            <div class="g"></div>
+            <div class="k">Skill</div>
+            <div class="v">What it does</div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k"><code>/setoku:onboard</code></div>
+            <div class="v">Sets Setoku up in a repo for the first time.</div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k"><code>/setoku:connect</code></div>
+            <div class="v">Adds a data source or custom integration.</div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k"><code>/setoku:generate</code></div>
+            <div class="v">Writes business context from your code.</div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k"><code>/setoku:curate</code></div>
+            <div class="v">Reviews and approves pending knowledge.</div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c prose">
+              Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex,
+              or whatever you run. Just ask in plain language, and the tools do
+              the rest.
+            </div>
+          </div>
+        </section>
+
+        <!-- APPS -->
+        <section id="apps">
+          <div class="r">
+            <div class="g"></div>
+            <div class="c sechead">
+              <h2>Apps: save and share the tools Claude builds you</h2>
+            </div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c lead">
+              Ask Claude to build a dashboard on your data. Then publish it to a
+              link as a Setoku App, the data stays live, and your whole team can
+              view it. Nothing to deploy, no frontend to maintain.
+            </div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k">
+              Built by asking<span class="t">publish_app</span>
+            </div>
+            <div class="v">
+              Describe it in plain language; the agent writes the app and
+              publishes it to a URL. Edit it the same way, just ask for the
+              change.
+            </div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k">
+              Backed by live data<span class="t">read-only</span>
+            </div>
+            <div class="v">
+              Apps read through the same governed path: row caps, audit, a
+              SELECT-only database role. They never get write access to your
+              sources.
+            </div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k">
+              App-private state<span class="t">no writes to your data</span>
+            </div>
+            <div class="v">
+              Each app keeps its own state (todos, votes, annotations) in a
+              sandbox that belongs to the app, not your database. Worst case, an
+              app messes up its own notes.
+            </div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k">
+              Share by link<span class="t">team or public</span>
+            </div>
+            <div class="v">
+              A team link is login-gated; an admin can flip one public for a
+              credential-free URL. The page runs in a locked-down sandbox with no
+              network, so a published app can’t phone home.
+            </div>
+          </div>
+        </section>
+
+        <!-- ARCHITECTURE -->
+        <section id="architecture">
+          <div class="r">
+            <div class="g"></div>
+            <div class="c sechead"><h2>Architecture</h2></div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c lead">
+              You can host this on whatever infra you like. We put it all on one
+              small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+              helps you add custom integrations. Only the proxy is public, so
+              your databases aren’t exposed. Queries are read-only, and knowledge
+              changes pass through a person.
+            </div>
+          </div>
+          <div class="r">
+            <div class="g blank"></div>
+            <div class="object diagram">
+              <div class="objframe">
+                <span class="otag">Figure · Object</span>
+                <svg
+                  viewBox="0 0 680 520"
+                  role="img"
+                  aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake for analytics, and your sources (GitHub, Vercel, Render, Slack, Mercury) are ingested into the lake."
+                >
+                  <defs>
+                    <marker
+                      id="ah"
+                      markerWidth="9"
+                      markerHeight="9"
+                      refX="6"
+                      refY="3"
+                      orient="auto-start-reverse"
+                    >
+                      <path d="M0 0 L6 3 L0 6 Z" fill="#54615A" />
+                    </marker>
+                  </defs>
+                  <rect class="node" x="250" y="14" width="180" height="44" rx="10" />
+                  <text class="t" x="340" y="41" text-anchor="middle">
+                    You + your AI
+                  </text>
+                  <path
+                    class="arr"
+                    d="M340 58 L340 142"
+                    marker-start="url(#ah)"
+                    marker-end="url(#ah)"
+                  />
+                  <text class="e" x="348" y="86">MCP</text>
+                  <rect class="box" x="60" y="110" width="560" height="300" rx="14" />
+                  <text class="e" x="76" y="130" fill="#8E968C">your box</text>
+                  <rect class="node" x="250" y="146" width="180" height="58" rx="10" />
+                  <text class="t" x="340" y="171" text-anchor="middle">
+                    Setoku gateway
+                  </text>
+                  <text class="s" x="340" y="189" text-anchor="middle">
+                    context · query tools
+                  </text>
+                  <rect class="node" x="452" y="150" width="150" height="50" rx="10" />
+                  <text class="t" x="527" y="179" text-anchor="middle">a person</text>
+                  <rect class="node" x="92" y="322" width="180" height="66" rx="10" />
+                  <text class="t" x="182" y="350" text-anchor="middle">
+                    Lake (ClickHouse)
+                  </text>
+                  <text class="s" x="182" y="368" text-anchor="middle">
+                    logs · events · DB mirror
+                  </text>
+                  <rect class="node" x="408" y="322" width="190" height="66" rx="10" />
+                  <text class="t" x="503" y="359" text-anchor="middle">
+                    Knowledge store
+                  </text>
+                  <rect class="node" x="92" y="440" width="180" height="64" rx="10" />
+                  <text class="t" x="182" y="468" text-anchor="middle">
+                    Your sources
+                  </text>
+                  <text class="s" x="182" y="486" text-anchor="middle">
+                    GitHub · Vercel · Slack…
+                  </text>
+                  <rect class="node" x="300" y="440" width="180" height="64" rx="10" />
+                  <text class="t" x="390" y="468" text-anchor="middle">
+                    Your database
+                  </text>
+                  <text class="s" x="390" y="486" text-anchor="middle">
+                    Postgres · read-only
+                  </text>
+                  <path
+                    class="arr"
+                    d="M412 204 L508 322"
+                    marker-start="url(#ah)"
+                    marker-end="url(#ah)"
+                  />
+                  <text class="e" x="424" y="266" text-anchor="middle">reads ·</text>
+                  <text class="e" x="424" y="282" text-anchor="middle">proposes</text>
+                  <path class="arr" d="M527 200 L513 322" marker-end="url(#ah)" />
+                  <text class="e" x="534" y="262">approves</text>
+                  <path class="arr" d="M210 322 L300 204" marker-end="url(#ah)" />
+                  <path class="arr" d="M182 440 L182 388" marker-end="url(#ah)" />
+                  <text class="e" x="190" y="420">ingest</text>
+                  <path class="arr" d="M388 440 L366 206" marker-end="url(#ah)" />
+                  <text class="e" x="300" y="300">read-only</text>
+                </svg>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- CONNECTORS -->
+        <section id="connectors">
+          <div class="r">
+            <div class="g"></div>
+            <div class="c sechead"><h2>Connectors</h2></div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c lead">
+              Point Setoku at the data you already have. Every source lands in a
+              local
+              <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+                >ClickHouse</a
+              >
+              data lake, on purpose: agents write arbitrary queries (scans,
+              GROUP&nbsp;BYs, whole-table aggregations), and a columnar engine
+              answers those in about a second, so the apps and dashboards they
+              build stay quick. Your app database connects read-only and is
+              mirrored in on a cron; the rest is ingested as it happens.
+            </div>
+          </div>
+          <div class="r cx th">
+            <div class="g"></div>
+            <div class="src">Source</div>
+            <div class="lands">What lands in the lake</div>
+            <div class="mode">Mode</div>
+          </div>
+          <div class="r cx">
+            <div class="g"></div>
+            <div class="src"><span class="dot"></span>PostgreSQL</div>
+            <div class="lands">App database</div>
+            <div class="mode">mirrored read-only</div>
+          </div>
+          <div class="r cx">
+            <div class="g"></div>
+            <div class="src"><span class="dot"></span>GitHub</div>
+            <div class="lands">Issues, PRs &amp; commits</div>
+            <div class="mode">ingested</div>
+          </div>
+          <div class="r cx">
+            <div class="g"></div>
+            <div class="src"><span class="dot"></span>Vercel</div>
+            <div class="lands">Deploys &amp; logs</div>
+            <div class="mode">ingested</div>
+          </div>
+          <div class="r cx">
+            <div class="g"></div>
+            <div class="src"><span class="dot"></span>Render</div>
+            <div class="lands">Deploys &amp; logs</div>
+            <div class="mode">ingested</div>
+          </div>
+          <div class="r cx">
+            <div class="g"></div>
+            <div class="src"><span class="dot"></span>Slack</div>
+            <div class="lands">Messages</div>
+            <div class="mode">ingested</div>
+          </div>
+          <div class="r cx">
+            <div class="g"></div>
+            <div class="src"><span class="dot"></span>Mercury</div>
+            <div class="lands">Banking &amp; finance</div>
+            <div class="mode">ingested</div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c prose">
+              No connector for your source yet? The included setup skills give
+              your coding agent the patterns to wire one up itself. See
+              <a
+                href="https://github.com/Hedgy-Labs/setoku"
+                target="_blank"
+                rel="noopener"
+                >the repo</a
+              >, or open an issue.
+            </div>
+          </div>
+        </section>
+
+        <!-- DEMO -->
+        <section id="demo">
+          <div class="r">
+            <div class="g"></div>
+            <div class="c sechead"><h2>Try it on real-ish data</h2></div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c lead">
+              There’s a live demo wired to a fictional pro sports club, the
+              Bonita Bulldogs (ticketing, sponsorship, concessions, payroll,
+              broadcast rights).
+            </div>
+          </div>
+
+          <div class="r">
+            <div class="g"></div>
+            <div class="c">
+              <div class="subhead">
+                <span class="step-n">1</span>Connect to the demo MCP server
+              </div>
+              <p class="prose" style="margin-top: 8px">
+                In Claude (or any MCP client) open Settings → Connectors → Add
+                custom connector, and paste this URL. The token rides in the URL,
+                so there’s no separate key to enter.
+              </p>
+              <p class="token" style="margin-top: 10px">
+                https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9
+              </p>
+            </div>
+          </div>
+
+          <div class="r">
+            <div class="g"></div>
+            <div class="c">
+              <div class="subhead"><span class="step-n">2</span>Ask a question</div>
+            </div>
+          </div>
+          <div class="r qa th">
+            <div class="g"></div>
+            <div class="q">Prompt</div>
+            <div class="a">Answer</div>
+          </div>
+          <div class="r qa">
+            <div class="g"></div>
+            <div class="q">“How many unique fans do we have?”</div>
+            <div class="a note">
+              <span class="val">71,204</span>
+              <span class="cmt"
+                >Deduped by normalized email, internal accounts excluded. Not
+                the raw 92,118.</span
+              >
+            </div>
+          </div>
+          <div class="r qa">
+            <div class="g"></div>
+            <div class="q">
+              “What’s our total annual revenue, and how much is media rights?”
+            </div>
+            <div class="a note">
+              <span class="val">$192M</span>
+              <span class="cmt"
+                >Five systems reconciled to the same units. Media rights is the
+                biggest line, ~$90M.</span
+              >
+            </div>
+          </div>
+          <div class="r qa">
+            <div class="g"></div>
+            <div class="q">“What was ticket revenue this season?”</div>
+            <div class="a note">
+              <span class="val">$46.8M</span>
+              <span class="cmt"
+                >Cents reconciled to dollars; refunds, exchanges, and comps
+                excluded.</span
+              >
+            </div>
+          </div>
+          <div class="r qa">
+            <div class="g"></div>
+            <div class="q">“What’s our total merchandise revenue?”</div>
+            <div class="a note">
+              <span class="val">It flags it</span>
+              <span class="cmt"
+                >Most merch is sold via Fanatics, not in this data, so it says
+                so instead of returning a wrong total.</span
+              >
+            </div>
+          </div>
+          <div class="r">
+            <div class="g blank"></div>
+            <div class="object">
+              <div class="objframe">
+                <span class="otag">Chart · =CHART(revenue)</span>
+                <div class="cl">Annual revenue by line · ~$192M total</div>
+                <svg
+                  viewBox="0 0 640 214"
+                  role="img"
+                  aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M."
+                >
+                  <g fill="#5F8C6B">
+                    <rect x="148" y="14" width="400" height="16" rx="3" />
+                    <rect x="148" y="48" width="209" height="16" rx="3" />
+                    <rect x="148" y="82" width="124" height="16" rx="3" />
+                    <rect x="148" y="116" width="62" height="16" rx="3" />
+                    <rect x="148" y="150" width="36" height="16" rx="3" />
+                    <rect x="148" y="184" width="22" height="16" rx="3" />
+                  </g>
+                  <g
+                    font-family="-apple-system,BlinkMacSystemFont,sans-serif"
+                    font-size="12.5"
+                    fill="#54615A"
+                  >
+                    <text x="8" y="26">Media rights</text>
+                    <text x="8" y="60">Ticketing</text>
+                    <text x="8" y="94">Sponsorship</text>
+                    <text x="8" y="128">Concessions</text>
+                    <text x="8" y="162">Merch</text>
+                    <text x="8" y="196">Other</text>
+                  </g>
+                  <g
+                    font-family="ui-monospace,SFMono-Regular,Menlo,monospace"
+                    font-size="12"
+                    fill="#212E26"
+                  >
+                    <text x="555" y="26">$90M</text>
+                    <text x="364" y="60">$47M</text>
+                    <text x="279" y="94">$28M</text>
+                    <text x="217" y="128">$14M</text>
+                    <text x="191" y="162">$8M</text>
+                    <text x="177" y="196">$5M</text>
+                  </g>
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          <div class="r">
+            <div class="g"></div>
+            <div class="c">
+              <div class="subhead"><span class="step-n">3</span>Try an app</div>
+              <p class="prose" style="margin-top: 8px">
+                Ask Claude to build a dashboard on the same data, then publish it
+                to a link. Two live examples, running on the demo data right now:
+              </p>
+              <ul class="uses" style="margin-top: 12px">
+                <li>
+                  <a
+                    href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+                    target="_blank"
+                    rel="noopener"
+                    >Sponsorship pricing table ↗</a
+                  >
+                  — inventory and rates for sponsorship placements.
+                </li>
+                <li>
+                  <a
+                    href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+                    target="_blank"
+                    rel="noopener"
+                    >Fan lifetime value ↗</a
+                  >
+                  — segment fans by spend across tickets, merch, and
+                  concessions.
+                </li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <!-- WHY -->
+        <section id="why">
+          <div class="r">
+            <div class="g"></div>
+            <div class="c sechead"><h2>Why we built it</h2></div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k">We’re curious.</div>
+            <div class="v">
+              There are plenty of AI memory stores, and plenty of data gateways.
+              Stapling the two together, and nudging the agent to gather
+              knowledge about the data as it goes, seemed useful and fun to
+              tinker with.
+            </div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k">We’re cheap.</div>
+            <div class="v">
+              We wanted something that runs on one small box, works on a Pro/Max
+              subscription or a cheap model with no added inference cost, mostly
+              sets itself up (no field engineer to pay for), stays portable
+              between providers, and is open source.
+            </div>
+          </div>
+          <div class="r kv">
+            <div class="g"></div>
+            <div class="k">We’re paranoid.</div>
+            <div class="v">
+              HR platforms, CRMs, and clouds are all announcing “context
+              layers.” They’d like the meaning of your business to accumulate on
+              their servers, where it can never leave. Context is deeper lock-in
+              than data, and a hosted context layer has no export button. Setoku
+              exists so that understanding accumulates on a box you own instead.
+              If we disappear tomorrow, your context doesn’t.
+            </div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c prose">
+              <b>We and some friends wanted the same thing.</b>
+            </div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c">
+              <ul class="uses">
+                <li>
+                  <b
+                    ><a
+                      href="https://www.hedgy.works"
+                      target="_blank"
+                      rel="noopener"
+                      >Hedgy</a
+                    ></b
+                  >: keep scaling without hiring. Debug from live logs and data,
+                  find growth levers, and match candidates and companies better
+                  with more data.
+                </li>
+                <li>
+                  <b
+                    ><a href="https://baggu.com" target="_blank" rel="noopener"
+                      >Baggu</a
+                    ></b
+                  >: give employees state-of-the-art tools. Faster onboarding,
+                  and a safe way to vibecode against real data.
+                </li>
+                <li>
+                  <b
+                    ><a href="https://tlon.io" target="_blank" rel="noopener"
+                      >Tlon</a
+                    ></b
+                  >: experimenting with giving agents curated data to work from.
+                </li>
+                <li>
+                  <b>Sports analysts</b>: query across data that doesn’t usually
+                  sit together.
+                </li>
+                <li>
+                  <b>Academic labs</b>: think through hypotheses against real
+                  papers, data, and drafts.
+                </li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <!-- SETUP HELP -->
+        <section id="help">
+          <div class="r">
+            <div class="g"></div>
+            <div class="c sechead"><h2>Setup help</h2></div>
+          </div>
+          <div class="r">
+            <div class="g"></div>
+            <div class="c prose">
+              It’s open source, so you can self-host it today. If you like, we’re
+              happy to help set it up. Just email
+              <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <!-- sheet tabs + status bar -->
+      <div class="tabbar">
+        <div class="tabs">
+          <a class="tab active" href="#overview" data-sec="overview">Overview</a>
+          <a class="tab" href="#how" data-sec="how">How it works</a>
+          <a class="tab" href="#apps" data-sec="apps">Apps</a>
+          <a class="tab" href="#architecture" data-sec="architecture"
+            >Architecture</a
+          >
+          <a class="tab" href="#connectors" data-sec="connectors">Connectors</a>
+          <a class="tab" href="#demo" data-sec="demo">Demo</a>
+          <a class="tab" href="#why" data-sec="why">Why</a>
+          <a
+            class="tab plus"
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            title="Source on GitHub"
+            >+</a
+          >
+        </div>
+        <div class="status" aria-hidden="true">
+          <span class="rdy">Ready</span>
+          <span>Sum: $192M</span>
+        </div>
+      </div>
+
+      <footer>
+        <a class="brand" href="#top" style="font-size: 14px"
+          ><svg class="mark" viewBox="0 0 64 64" style="width: 17px; height: 17px">
+            <use href="#clover" />
+          </svg>
+          Setoku</a
+        >
+        <a
+          href="https://github.com/Hedgy-Labs/setoku"
+          target="_blank"
+          rel="noopener"
+          >GitHub</a
+        >
+        <a href="#demo">Demo</a>
+        <a href="mailto:hello@setoku.com">Contact</a>
+        <span>Apache-2.0</span>
+        <span class="jp">設 × 奥 · set (math) × oku (innermost)</span>
+      </footer>
+    </div>
+
+    <script>
+      // rotating hero word
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) {
+            return w.trim();
+          })
+          .filter(Boolean);
+        if (words.length < 2) return;
+
+        var reduce = window.matchMedia(
+          "(prefers-reduced-motion: reduce)"
+        ).matches;
+        var LIFT = "0.72em";
+        var HALF = 240;
+        var HOLD = 2400;
+        var i = 0;
+
+        function widthOf(w) {
+          measure.textContent = w;
+          return measure.getBoundingClientRect().width;
+        }
+        box.style.width = widthOf(words[0]) + "px";
+
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next;
+            box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length;
+            return;
+          }
+          word
+            .animate(
+              [
+                { transform: "translateY(0)", opacity: 1 },
+                { transform: "translateY(-" + LIFT + ")", opacity: 0 },
+              ],
+              {
+                duration: HALF,
+                easing: "cubic-bezier(0.4, 0, 1, 1)",
+                fill: "forwards",
+              }
+            )
+            .finished.then(function () {
+              word.textContent = next;
+              box.style.width = widthOf(next) + "px";
+              word.animate(
+                [
+                  { transform: "translateY(" + LIFT + ")", opacity: 0 },
+                  { transform: "translateY(0)", opacity: 1 },
+                ],
+                {
+                  duration: HALF,
+                  easing: "cubic-bezier(0, 0, 0.2, 1)",
+                  fill: "forwards",
+                }
+              );
+              i = (i + 1) % words.length;
+            })
+            .catch(function () {});
+        }
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () {
+          box.style.width = widthOf(words[i]) + "px";
+        });
+      })();
+
+      // active sheet tab follows scroll
+      (function () {
+        var tabs = {};
+        document.querySelectorAll(".tab[data-sec]").forEach(function (t) {
+          tabs[t.getAttribute("data-sec")] = t;
+        });
+        var secs = document.querySelectorAll("section[id]");
+        if (!("IntersectionObserver" in window)) return;
+        var io = new IntersectionObserver(
+          function (entries) {
+            entries.forEach(function (e) {
+              if (e.isIntersecting) {
+                Object.values(tabs).forEach(function (t) {
+                  t.classList.remove("active");
+                });
+                var t = tabs[e.target.id];
+                if (t) t.classList.add("active");
+              }
+            });
+          },
+          { rootMargin: "-45% 0px -50% 0px" }
+        );
+        secs.forEach(function (s) {
+          io.observe(s);
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/5-swiss-brutalist.html
+++ b/site/riffs/5-swiss-brutalist.html
@@ -1,0 +1,1350 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · open-source MCP server for company data</title>
+    <meta
+      name="description"
+      content="Setoku is an open-source MCP server that gives your AI a read-only view of your company’s data, plus the context to use it correctly."
+    />
+    <style>
+      :root {
+        --paper: #f4f1e9;
+        --paper-2: #eae5d8;
+        --ink: #14140f;
+        --ink-2: #45443c;
+        --ink-3: #6d6c62;
+        --rule: #14140f;
+        --hair: rgba(20, 20, 15, 0.16);
+        --accent: #2f5c3c; /* muted sage, used sparingly */
+        --sans: "Neue Haas Grotesk Display", "Helvetica Neue", Inter,
+          Arial, system-ui, sans-serif;
+        --mono: "SFMono-Regular", "SF Mono", Menlo, Consolas, monospace;
+        --gut: 24px;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+        scroll-behavior: smooth;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family: var(--sans);
+        font-weight: 400;
+        font-size: 16px;
+        line-height: 1.5;
+        letter-spacing: -0.01em;
+        overflow-x: hidden;
+      }
+      a {
+        color: var(--ink);
+        text-decoration: none;
+        border-bottom: 1px solid var(--ink);
+      }
+      a:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+      svg {
+        display: block;
+      }
+      ::selection {
+        background: var(--ink);
+        color: var(--paper);
+      }
+
+      /* ---- frame + grid ---- */
+      .frame {
+        max-width: 1240px;
+        margin: 0 auto;
+        border-left: 1px solid var(--rule);
+        border-right: 1px solid var(--rule);
+        min-height: 100vh;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        column-gap: var(--gut);
+        padding-inline: clamp(16px, 3vw, 40px);
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 0.85em;
+        background: var(--paper-2);
+        padding: 1px 5px;
+        color: var(--ink);
+      }
+
+      /* ---- header ---- */
+      header {
+        border-bottom: 1px solid var(--rule);
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        background: var(--paper);
+      }
+      .bar {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        padding: 12px clamp(16px, 3vw, 40px);
+      }
+      .brand {
+        font-weight: 700;
+        font-size: 17px;
+        letter-spacing: -0.03em;
+        text-transform: uppercase;
+        border: none;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .brand:hover {
+        color: var(--ink);
+      }
+      .brand .mark {
+        width: 18px;
+        height: 18px;
+        color: var(--ink);
+      }
+      .nav {
+        display: flex;
+        gap: 22px;
+      }
+      .nav a {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        border: none;
+        color: var(--ink-2);
+      }
+      .nav a:hover {
+        color: var(--accent);
+      }
+      @media (max-width: 620px) {
+        .nav a.hideable {
+          display: none;
+        }
+      }
+
+      /* ---- section scaffolding ---- */
+      section {
+        border-bottom: 1px solid var(--rule);
+        padding-block: clamp(40px, 6vw, 88px);
+      }
+      .snum {
+        grid-column: 1 / 2;
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--ink-3);
+        padding-top: 6px;
+      }
+      .shead {
+        grid-column: 2 / 5;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        font-weight: 700;
+        padding-top: 6px;
+      }
+      .sbody {
+        grid-column: 5 / 13;
+      }
+      @media (max-width: 860px) {
+        .snum {
+          grid-column: 1 / 2;
+        }
+        .shead {
+          grid-column: 2 / 13;
+          margin-bottom: 20px;
+        }
+        .sbody {
+          grid-column: 1 / 13;
+        }
+      }
+      .lead {
+        font-size: clamp(19px, 2.4vw, 26px);
+        line-height: 1.32;
+        letter-spacing: -0.02em;
+        max-width: 22em;
+        margin-bottom: 34px;
+      }
+      p {
+        max-width: 40em;
+      }
+
+      /* ---- hero ---- */
+      .hero {
+        padding-block: clamp(36px, 5vw, 70px) clamp(40px, 6vw, 80px);
+        border-bottom: 1px solid var(--rule);
+      }
+      .eyebrow {
+        grid-column: 1 / 13;
+        font-family: var(--mono);
+        font-size: 12px;
+        letter-spacing: 0.04em;
+        color: var(--ink-3);
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        border-bottom: 1px solid var(--hair);
+        padding-bottom: 12px;
+        margin-bottom: clamp(24px, 4vw, 48px);
+      }
+      h1 {
+        grid-column: 1 / 13;
+        font-weight: 700;
+        font-size: clamp(44px, 11vw, 122px);
+        line-height: 0.94;
+        letter-spacing: -0.045em;
+        text-transform: none;
+        margin-bottom: clamp(28px, 4vw, 44px);
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        color: var(--accent);
+        overflow: hidden;
+        transition: width 460ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+        will-change: transform, opacity;
+      }
+      .rotator-measure {
+        position: absolute;
+        left: 0;
+        top: 0;
+        visibility: hidden;
+        pointer-events: none;
+        white-space: nowrap;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .rotator {
+          transition: none;
+        }
+      }
+      .hero .lede {
+        grid-column: 6 / 13;
+        font-size: clamp(15px, 1.5vw, 18px);
+        color: var(--ink-2);
+        max-width: 34em;
+        line-height: 1.5;
+      }
+      .hero .actions {
+        grid-column: 1 / 6;
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+        align-self: end;
+      }
+      @media (max-width: 860px) {
+        .hero .lede,
+        .hero .actions {
+          grid-column: 1 / 13;
+        }
+        .hero .actions {
+          margin-bottom: 28px;
+          flex-direction: row;
+          gap: 12px;
+        }
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        font-size: 14px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        padding: 14px 4px;
+        border: none;
+        border-top: 1px solid var(--rule);
+        color: var(--ink);
+        max-width: 300px;
+      }
+      .btn:last-child {
+        border-bottom: 1px solid var(--rule);
+      }
+      .btn:hover {
+        color: var(--accent);
+        padding-left: 10px;
+      }
+      .btn .ar {
+        font-family: var(--mono);
+      }
+
+      /* ---- ledger rows (how / apps) ---- */
+      .rows {
+        border-top: 1px solid var(--rule);
+      }
+      .lrow {
+        display: grid;
+        grid-template-columns: 3fr 5fr;
+        gap: var(--gut);
+        border-bottom: 1px solid var(--hair);
+        padding: 18px 0;
+      }
+      .lrow .k {
+        font-weight: 700;
+        font-size: 16px;
+        letter-spacing: -0.01em;
+      }
+      .lrow .k .t {
+        display: block;
+        font-family: var(--mono);
+        font-size: 11px;
+        font-weight: 400;
+        color: var(--accent);
+        text-transform: none;
+        letter-spacing: 0;
+        margin-top: 6px;
+      }
+      .lrow .v {
+        color: var(--ink-2);
+        font-size: 15px;
+        max-width: 36em;
+      }
+      @media (max-width: 620px) {
+        .lrow {
+          grid-template-columns: 1fr;
+          gap: 8px;
+        }
+      }
+
+      /* ---- code ---- */
+      pre {
+        background: var(--ink);
+        color: var(--paper);
+        border: none;
+        padding: 20px 22px;
+        overflow-x: auto;
+        margin: 20px 0;
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.85;
+      }
+      pre code {
+        background: none;
+        color: inherit;
+        padding: 0;
+        font-size: inherit;
+        white-space: pre;
+      }
+      pre code .c {
+        color: #8f9a86;
+      }
+      .note {
+        font-size: 15px;
+        color: var(--ink-2);
+        margin-top: 16px;
+        max-width: 40em;
+      }
+      details.manual {
+        margin-top: 22px;
+        border-top: 1px solid var(--hair);
+        padding-top: 14px;
+      }
+      details.manual summary {
+        cursor: pointer;
+        font-family: var(--mono);
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        color: var(--ink-3);
+      }
+      details.manual summary:hover {
+        color: var(--accent);
+      }
+      ul.uses {
+        list-style: none;
+        margin-top: 18px;
+        border-top: 1px solid var(--hair);
+      }
+      ul.uses li {
+        color: var(--ink-2);
+        font-size: 15px;
+        padding: 12px 0;
+        border-bottom: 1px solid var(--hair);
+        max-width: 44em;
+      }
+      ul.uses b {
+        color: var(--ink);
+        font-weight: 700;
+      }
+
+      /* ---- architecture ---- */
+      .diagram {
+        margin-top: 30px;
+        border: 1px solid var(--rule);
+        padding: 20px;
+        overflow-x: auto;
+      }
+      .diagram svg {
+        width: 100%;
+        min-width: 520px;
+        height: auto;
+      }
+      .diagram .node {
+        fill: none;
+        stroke: var(--ink);
+        stroke-width: 1;
+      }
+      .diagram .box {
+        fill: none;
+        stroke: var(--ink-3);
+        stroke-width: 1;
+        stroke-dasharray: 3 4;
+      }
+      .diagram .t {
+        font-family: var(--sans);
+        font-size: 13px;
+        font-weight: 700;
+        fill: var(--ink);
+      }
+      .diagram .s {
+        font-family: var(--mono);
+        font-size: 10px;
+        fill: var(--ink-3);
+      }
+      .diagram .e {
+        font-family: var(--mono);
+        font-size: 10px;
+        fill: var(--ink-2);
+        text-transform: uppercase;
+      }
+      .diagram .arr {
+        stroke: var(--ink);
+        stroke-width: 1;
+        fill: none;
+      }
+
+      /* ---- connectors table ---- */
+      .conn {
+        border-top: 1px solid var(--rule);
+        margin-top: 26px;
+      }
+      .conn .caphead {
+        font-family: var(--mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--ink-3);
+        padding: 14px 0 10px;
+        border-bottom: 1px solid var(--hair);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .conn .caphead .dot {
+        width: 7px;
+        height: 7px;
+        background: var(--accent);
+      }
+      .crow {
+        display: grid;
+        grid-template-columns: 40px 3fr 6fr;
+        gap: var(--gut);
+        align-items: baseline;
+        border-bottom: 1px solid var(--hair);
+        padding: 13px 0;
+      }
+      .crow .idx {
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--ink-3);
+      }
+      .crow b {
+        font-weight: 700;
+        font-size: 15px;
+      }
+      .crow span {
+        color: var(--ink-2);
+        font-size: 14px;
+      }
+      @media (max-width: 620px) {
+        .crow {
+          grid-template-columns: 30px 1fr;
+        }
+        .crow span {
+          grid-column: 2 / 3;
+        }
+      }
+
+      /* ---- demo ---- */
+      .step {
+        margin-top: 40px;
+        border-top: 1px solid var(--rule);
+        padding-top: 20px;
+      }
+      .step:first-of-type {
+        margin-top: 30px;
+      }
+      .step-h {
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
+        font-size: 18px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        margin-bottom: 12px;
+      }
+      .step-n {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--accent);
+        border: 1px solid var(--accent);
+        width: 24px;
+        height: 24px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: none;
+      }
+      .qa {
+        display: grid;
+        gap: 0;
+        margin-top: 24px;
+        border-top: 1px solid var(--hair);
+      }
+      .ex {
+        display: grid;
+        grid-template-columns: 5fr 7fr;
+        gap: var(--gut);
+        padding: 22px 0;
+        border-bottom: 1px solid var(--hair);
+        align-items: baseline;
+      }
+      .ex .q {
+        color: var(--ink-2);
+        font-size: 15px;
+        font-style: italic;
+        max-width: 22em;
+      }
+      .ex .a .big {
+        font-size: clamp(30px, 5vw, 52px);
+        font-weight: 700;
+        letter-spacing: -0.04em;
+        line-height: 1;
+        color: var(--ink);
+      }
+      .ex .a .cap {
+        display: block;
+        font-size: 13.5px;
+        color: var(--ink-3);
+        margin-top: 8px;
+        max-width: 32em;
+      }
+      @media (max-width: 620px) {
+        .ex {
+          grid-template-columns: 1fr;
+          gap: 10px;
+        }
+      }
+      .chart {
+        width: 100%;
+      }
+      .chart .cl {
+        font-family: var(--mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        color: var(--ink-3);
+        margin-bottom: 12px;
+      }
+      .chart svg {
+        width: 100%;
+        height: auto;
+      }
+
+      /* ---- why ---- */
+      .why h3 {
+        font-size: clamp(24px, 3.5vw, 40px);
+        font-weight: 700;
+        letter-spacing: -0.035em;
+        margin: 36px 0 10px;
+        line-height: 1;
+      }
+      .why h3:first-of-type {
+        margin-top: 0;
+      }
+      .why p {
+        color: var(--ink-2);
+        max-width: 40em;
+      }
+
+      /* ---- footer ---- */
+      footer {
+        padding-block: 48px;
+      }
+      .foot {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 20px;
+        justify-content: space-between;
+      }
+      .foot .l {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 20px;
+      }
+      .foot a,
+      .foot span {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--ink-2);
+        border: none;
+      }
+      .foot a:hover {
+        color: var(--accent);
+      }
+      .foot .jp {
+        font-family: var(--mono);
+        text-transform: none;
+        letter-spacing: 0;
+        color: var(--ink-3);
+      }
+      .bigmark {
+        font-weight: 700;
+        font-size: clamp(56px, 20vw, 240px);
+        letter-spacing: -0.05em;
+        line-height: 0.8;
+        text-transform: uppercase;
+        color: var(--ink);
+        padding-top: 40px;
+        border-top: 1px solid var(--hair);
+        margin-top: 40px;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path
+          d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z"
+          fill="currentColor"
+        />
+      </symbol>
+    </svg>
+
+    <div class="frame">
+      <header>
+        <div class="bar">
+          <a class="brand" href="#top"
+            ><svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+            Setoku</a
+          >
+          <nav class="nav">
+            <a class="hideable" href="#how">How it works</a>
+            <a class="hideable" href="#apps">Apps</a>
+            <a class="hideable" href="#connectors">Connectors</a>
+            <a
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >GitHub ↗</a
+            >
+          </nav>
+        </div>
+      </header>
+
+      <main id="top">
+        <!-- HERO -->
+        <section class="hero grid">
+          <div class="eyebrow">
+            <span>Open source · MCP server · Apache-2.0</span>
+            <span>Self-hosted</span>
+          </div>
+          <h1>
+            Make any AI fluent in your
+            <span
+              class="rotator"
+              data-words="company,family,personal"
+              ><span class="rotator-word">company</span
+              ><span class="rotator-measure" aria-hidden="true"></span></span>
+            data.
+          </h1>
+          <div class="actions">
+            <a
+              class="btn"
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >View on GitHub<span class="ar">↗</span></a
+            >
+            <a class="btn" href="#demo"
+              >Try the demo<span class="ar">→</span></a
+            >
+          </div>
+          <p class="lede">
+            Setoku is a small self-hosted MCP knowledge server + Claude Code
+            skills for hooking up your data. It does two things: it gives your
+            AI a read-only way to query your data, and it remembers what that
+            data means (the metric definitions, the gotchas), getting better
+            the more you use it. The MCP works with whatever AI you already
+            have, and no model runs on the server, so no added inference cost.
+          </p>
+        </section>
+
+        <!-- QUICKSTART -->
+        <section id="quickstart" class="grid">
+          <div class="snum">01</div>
+          <div class="shead">Quickstart</div>
+          <div class="sbody">
+            <p class="lead">
+              Setoku installs as a Claude Code plugin. Add the plugin, then run
+              onboarding from your main project directory, the codebase you want
+              Setoku to learn from.
+            </p>
+            <pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+            <p class="note">
+              Onboarding stands up the server, auths your Claude, wires your
+              database read-only, and generates the first knowledge from your
+              code. You stay in the loop for anything that touches your data. To
+              start onboarding, run <code>/setoku:onboard</code>.
+            </p>
+            <p class="note">
+              You’ll need somewhere to host it. Something like OVH’s
+              <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener"
+                >VPS-2</a
+              >
+              is plenty.
+            </p>
+            <details class="manual">
+              <summary>Or stand up the server by hand</summary>
+              <pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+              <p class="note">
+                Installs Docker, generates secrets, gets an HTTPS certificate,
+                and prints the connect command. Then add the plugin and run
+                /setoku:onboard from your project; it’ll detect the box you just
+                made.
+              </p>
+            </details>
+          </div>
+        </section>
+
+        <!-- HOW -->
+        <section id="how" class="grid">
+          <div class="snum">02</div>
+          <div class="shead">How it works</div>
+          <div class="sbody">
+            <p class="lead">
+              Setoku gives the AI two kinds of MCP tools, and one rule: look up
+              what the data means before you touch it.
+            </p>
+            <div class="rows">
+              <div class="lrow">
+                <div class="k">
+                  Context tools<span class="t">find_context · get_metric</span>
+                </div>
+                <div class="v">
+                  The AI reads what your data means first: canonical metric
+                  definitions, entity docs, and the gotchas that make a naive
+                  query wrong.
+                </div>
+              </div>
+              <div class="lrow">
+                <div class="k">
+                  Read-only query<span class="t">get_schema · run_query</span>
+                </div>
+                <div class="v">
+                  Read-only, with a row cap, a statement timeout, a table
+                  allow-list, and an append-only audit log. Enforced by the
+                  database role, not by parsing SQL.
+                </div>
+              </div>
+              <div class="lrow">
+                <div class="k">
+                  Human-approved<span class="t">report_correction</span>
+                </div>
+                <div class="v">
+                  The AI can only propose changes to what Setoku knows. A person
+                  accepts them on the admin page, outside the agent loop, so an
+                  injected session can’t rewrite the brain.
+                </div>
+              </div>
+            </div>
+            <p class="note"><b>You set it up with Claude Code skills:</b></p>
+            <ul class="uses">
+              <li>
+                <code>/setoku:onboard</code> sets Setoku up in a repo for the
+                first time.
+              </li>
+              <li>
+                <code>/setoku:connect</code> adds a data source or custom
+                integration.
+              </li>
+              <li>
+                <code>/setoku:generate</code> writes business context from your
+                code.
+              </li>
+              <li>
+                <code>/setoku:curate</code> reviews and approves pending
+                knowledge.
+              </li>
+            </ul>
+            <p class="note">
+              Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex,
+              or whatever you run. Just ask in plain language, and the tools do
+              the rest.
+            </p>
+          </div>
+        </section>
+
+        <!-- APPS -->
+        <section id="apps" class="grid">
+          <div class="snum">03</div>
+          <div class="shead">Apps — save and share the tools Claude builds you</div>
+          <div class="sbody">
+            <p class="lead">
+              Ask Claude to build a dashboard on your data. Then publish it to a
+              link as a Setoku App, the data stays live, and your whole team can
+              view it. Nothing to deploy, no frontend to maintain.
+            </p>
+            <div class="rows">
+              <div class="lrow">
+                <div class="k">
+                  Built by asking<span class="t">publish_app</span>
+                </div>
+                <div class="v">
+                  Describe it in plain language; the agent writes the app and
+                  publishes it to a URL. Edit it the same way, just ask for the
+                  change.
+                </div>
+              </div>
+              <div class="lrow">
+                <div class="k">
+                  Backed by live data<span class="t">read-only</span>
+                </div>
+                <div class="v">
+                  Apps read through the same governed path: row caps, audit, a
+                  SELECT-only database role. They never get write access to your
+                  sources.
+                </div>
+              </div>
+              <div class="lrow">
+                <div class="k">
+                  App-private state<span class="t">no writes to your data</span>
+                </div>
+                <div class="v">
+                  Each app keeps its own state (todos, votes, annotations) in a
+                  sandbox that belongs to the app, not your database. Worst
+                  case, an app messes up its own notes.
+                </div>
+              </div>
+              <div class="lrow">
+                <div class="k">
+                  Share by link<span class="t">team or public</span>
+                </div>
+                <div class="v">
+                  A team link is login-gated; an admin can flip one public for a
+                  credential-free URL. The page runs in a locked-down sandbox
+                  with no network, so a published app can’t phone home.
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- ARCHITECTURE -->
+        <section id="architecture" class="grid">
+          <div class="snum">04</div>
+          <div class="shead">Architecture</div>
+          <div class="sbody">
+            <p class="lead">
+              You can host this on whatever infra you like. We put it all on one
+              small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+              helps you add custom integrations. Only the proxy is public, so
+              your databases aren’t exposed. Queries are read-only, and
+              knowledge changes pass through a person.
+            </p>
+            <div class="diagram">
+              <svg
+                viewBox="0 0 680 520"
+                role="img"
+                aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake for analytics, and your sources are ingested into the lake."
+              >
+                <defs>
+                  <marker
+                    id="ah"
+                    markerWidth="9"
+                    markerHeight="9"
+                    refX="6"
+                    refY="3"
+                    orient="auto-start-reverse"
+                  >
+                    <path d="M0 0 L6 3 L0 6 Z" fill="#14140f" />
+                  </marker>
+                </defs>
+                <rect class="node" x="250" y="14" width="180" height="44" />
+                <text class="t" x="340" y="41" text-anchor="middle">
+                  You + your AI
+                </text>
+                <path
+                  class="arr"
+                  d="M340 58 L340 142"
+                  marker-start="url(#ah)"
+                  marker-end="url(#ah)"
+                />
+                <text class="e" x="348" y="86">MCP</text>
+                <rect class="box" x="60" y="110" width="560" height="300" />
+                <text class="e" x="76" y="130">your box</text>
+                <rect class="node" x="250" y="146" width="180" height="58" />
+                <text class="t" x="340" y="171" text-anchor="middle">
+                  Setoku gateway
+                </text>
+                <text class="s" x="340" y="189" text-anchor="middle">
+                  context · query tools
+                </text>
+                <rect class="node" x="452" y="150" width="150" height="50" />
+                <text class="t" x="527" y="179" text-anchor="middle">
+                  a person
+                </text>
+                <rect class="node" x="92" y="322" width="180" height="66" />
+                <text class="t" x="182" y="350" text-anchor="middle">
+                  Lake (ClickHouse)
+                </text>
+                <text class="s" x="182" y="368" text-anchor="middle">
+                  logs · events · DB mirror
+                </text>
+                <rect class="node" x="408" y="322" width="190" height="66" />
+                <text class="t" x="503" y="359" text-anchor="middle">
+                  Knowledge store
+                </text>
+                <rect class="node" x="92" y="440" width="180" height="64" />
+                <text class="t" x="182" y="468" text-anchor="middle">
+                  Your sources
+                </text>
+                <text class="s" x="182" y="486" text-anchor="middle">
+                  GitHub · Vercel · Slack…
+                </text>
+                <rect class="node" x="300" y="440" width="180" height="64" />
+                <text class="t" x="390" y="468" text-anchor="middle">
+                  Your database
+                </text>
+                <text class="s" x="390" y="486" text-anchor="middle">
+                  Postgres · read-only
+                </text>
+                <path
+                  class="arr"
+                  d="M412 204 L508 322"
+                  marker-start="url(#ah)"
+                  marker-end="url(#ah)"
+                />
+                <text class="e" x="424" y="266" text-anchor="middle">reads ·</text>
+                <text class="e" x="424" y="282" text-anchor="middle">proposes</text>
+                <path class="arr" d="M527 200 L513 322" marker-end="url(#ah)" />
+                <text class="e" x="534" y="262">approves</text>
+                <path class="arr" d="M210 322 L300 204" marker-end="url(#ah)" />
+                <path class="arr" d="M182 440 L182 388" marker-end="url(#ah)" />
+                <text class="e" x="190" y="420">ingest</text>
+                <path class="arr" d="M388 440 L366 206" marker-end="url(#ah)" />
+                <text class="e" x="300" y="300">read-only</text>
+              </svg>
+            </div>
+          </div>
+        </section>
+
+        <!-- CONNECTORS -->
+        <section id="connectors" class="grid">
+          <div class="snum">05</div>
+          <div class="shead">Connectors</div>
+          <div class="sbody">
+            <p class="lead">
+              Point Setoku at the data you already have. Every source lands in a
+              local
+              <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+                >ClickHouse</a
+              >
+              data lake, on purpose: agents write arbitrary queries (scans,
+              GROUP BYs, whole-table aggregations), and a columnar engine
+              answers those in about a second, so the apps and dashboards they
+              build stay quick. Your app database connects read-only and is
+              mirrored in on a cron; the rest is ingested as it happens.
+            </p>
+            <div class="conn">
+              <div class="caphead"><span class="dot"></span>ClickHouse · one lake, every source</div>
+              <div class="crow">
+                <span class="idx">01</span><b>PostgreSQL</b
+                ><span>app database, mirrored read-only</span>
+              </div>
+              <div class="crow">
+                <span class="idx">02</span><b>GitHub</b
+                ><span>issues, PRs &amp; commits</span>
+              </div>
+              <div class="crow">
+                <span class="idx">03</span><b>Vercel</b
+                ><span>deploys &amp; logs</span>
+              </div>
+              <div class="crow">
+                <span class="idx">04</span><b>Render</b
+                ><span>deploys &amp; logs</span>
+              </div>
+              <div class="crow">
+                <span class="idx">05</span><b>Slack</b><span>messages</span>
+              </div>
+              <div class="crow">
+                <span class="idx">06</span><b>Mercury</b
+                ><span>banking &amp; finance</span>
+              </div>
+            </div>
+            <p class="note">
+              No connector for your source yet? The included setup skills give
+              your coding agent the patterns to wire one up itself. See
+              <a
+                href="https://github.com/Hedgy-Labs/setoku"
+                target="_blank"
+                rel="noopener"
+                >the repo</a
+              >, or open an issue.
+            </p>
+          </div>
+        </section>
+
+        <!-- DEMO -->
+        <section id="demo" class="grid">
+          <div class="snum">06</div>
+          <div class="shead">Try it on real-ish data</div>
+          <div class="sbody">
+            <p class="lead">
+              There’s a live demo wired to a fictional pro sports club, the
+              Bonita Bulldogs (ticketing, sponsorship, concessions, payroll,
+              broadcast rights).
+            </p>
+
+            <div class="step">
+              <h3 class="step-h">
+                <span class="step-n">1</span>Connect to the demo MCP server
+              </h3>
+              <p class="note" style="margin-top: 0">
+                In Claude (or any MCP client) open Settings → Connectors → Add
+                custom connector, and paste this URL. The token rides in the
+                URL, so there’s no separate key to enter.
+              </p>
+              <pre><code>https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</code></pre>
+            </div>
+
+            <div class="step">
+              <h3 class="step-h"><span class="step-n">2</span>Ask a question</h3>
+              <div class="qa">
+                <div class="ex">
+                  <div class="q">“How many unique fans do we have?”</div>
+                  <div class="a">
+                    <div class="big">71,204</div>
+                    <span class="cap"
+                      >deduped by normalized email, internal accounts excluded.
+                      Not the raw 92,118.</span
+                    >
+                  </div>
+                </div>
+                <div class="ex">
+                  <div class="q">
+                    “What’s our total annual revenue, and how much is media
+                    rights?”
+                  </div>
+                  <div class="a">
+                    <div class="big">$192M</div>
+                    <span class="cap"
+                      >five systems reconciled to the same units. Media rights
+                      is the biggest line, ~$90M.</span
+                    >
+                  </div>
+                </div>
+                <div class="ex">
+                  <div class="q">“What was ticket revenue this season?”</div>
+                  <div class="a">
+                    <div class="big">$46.8M</div>
+                    <span class="cap"
+                      >cents reconciled to dollars; refunds, exchanges, and
+                      comps excluded.</span
+                    >
+                  </div>
+                </div>
+                <div class="ex">
+                  <div class="q">“What’s our total merchandise revenue?”</div>
+                  <div class="a">
+                    <div class="big">It flags it</div>
+                    <span class="cap"
+                      >most merch is sold via Fanatics, not in this data, so it
+                      says so instead of returning a wrong total.</span
+                    >
+                  </div>
+                </div>
+                <div class="ex">
+                  <div class="q">“Chart revenue by line.”</div>
+                  <div class="a">
+                    <div class="chart">
+                      <div class="cl">Annual revenue by line · ~$192M total</div>
+                      <svg
+                        viewBox="0 0 640 214"
+                        role="img"
+                        aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M."
+                      >
+                        <g fill="#2f5c3c">
+                          <rect x="148" y="14" width="400" height="16" />
+                          <rect x="148" y="48" width="209" height="16" />
+                          <rect x="148" y="82" width="124" height="16" />
+                          <rect x="148" y="116" width="62" height="16" />
+                          <rect x="148" y="150" width="36" height="16" />
+                          <rect x="148" y="184" width="22" height="16" />
+                        </g>
+                        <g
+                          font-family="Helvetica Neue, Arial, sans-serif"
+                          font-size="12.5"
+                          fill="#45443c"
+                        >
+                          <text x="8" y="26">Media rights</text>
+                          <text x="8" y="60">Ticketing</text>
+                          <text x="8" y="94">Sponsorship</text>
+                          <text x="8" y="128">Concessions</text>
+                          <text x="8" y="162">Merch</text>
+                          <text x="8" y="196">Other</text>
+                        </g>
+                        <g
+                          font-family="SFMono-Regular, Menlo, monospace"
+                          font-size="12"
+                          fill="#14140f"
+                        >
+                          <text x="555" y="26">$90M</text>
+                          <text x="364" y="60">$47M</text>
+                          <text x="279" y="94">$28M</text>
+                          <text x="217" y="128">$14M</text>
+                          <text x="191" y="162">$8M</text>
+                          <text x="177" y="196">$5M</text>
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="step">
+              <h3 class="step-h"><span class="step-n">3</span>Try an app</h3>
+              <p class="note" style="margin-top: 0">
+                Ask Claude to build a dashboard on the same data, then publish it
+                to a link. Two live examples, running on the demo data right
+                now:
+              </p>
+              <ul class="uses">
+                <li>
+                  <a
+                    href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+                    target="_blank"
+                    rel="noopener"
+                    >Sponsorship pricing table ↗</a
+                  >
+                  — inventory and rates for sponsorship placements.
+                </li>
+                <li>
+                  <a
+                    href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+                    target="_blank"
+                    rel="noopener"
+                    >Fan lifetime value ↗</a
+                  >
+                  — segment fans by spend across tickets, merch, and
+                  concessions.
+                </li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <!-- WHY -->
+        <section id="why" class="why grid">
+          <div class="snum">07</div>
+          <div class="shead">Why we built it</div>
+          <div class="sbody">
+            <h3>We’re curious.</h3>
+            <p>
+              There are plenty of AI memory stores, and plenty of data gateways.
+              Stapling the two together, and nudging the agent to gather
+              knowledge about the data as it goes, seemed useful and fun to
+              tinker with.
+            </p>
+            <h3>We’re cheap.</h3>
+            <p>
+              We wanted something that runs on one small box, works on a Pro/Max
+              subscription or a cheap model with no added inference cost, mostly
+              sets itself up (no field engineer to pay for), stays portable
+              between providers, and is open source.
+            </p>
+            <h3>We’re paranoid.</h3>
+            <p>
+              HR platforms, CRMs, and clouds are all announcing “context
+              layers.” They’d like the meaning of your business to accumulate on
+              their servers, where it can never leave. Context is deeper lock-in
+              than data, and a hosted context layer has no export button. Setoku
+              exists so that understanding accumulates on a box you own instead.
+              If we disappear tomorrow, your context doesn’t.
+            </p>
+            <h3>We and some friends wanted the same thing.</h3>
+            <ul class="uses">
+              <li>
+                <b><a href="https://www.hedgy.works" target="_blank" rel="noopener">Hedgy</a></b>: keep scaling without hiring. Debug from
+                live logs and data, find growth levers, and match candidates and
+                companies better with more data.
+              </li>
+              <li>
+                <b><a href="https://baggu.com" target="_blank" rel="noopener">Baggu</a></b>: give employees state-of-the-art tools. Faster
+                onboarding, and a safe way to vibecode against real data.
+              </li>
+              <li>
+                <b><a href="https://tlon.io" target="_blank" rel="noopener">Tlon</a></b>: experimenting with giving agents curated data to
+                work from.
+              </li>
+              <li>
+                <b>Sports analysts</b>: query across data that doesn’t usually
+                sit together.
+              </li>
+              <li>
+                <b>Academic labs</b>: think through hypotheses against real
+                papers, data, and drafts.
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <!-- HELP -->
+        <section id="help" class="grid">
+          <div class="snum">08</div>
+          <div class="shead">Setup help</div>
+          <div class="sbody">
+            <p class="lead" style="margin-bottom: 0">
+              It’s open source, so you can self-host it today. If you like, we’re
+              happy to help set it up. Just email
+              <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <footer>
+        <div class="grid" style="grid-template-columns: 1fr">
+          <div class="foot">
+            <div class="l">
+              <a class="brand" href="#top" style="font-size: 14px"
+                ><svg
+                  class="mark"
+                  viewBox="0 0 64 64"
+                  style="width: 15px; height: 15px"
+                >
+                  <use href="#clover" />
+                </svg>
+                Setoku</a
+              >
+              <a
+                href="https://github.com/Hedgy-Labs/setoku"
+                target="_blank"
+                rel="noopener"
+                >GitHub</a
+              >
+              <a href="#demo">Demo</a>
+              <a href="mailto:hello@setoku.com">Contact</a>
+              <span>Apache-2.0</span>
+            </div>
+            <span class="jp">設 × 奥 · set (math) × oku (innermost)</span>
+          </div>
+          <div class="bigmark">Setoku</div>
+        </div>
+      </footer>
+    </div>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) {
+            return w.trim();
+          })
+          .filter(Boolean);
+        if (words.length < 2) return;
+
+        var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        var LIFT = "0.72em";
+        var HALF = 240;
+        var HOLD = 2400;
+        var i = 0;
+
+        function widthOf(w) {
+          measure.textContent = w;
+          return measure.getBoundingClientRect().width;
+        }
+
+        box.style.width = widthOf(words[0]) + "px";
+
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next;
+            box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length;
+            return;
+          }
+          word
+            .animate(
+              [
+                { transform: "translateY(0)", opacity: 1 },
+                { transform: "translateY(-" + LIFT + ")", opacity: 0 },
+              ],
+              { duration: HALF, easing: "cubic-bezier(0.4, 0, 1, 1)", fill: "forwards" }
+            )
+            .finished.then(function () {
+              word.textContent = next;
+              box.style.width = widthOf(next) + "px";
+              word.animate(
+                [
+                  { transform: "translateY(" + LIFT + ")", opacity: 0 },
+                  { transform: "translateY(0)", opacity: 1 },
+                ],
+                { duration: HALF, easing: "cubic-bezier(0, 0, 0.2, 1)", fill: "forwards" }
+              );
+              i = (i + 1) % words.length;
+            })
+            .catch(function () {});
+        }
+
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () {
+          box.style.width = widthOf(words[i]) + "px";
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/6-notebook.html
+++ b/site/riffs/6-notebook.html
@@ -1,0 +1,1406 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>setoku.ipynb · make any AI fluent in your company data</title>
+    <meta
+      name="description"
+      content="Setoku is an open-source MCP server that gives your AI a read-only view of your company’s data, plus the context to use it correctly."
+    />
+    <style>
+      :root {
+        --cream: #faf6ec;
+        --cream-2: #f1eadb;
+        --paper: #ffffff;
+        --ink: #212e26;
+        --ink-soft: #3f4a43;
+        --ink-faint: #4c554e;
+        --line: rgba(33, 46, 38, 0.14);
+        --line-soft: rgba(33, 46, 38, 0.08);
+        --sage: #5f8c6b;
+        --sage-d: #33543d;
+        --out: #8a5a41;
+        --mono: ui-monospace, "SF Mono", "SFMono-Regular", Menlo, Consolas,
+          "Liberation Mono", monospace;
+        --sans: ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", Arial,
+          sans-serif;
+        --nb: 860px;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+        scroll-behavior: smooth;
+      }
+      body {
+        background: var(--cream);
+        color: var(--ink);
+        font-family: var(--sans);
+        font-size: 16px;
+        line-height: 1.6;
+      }
+      a {
+        color: var(--sage-d);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+        text-underline-offset: 3px;
+      }
+      svg {
+        display: block;
+      }
+      ::selection {
+        background: var(--sage);
+        color: #fff;
+      }
+
+      /* ---- notebook chrome ---- */
+      .toolbar {
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        background: color-mix(in srgb, var(--cream) 90%, transparent);
+        backdrop-filter: blur(10px);
+        border-bottom: 1px solid var(--line);
+      }
+      .toolbar-inner {
+        max-width: var(--nb);
+        margin: 0 auto;
+        padding: 9px 20px;
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        flex-wrap: wrap;
+      }
+      .tb-file {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 600;
+        font-size: 15px;
+        letter-spacing: -0.01em;
+      }
+      .tb-file .mark {
+        width: 20px;
+        height: 20px;
+        color: #1a1a19;
+      }
+      .tb-file .ext {
+        color: var(--ink-faint);
+        font-weight: 500;
+      }
+      .tb-menu {
+        display: flex;
+        gap: 14px;
+        font-size: 13px;
+        color: var(--ink-faint);
+      }
+      .tb-menu span {
+        cursor: default;
+      }
+      @media (max-width: 620px) {
+        .tb-menu {
+          display: none;
+        }
+      }
+      .tb-kernel {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: 7px;
+        font-family: var(--mono);
+        font-size: 11.5px;
+        color: var(--ink-faint);
+        letter-spacing: 0.01em;
+      }
+      .tb-kernel .k-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--sage);
+        box-shadow: 0 0 0 0 rgba(95, 140, 107, 0.5);
+        animation: pulse 2.6s ease-out infinite;
+      }
+      @keyframes pulse {
+        0% {
+          box-shadow: 0 0 0 0 rgba(95, 140, 107, 0.45);
+        }
+        70% {
+          box-shadow: 0 0 0 6px rgba(95, 140, 107, 0);
+        }
+        100% {
+          box-shadow: 0 0 0 0 rgba(95, 140, 107, 0);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .tb-kernel .k-dot {
+          animation: none;
+        }
+      }
+
+      /* ---- notebook body ---- */
+      .nb {
+        max-width: var(--nb);
+        margin: 0 auto;
+        padding: 26px 20px 60px;
+      }
+      .cell {
+        display: grid;
+        grid-template-columns: 66px 1fr;
+        gap: 0;
+        align-items: start;
+        padding: 7px 0;
+        border-left: 3px solid transparent;
+        border-radius: 4px;
+        transition: border-color 0.15s, background 0.15s;
+      }
+      .cell:hover {
+        border-left-color: var(--line);
+        background: rgba(33, 46, 38, 0.012);
+      }
+      .cell.sel {
+        border-left-color: var(--sage);
+      }
+      .gutter {
+        font-family: var(--mono);
+        font-size: 12px;
+        line-height: 1.5;
+        text-align: right;
+        padding: 6px 12px 0 0;
+        color: var(--ink-faint);
+        white-space: nowrap;
+        user-select: none;
+      }
+      .gutter.in {
+        color: var(--sage-d);
+      }
+      .gutter.out {
+        color: var(--out);
+      }
+      @media (max-width: 620px) {
+        .cell {
+          grid-template-columns: 44px 1fr;
+        }
+        .gutter {
+          font-size: 10.5px;
+          padding-right: 8px;
+        }
+      }
+
+      /* markdown (rendered) cells */
+      .md {
+        padding: 2px 2px;
+      }
+      .md.title {
+        padding-top: 12px;
+      }
+      .eyebrow {
+        font-family: var(--mono);
+        font-size: 12px;
+        letter-spacing: 0.05em;
+        color: var(--sage-d);
+      }
+      h1 {
+        font-weight: 800;
+        font-size: clamp(30px, 5.4vw, 46px);
+        line-height: 1.05;
+        letter-spacing: -0.03em;
+        margin: 14px 0 0;
+        max-width: 15em;
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        color: var(--sage-d);
+        transition: width 460ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+        will-change: transform, opacity;
+        border-bottom: 0.06em solid rgba(51, 84, 61, 0.28);
+      }
+      .rotator-measure {
+        position: absolute;
+        left: 0;
+        top: 0;
+        visibility: hidden;
+        pointer-events: none;
+        white-space: nowrap;
+      }
+      .lede {
+        color: var(--ink-soft);
+        font-size: 17.5px;
+        margin-top: 16px;
+        max-width: 44em;
+      }
+      .actions {
+        margin-top: 20px;
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        font-size: 14px;
+        font-weight: 600;
+        padding: 8px 15px;
+        border-radius: 8px;
+        border: 1px solid var(--ink);
+        background: var(--ink);
+        color: var(--cream);
+      }
+      .btn:hover {
+        background: var(--sage-d);
+        border-color: var(--sage-d);
+        text-decoration: none;
+      }
+      .btn.ghost {
+        background: transparent;
+        color: var(--ink);
+        border-color: var(--line);
+      }
+      .btn.ghost:hover {
+        background: transparent;
+        border-color: var(--sage);
+        color: var(--sage-d);
+      }
+      h2 {
+        font-weight: 700;
+        font-size: 15px;
+        font-family: var(--mono);
+        letter-spacing: 0.02em;
+        margin: 4px 0 8px;
+        color: var(--ink);
+      }
+      h2::before {
+        content: "## ";
+        color: var(--sage);
+      }
+      h3.md-h {
+        font-weight: 700;
+        font-size: 14px;
+        font-family: var(--mono);
+        margin: 16px 0 4px;
+        color: var(--ink);
+      }
+      h3.md-h::before {
+        content: "### ";
+        color: var(--sage);
+      }
+      .md p {
+        color: var(--ink-soft);
+        max-width: 46em;
+        margin-top: 8px;
+      }
+      .md p:first-child {
+        margin-top: 0;
+      }
+      .md b {
+        color: var(--ink);
+        font-weight: 650;
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 0.85em;
+        background: var(--cream-2);
+        padding: 1.5px 6px;
+        border-radius: 5px;
+        color: var(--sage-d);
+      }
+      ul.md-list {
+        list-style: none;
+        margin-top: 10px;
+        display: grid;
+        gap: 8px;
+      }
+      ul.md-list li {
+        color: var(--ink-soft);
+        font-size: 15px;
+        line-height: 1.5;
+        padding-left: 20px;
+        position: relative;
+        max-width: 46em;
+      }
+      ul.md-list li::before {
+        content: "-";
+        position: absolute;
+        left: 4px;
+        color: var(--sage);
+        font-family: var(--mono);
+      }
+      ul.md-list b {
+        color: var(--ink);
+        font-weight: 650;
+      }
+
+      /* code input cells */
+      .input {
+        background: var(--paper);
+        border: 1px solid var(--line);
+        border-left: 3px solid var(--sage);
+        border-radius: 7px;
+        overflow-x: auto;
+      }
+      .input pre {
+        padding: 13px 16px;
+        margin: 0;
+      }
+      .input code {
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.75;
+        background: none;
+        padding: 0;
+        color: var(--ink);
+        white-space: pre;
+      }
+      .input code .c {
+        color: var(--ink-faint);
+      }
+      .input code .p {
+        color: var(--sage-d);
+      }
+      details.manual {
+        margin: 12px 0 2px;
+      }
+      details.manual summary {
+        cursor: pointer;
+        font-family: var(--mono);
+        font-size: 12.5px;
+        color: var(--sage-d);
+        list-style: none;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+      details.manual summary::-webkit-details-marker {
+        display: none;
+      }
+      details.manual summary::before {
+        content: "›";
+        transition: transform 0.2s;
+      }
+      details.manual[open] summary::before {
+        transform: rotate(90deg);
+      }
+      .note {
+        font-size: 14px;
+        color: var(--ink-soft);
+        margin-top: 12px;
+        max-width: 46em;
+      }
+
+      /* how-it-works / apps rows */
+      .rows {
+        margin-top: 6px;
+        display: grid;
+        gap: 2px;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 168px 1fr;
+        gap: 18px;
+        padding: 12px 0;
+        border-top: 1px solid var(--line-soft);
+        align-items: start;
+      }
+      .row:first-child {
+        border-top: none;
+      }
+      @media (max-width: 560px) {
+        .row {
+          grid-template-columns: 1fr;
+          gap: 4px;
+        }
+      }
+      .row .k {
+        font-weight: 650;
+        font-size: 14.5px;
+      }
+      .row .k .t {
+        display: block;
+        font-family: var(--mono);
+        font-size: 11.5px;
+        color: var(--sage-d);
+        font-weight: 500;
+        margin-top: 3px;
+      }
+      .row .v {
+        color: var(--ink-soft);
+        font-size: 14.5px;
+      }
+
+      /* connectors / lake */
+      .lakebox {
+        border: 1px dashed var(--line);
+        border-radius: 12px;
+        padding: 13px 14px 14px;
+        display: inline-block;
+        margin-top: 12px;
+      }
+      .lk {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        margin-bottom: 11px;
+        display: flex;
+        align-items: center;
+        gap: 7px;
+      }
+      .lk .dot,
+      .chip .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--sage);
+        flex: 0 0 auto;
+      }
+      .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+      }
+      .chip {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        padding: 9px 13px;
+        background: var(--paper);
+        font-size: 14px;
+      }
+      .chip b {
+        font-weight: 650;
+      }
+      .chip span {
+        color: var(--ink-faint);
+        font-size: 12.5px;
+      }
+
+      /* figure / output cells */
+      .figure {
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        background: var(--paper);
+        padding: 16px 18px 12px;
+        overflow-x: auto;
+      }
+      .figure .cap {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        margin-bottom: 12px;
+      }
+      .figure svg {
+        width: 100%;
+        height: auto;
+        display: block;
+        margin: 0 auto;
+      }
+      .figure.arch svg {
+        min-width: 560px;
+      }
+      .diagram .node {
+        fill: #fff;
+        stroke: var(--ink);
+        stroke-width: 1.4;
+      }
+      .diagram .box {
+        fill: none;
+        stroke: var(--ink-faint);
+        stroke-width: 1.2;
+        stroke-dasharray: 4 5;
+      }
+      .diagram .t {
+        font-family: var(--sans);
+        font-size: 13px;
+        fill: var(--ink);
+      }
+      .diagram .s {
+        font-family: var(--sans);
+        font-size: 10.5px;
+        fill: var(--ink-soft);
+      }
+      .diagram .e {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        fill: var(--ink-soft);
+      }
+      .diagram .arr {
+        stroke: var(--ink-soft);
+        stroke-width: 1.4;
+        fill: none;
+      }
+
+      /* text output (plain result) cells */
+      .txtout {
+        font-family: var(--mono);
+        font-size: 13.5px;
+        line-height: 1.55;
+        color: var(--ink);
+        padding: 3px 2px;
+      }
+      .txtout .val {
+        font-size: 27px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+        line-height: 1.05;
+        color: var(--ink);
+        font-family: var(--sans);
+      }
+      .txtout .meta {
+        display: block;
+        margin-top: 7px;
+        font-family: var(--sans);
+        font-size: 13.5px;
+        color: var(--ink-soft);
+        max-width: 44em;
+        line-height: 1.5;
+      }
+      .txtout .flag {
+        display: inline-block;
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--out);
+        border: 1px solid color-mix(in srgb, var(--out) 40%, transparent);
+        border-radius: 5px;
+        padding: 1px 7px;
+        margin-bottom: 8px;
+      }
+      /* natural-language question input cell */
+      .ask {
+        background: var(--paper);
+        border: 1px solid var(--line);
+        border-left: 3px solid var(--sage);
+        border-radius: 7px;
+        padding: 12px 15px;
+        font-family: var(--mono);
+        font-size: 13.5px;
+        color: var(--ink);
+      }
+      .ask .fn {
+        color: var(--sage-d);
+      }
+      .ask .str {
+        color: var(--ink);
+      }
+
+      /* footer cell */
+      .colophon {
+        margin-top: 30px;
+        border-top: 1px solid var(--line);
+        padding-top: 20px;
+        display: flex;
+        justify-content: space-between;
+        gap: 18px;
+        flex-wrap: wrap;
+        align-items: center;
+        font-size: 13.5px;
+        color: var(--ink-faint);
+        max-width: var(--nb);
+        margin-left: auto;
+        margin-right: auto;
+        padding-left: 20px;
+        padding-right: 20px;
+      }
+      .colophon .l {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      .colophon a {
+        color: var(--ink-soft);
+      }
+      .colophon .jp {
+        font-family: var(--mono);
+        font-size: 12px;
+      }
+      .colophon .brand {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-weight: 700;
+        color: var(--ink);
+      }
+      .colophon .brand .mark {
+        width: 17px;
+        height: 17px;
+        color: #1a1a19;
+      }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path
+          d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z"
+          fill="currentColor"
+        />
+      </symbol>
+    </svg>
+
+    <div class="toolbar">
+      <div class="toolbar-inner">
+        <span class="tb-file"
+          ><svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+          setoku<span class="ext">.ipynb</span></span
+        >
+        <nav class="tb-menu" aria-hidden="true">
+          <span>File</span><span>Edit</span><span>View</span><span>Run</span
+          ><span>Kernel</span>
+        </nav>
+        <span class="tb-kernel"
+          ><span class="k-dot"></span>kernel: idle · MCP connected</span
+        >
+      </div>
+    </div>
+
+    <main class="nb" id="top">
+      <!-- TITLE (markdown cell) -->
+      <div class="cell sel">
+        <div class="gutter" aria-hidden="true"></div>
+        <div class="md title">
+          <span class="eyebrow"
+            >Open source · MCP server · Apache-2.0</span
+          >
+          <h1>
+            Make any AI fluent in your <span
+              class="rotator"
+              data-words="company,family,personal"
+              ><span class="rotator-word">company</span
+              ><span class="rotator-measure" aria-hidden="true"></span></span> data.
+          </h1>
+          <p class="lede">
+            Setoku is a small self-hosted MCP knowledge server + Claude Code
+            skills for hooking up your data. It does two things: it gives your
+            AI a read-only way to query your data, and it remembers what that
+            data means (the metric definitions, the gotchas), getting better the
+            more you use it. The MCP works with whatever AI you already have, and
+            no model runs on the server, so no added inference cost.
+          </p>
+          <div class="actions">
+            <a
+              class="btn"
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >View on GitHub ↗</a
+            >
+            <a class="btn ghost" href="#demo">Try the demo</a>
+          </div>
+        </div>
+      </div>
+
+      <!-- QUICKSTART markdown -->
+      <div class="cell">
+        <div class="gutter" aria-hidden="true"></div>
+        <div class="md">
+          <h2>Quickstart</h2>
+          <p>
+            Setoku installs as a Claude Code plugin. Add the plugin, then run
+            onboarding from your main project directory, the codebase you want
+            Setoku to learn from:
+          </p>
+        </div>
+      </div>
+      <!-- QUICKSTART code input -->
+      <div class="cell">
+        <div class="gutter in">In [1]:</div>
+        <div class="input">
+          <pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+<span class="p">/plugin</span> marketplace add Hedgy-Labs/setoku
+<span class="p">/plugin</span> install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+<span class="p">/setoku:onboard</span></code></pre>
+        </div>
+      </div>
+      <div class="cell">
+        <div class="gutter" aria-hidden="true"></div>
+        <div class="md">
+          <p>
+            Onboarding stands up the server, auths your Claude, wires your
+            database read-only, and generates the first knowledge from your
+            code. You stay in the loop for anything that touches your data. To
+            start onboarding, run <code>/setoku:onboard</code>.
+          </p>
+          <p>
+            You’ll need somewhere to host it. Something like OVH’s
+            <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener"
+              >VPS-2</a
+            >
+            is plenty.
+          </p>
+          <details class="manual">
+            <summary>Or stand up the server by hand</summary>
+            <div class="input" style="margin-top: 12px">
+              <pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+            </div>
+            <p class="note">
+              Installs Docker, generates secrets, gets an HTTPS certificate, and
+              prints the connect command. Then add the plugin and run
+              /setoku:onboard from your project; it’ll detect the box you just
+              made.
+            </p>
+          </details>
+        </div>
+      </div>
+
+      <!-- HOW IT WORKS -->
+      <div class="cell">
+        <div class="gutter" aria-hidden="true"></div>
+        <div class="md">
+          <h2>How it works</h2>
+          <p>
+            Setoku gives the AI two kinds of MCP tools, and one rule: look up
+            what the data means before you touch it.
+          </p>
+          <div class="rows">
+            <div class="row">
+              <div class="k">
+                Context tools<span class="t">find_context · get_metric</span>
+              </div>
+              <div class="v">
+                The AI reads what your data means first: canonical metric
+                definitions, entity docs, and the gotchas that make a naive
+                query wrong.
+              </div>
+            </div>
+            <div class="row">
+              <div class="k">
+                Read-only query<span class="t">get_schema · run_query</span>
+              </div>
+              <div class="v">
+                Read-only, with a row cap, a statement timeout, a table
+                allow-list, and an append-only audit log. Enforced by the
+                database role, not by parsing SQL.
+              </div>
+            </div>
+            <div class="row">
+              <div class="k">
+                Human-approved<span class="t">report_correction</span>
+              </div>
+              <div class="v">
+                The AI can only propose changes to what Setoku knows. A person
+                accepts them on the admin page, outside the agent loop, so an
+                injected session can’t rewrite the brain.
+              </div>
+            </div>
+          </div>
+          <p class="note">You set it up with <b>Claude Code</b> skills:</p>
+          <ul class="md-list">
+            <li>
+              <code>/setoku:onboard</code> sets Setoku up in a repo for the
+              first time.
+            </li>
+            <li>
+              <code>/setoku:connect</code> adds a data source or custom
+              integration.
+            </li>
+            <li>
+              <code>/setoku:generate</code> writes business context from your
+              code.
+            </li>
+            <li>
+              <code>/setoku:curate</code> reviews and approves pending
+              knowledge.
+            </li>
+          </ul>
+          <p class="note">
+            Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex,
+            or whatever you run. Just ask in plain language, and the tools do
+            the rest.
+          </p>
+        </div>
+      </div>
+
+      <!-- APPS -->
+      <div class="cell">
+        <div class="gutter" aria-hidden="true"></div>
+        <div class="md">
+          <h2>Apps: save and share the tools Claude builds you</h2>
+          <p>
+            Ask Claude to build a dashboard on your data. Then publish it to a
+            link as a Setoku App, the data stays live, and your whole team can
+            view it. Nothing to deploy, no frontend to maintain.
+          </p>
+          <div class="rows">
+            <div class="row">
+              <div class="k">
+                Built by asking<span class="t">publish_app</span>
+              </div>
+              <div class="v">
+                Describe it in plain language; the agent writes the app and
+                publishes it to a URL. Edit it the same way, just ask for the
+                change.
+              </div>
+            </div>
+            <div class="row">
+              <div class="k">
+                Backed by live data<span class="t">read-only</span>
+              </div>
+              <div class="v">
+                Apps read through the same governed path: row caps, audit, a
+                SELECT-only database role. They never get write access to your
+                sources.
+              </div>
+            </div>
+            <div class="row">
+              <div class="k">
+                App-private state<span class="t">no writes to your data</span>
+              </div>
+              <div class="v">
+                Each app keeps its own state (todos, votes, annotations) in a
+                sandbox that belongs to the app, not your database. Worst case,
+                an app messes up its own notes.
+              </div>
+            </div>
+            <div class="row">
+              <div class="k">
+                Share by link<span class="t">team or public</span>
+              </div>
+              <div class="v">
+                A team link is login-gated; an admin can flip one public for a
+                credential-free URL. The page runs in a locked-down sandbox with
+                no network, so a published app can’t phone home.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ARCHITECTURE markdown + figure output -->
+      <div class="cell">
+        <div class="gutter" aria-hidden="true"></div>
+        <div class="md">
+          <h2>Architecture</h2>
+          <p>
+            You can host this on whatever infra you like. We put it all on one
+            small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+            helps you add custom integrations. Only the proxy is public, so your
+            databases aren’t exposed. Queries are read-only, and knowledge
+            changes pass through a person.
+          </p>
+        </div>
+      </div>
+      <div class="cell">
+        <div class="gutter out">Out [ ]:</div>
+        <div class="figure arch diagram">
+          <div class="cap">fig · setoku architecture and data flow</div>
+          <svg
+            viewBox="0 0 680 520"
+            role="img"
+            aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake for analytics, and your sources (GitHub, Vercel, Render, Slack, Mercury) are ingested into the lake."
+          >
+            <defs>
+              <marker
+                id="ah"
+                markerWidth="9"
+                markerHeight="9"
+                refX="6"
+                refY="3"
+                orient="auto-start-reverse"
+              >
+                <path d="M0 0 L6 3 L0 6 Z" fill="#54615A" />
+              </marker>
+            </defs>
+            <rect class="node" x="250" y="14" width="180" height="44" rx="10" />
+            <text class="t" x="340" y="41" text-anchor="middle">
+              You + your AI
+            </text>
+            <path
+              class="arr"
+              d="M340 58 L340 142"
+              marker-start="url(#ah)"
+              marker-end="url(#ah)"
+            />
+            <text class="e" x="348" y="86">MCP</text>
+            <rect class="box" x="60" y="110" width="560" height="300" rx="14" />
+            <text class="e" x="76" y="130" fill="#8E968C">your box</text>
+            <rect class="node" x="250" y="146" width="180" height="58" rx="10" />
+            <text class="t" x="340" y="171" text-anchor="middle">
+              Setoku gateway
+            </text>
+            <text class="s" x="340" y="189" text-anchor="middle">
+              context · query tools
+            </text>
+            <rect class="node" x="452" y="150" width="150" height="50" rx="10" />
+            <text class="t" x="527" y="179" text-anchor="middle">a person</text>
+            <rect class="node" x="92" y="322" width="180" height="66" rx="10" />
+            <text class="t" x="182" y="350" text-anchor="middle">
+              Lake (ClickHouse)
+            </text>
+            <text class="s" x="182" y="368" text-anchor="middle">
+              logs · events · DB mirror
+            </text>
+            <rect class="node" x="408" y="322" width="190" height="66" rx="10" />
+            <text class="t" x="503" y="359" text-anchor="middle">
+              Knowledge store
+            </text>
+            <rect class="node" x="92" y="440" width="180" height="64" rx="10" />
+            <text class="t" x="182" y="468" text-anchor="middle">
+              Your sources
+            </text>
+            <text class="s" x="182" y="486" text-anchor="middle">
+              GitHub · Vercel · Slack…
+            </text>
+            <rect class="node" x="300" y="440" width="180" height="64" rx="10" />
+            <text class="t" x="390" y="468" text-anchor="middle">
+              Your database
+            </text>
+            <text class="s" x="390" y="486" text-anchor="middle">
+              Postgres · read-only
+            </text>
+            <path
+              class="arr"
+              d="M412 204 L508 322"
+              marker-start="url(#ah)"
+              marker-end="url(#ah)"
+            />
+            <text class="e" x="424" y="266" text-anchor="middle">reads ·</text>
+            <text class="e" x="424" y="282" text-anchor="middle">proposes</text>
+            <path class="arr" d="M527 200 L513 322" marker-end="url(#ah)" />
+            <text class="e" x="534" y="262">approves</text>
+            <path class="arr" d="M210 322 L300 204" marker-end="url(#ah)" />
+            <path class="arr" d="M182 440 L182 388" marker-end="url(#ah)" />
+            <text class="e" x="190" y="420">ingest</text>
+            <path class="arr" d="M388 440 L366 206" marker-end="url(#ah)" />
+            <text class="e" x="300" y="300">read-only</text>
+          </svg>
+        </div>
+      </div>
+
+      <!-- CONNECTORS -->
+      <div class="cell">
+        <div class="gutter" aria-hidden="true"></div>
+        <div class="md">
+          <h2>Connectors</h2>
+          <p>
+            Point Setoku at the data you already have. Every source lands in a
+            local
+            <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+              >ClickHouse</a
+            >
+            data lake, on purpose: agents write arbitrary queries (scans, GROUP
+            BYs, whole-table aggregations), and a columnar engine answers those
+            in about a second, so the apps and dashboards they build stay quick.
+            Your app database connects read-only and is mirrored in on a cron;
+            the rest is ingested as it happens.
+          </p>
+          <div class="lakebox">
+            <div class="lk">
+              <span class="dot"></span>ClickHouse · one lake, every source
+            </div>
+            <div class="chips">
+              <div class="chip">
+                <span class="dot"></span><b>PostgreSQL</b
+                ><span>app database, mirrored read-only</span>
+              </div>
+              <div class="chip">
+                <span class="dot"></span><b>GitHub</b
+                ><span>issues, PRs &amp; commits</span>
+              </div>
+              <div class="chip">
+                <span class="dot"></span><b>Vercel</b><span>deploys &amp; logs</span>
+              </div>
+              <div class="chip">
+                <span class="dot"></span><b>Render</b><span>deploys &amp; logs</span>
+              </div>
+              <div class="chip">
+                <span class="dot"></span><b>Slack</b><span>messages</span>
+              </div>
+              <div class="chip">
+                <span class="dot"></span><b>Mercury</b
+                ><span>banking &amp; finance</span>
+              </div>
+            </div>
+          </div>
+          <p class="note">
+            No connector for your source yet? The included setup skills give your
+            coding agent the patterns to wire one up itself. See
+            <a
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >the repo</a
+            >, or open an issue.
+          </p>
+        </div>
+      </div>
+
+      <!-- DEMO -->
+      <div class="cell" id="demo">
+        <div class="gutter" aria-hidden="true"></div>
+        <div class="md">
+          <h2>Try it on real-ish data</h2>
+          <p>
+            There’s a live demo wired to a fictional pro sports club, the Bonita
+            Bulldogs (ticketing, sponsorship, concessions, payroll, broadcast
+            rights).
+          </p>
+          <p class="note">
+            In Claude (or any MCP client) open Settings → Connectors → Add custom
+            connector, and paste this URL. The token rides in the URL, so
+            there’s no separate key to enter.
+          </p>
+        </div>
+      </div>
+      <div class="cell">
+        <div class="gutter in">In [1]:</div>
+        <div class="input">
+          <pre><code>https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</code></pre>
+        </div>
+      </div>
+
+      <!-- Q1 -->
+      <div class="cell">
+        <div class="gutter in">In [2]:</div>
+        <div class="ask">
+          <span class="fn">ask</span>(<span class="str"
+            >“How many unique fans do we have?”</span
+          >)
+        </div>
+      </div>
+      <div class="cell">
+        <div class="gutter out">Out [2]:</div>
+        <div class="txtout">
+          <span class="val">71,204</span>
+          <span class="meta"
+            >deduped by normalized email, internal accounts excluded. Not the raw
+            92,118.</span
+          >
+        </div>
+      </div>
+
+      <!-- Q2 -->
+      <div class="cell">
+        <div class="gutter in">In [3]:</div>
+        <div class="ask">
+          <span class="fn">ask</span>(<span class="str"
+            >“What’s our total annual revenue, and how much is media
+            rights?”</span
+          >)
+        </div>
+      </div>
+      <div class="cell">
+        <div class="gutter out">Out [3]:</div>
+        <div class="txtout">
+          <span class="val">$192M</span>
+          <span class="meta"
+            >five systems reconciled to the same units. Media rights is the
+            biggest line, ~$90M.</span
+          >
+        </div>
+      </div>
+
+      <!-- Q3 -->
+      <div class="cell">
+        <div class="gutter in">In [4]:</div>
+        <div class="ask">
+          <span class="fn">ask</span>(<span class="str"
+            >“What was ticket revenue this season?”</span
+          >)
+        </div>
+      </div>
+      <div class="cell">
+        <div class="gutter out">Out [4]:</div>
+        <div class="txtout">
+          <span class="val">$46.8M</span>
+          <span class="meta"
+            >cents reconciled to dollars; refunds, exchanges, and comps
+            excluded.</span
+          >
+        </div>
+      </div>
+
+      <!-- Q4 -->
+      <div class="cell">
+        <div class="gutter in">In [5]:</div>
+        <div class="ask">
+          <span class="fn">ask</span>(<span class="str"
+            >“What’s our total merchandise revenue?”</span
+          >)
+        </div>
+      </div>
+      <div class="cell">
+        <div class="gutter out">Out [5]:</div>
+        <div class="txtout">
+          <span class="flag">flags it</span>
+          <span class="meta"
+            >most merch is sold via Fanatics, not in this data, so it says so
+            instead of returning a wrong total.</span
+          >
+        </div>
+      </div>
+
+      <!-- Q5 chart -->
+      <div class="cell">
+        <div class="gutter in">In [6]:</div>
+        <div class="ask">
+          <span class="fn">ask</span>(<span class="str">“Chart revenue by line.”</span>)
+        </div>
+      </div>
+      <div class="cell">
+        <div class="gutter out">Out [6]:</div>
+        <div class="figure">
+          <div class="cap">Annual revenue by line · ~$192M total</div>
+          <svg
+            viewBox="0 0 640 214"
+            role="img"
+            aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M."
+          >
+            <g fill="#5F8C6B">
+              <rect x="148" y="14" width="400" height="16" rx="3" />
+              <rect x="148" y="48" width="209" height="16" rx="3" />
+              <rect x="148" y="82" width="124" height="16" rx="3" />
+              <rect x="148" y="116" width="62" height="16" rx="3" />
+              <rect x="148" y="150" width="36" height="16" rx="3" />
+              <rect x="148" y="184" width="22" height="16" rx="3" />
+            </g>
+            <g
+              font-family="ui-sans-serif, system-ui, sans-serif"
+              font-size="12.5"
+              fill="#54615A"
+            >
+              <text x="8" y="26">Media rights</text>
+              <text x="8" y="60">Ticketing</text>
+              <text x="8" y="94">Sponsorship</text>
+              <text x="8" y="128">Concessions</text>
+              <text x="8" y="162">Merch</text>
+              <text x="8" y="196">Other</text>
+            </g>
+            <g
+              font-family="ui-monospace, Menlo, monospace"
+              font-size="12"
+              fill="#212E26"
+            >
+              <text x="555" y="26">$90M</text>
+              <text x="364" y="60">$47M</text>
+              <text x="279" y="94">$28M</text>
+              <text x="217" y="128">$14M</text>
+              <text x="191" y="162">$8M</text>
+              <text x="177" y="196">$5M</text>
+            </g>
+          </svg>
+        </div>
+      </div>
+
+      <!-- apps in the demo -->
+      <div class="cell">
+        <div class="gutter" aria-hidden="true"></div>
+        <div class="md">
+          <h3 class="md-h">Try an app</h3>
+          <p class="note">
+            Ask Claude to build a dashboard on the same data, then publish it to
+            a link. Two live examples, running on the demo data right now:
+          </p>
+          <ul class="md-list">
+            <li>
+              <a
+                href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+                target="_blank"
+                rel="noopener"
+                >Sponsorship pricing table ↗</a
+              >
+              — inventory and rates for sponsorship placements.
+            </li>
+            <li>
+              <a
+                href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+                target="_blank"
+                rel="noopener"
+                >Fan lifetime value ↗</a
+              >
+              — segment fans by spend across tickets, merch, and concessions.
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- WHY -->
+      <div class="cell">
+        <div class="gutter" aria-hidden="true"></div>
+        <div class="md">
+          <h2>Why we built it</h2>
+          <h3 class="md-h">We’re curious.</h3>
+          <p>
+            There are plenty of AI memory stores, and plenty of data gateways.
+            Stapling the two together, and nudging the agent to gather knowledge
+            about the data as it goes, seemed useful and fun to tinker with.
+          </p>
+          <h3 class="md-h">We’re cheap.</h3>
+          <p>
+            We wanted something that runs on one small box, works on a Pro/Max
+            subscription or a cheap model with no added inference cost, mostly
+            sets itself up (no field engineer to pay for), stays portable between
+            providers, and is open source.
+          </p>
+          <h3 class="md-h">We’re paranoid.</h3>
+          <p>
+            HR platforms, CRMs, and clouds are all announcing “context layers.”
+            They’d like the meaning of your business to accumulate on their
+            servers, where it can never leave. Context is deeper lock-in than
+            data, and a hosted context layer has no export button. Setoku exists
+            so that understanding accumulates on a box you own instead. If we
+            disappear tomorrow, your context doesn’t.
+          </p>
+          <h3 class="md-h">We and some friends wanted the same thing.</h3>
+          <ul class="md-list">
+            <li>
+              <b
+                ><a href="https://www.hedgy.works" target="_blank" rel="noopener"
+                  >Hedgy</a
+                ></b
+              >: keep scaling without hiring. Debug from live logs and data, find
+              growth levers, and match candidates and companies better with more
+              data.
+            </li>
+            <li>
+              <b
+                ><a href="https://baggu.com" target="_blank" rel="noopener"
+                  >Baggu</a
+                ></b
+              >: give employees state-of-the-art tools. Faster onboarding, and a
+              safe way to vibecode against real data.
+            </li>
+            <li>
+              <b
+                ><a href="https://tlon.io" target="_blank" rel="noopener"
+                  >Tlon</a
+                ></b
+              >: experimenting with giving agents curated data to work from.
+            </li>
+            <li>
+              <b>Sports analysts</b>: query across data that doesn’t usually sit
+              together.
+            </li>
+            <li>
+              <b>Academic labs</b>: think through hypotheses against real papers,
+              data, and drafts.
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- SETUP HELP -->
+      <div class="cell">
+        <div class="gutter" aria-hidden="true"></div>
+        <div class="md">
+          <h2>Setup help</h2>
+          <p>
+            It’s open source, so you can self-host it today. If you like, we’re
+            happy to help set it up. Just email
+            <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+          </p>
+        </div>
+      </div>
+    </main>
+
+    <div class="colophon">
+      <div class="l">
+        <a class="brand" href="#top"
+          ><svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+          Setoku</a
+        >
+        <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener"
+          >GitHub</a
+        >
+        <a href="#demo">Demo</a>
+        <a href="mailto:hello@setoku.com">Contact</a>
+        <span>Apache-2.0</span>
+      </div>
+      <span class="jp">設 × 奥 · set (math) × oku (innermost)</span>
+    </div>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) { return w.trim(); })
+          .filter(Boolean);
+        if (words.length < 2) return;
+
+        var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        var LIFT = "0.72em";
+        var HALF = 240;
+        var HOLD = 2400;
+        var i = 0;
+
+        function widthOf(w) {
+          measure.textContent = w;
+          return measure.getBoundingClientRect().width;
+        }
+        box.style.width = widthOf(words[0]) + "px";
+
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next;
+            box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length;
+            return;
+          }
+          word
+            .animate(
+              [
+                { transform: "translateY(0)", opacity: 1 },
+                { transform: "translateY(-" + LIFT + ")", opacity: 0 },
+              ],
+              { duration: HALF, easing: "cubic-bezier(0.4, 0, 1, 1)", fill: "forwards" }
+            )
+            .finished.then(function () {
+              word.textContent = next;
+              box.style.width = widthOf(next) + "px";
+              word.animate(
+                [
+                  { transform: "translateY(" + LIFT + ")", opacity: 0 },
+                  { transform: "translateY(0)", opacity: 1 },
+                ],
+                { duration: HALF, easing: "cubic-bezier(0, 0, 0.2, 1)", fill: "forwards" }
+              );
+              i = (i + 1) % words.length;
+            })
+            .catch(function () {});
+        }
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () {
+          box.style.width = widthOf(words[i]) + "px";
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/7-fieldguide.html
+++ b/site/riffs/7-fieldguide.html
@@ -1,0 +1,1062 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · A Field Guide</title>
+    <meta
+      name="description"
+      content="Setoku is an open-source MCP server that gives your AI a read-only view of your company’s data, plus the context to use it correctly. A field guide."
+    />
+    <style>
+      :root {
+        --paper: #f3ecd8;
+        --paper-2: #ece2c8;
+        --plate: #f7f1e1;
+        --ink: #2a2720;
+        --ink-soft: #4a453a;
+        --ink-faint: #6b6350;
+        --rule: #b8ab8a;
+        --rule-soft: #cabf9f;
+        --olive: #55613a;
+        --olive-d: #3c471f;
+        --sepia: #7a6a45;
+        --serif: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua",
+          Georgia, serif;
+        --sans: "Optima", "Gill Sans", "Gill Sans MT", ui-sans-serif, system-ui,
+          sans-serif;
+        --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        --w: 780px;
+      }
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      html { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+      body {
+        background: var(--paper);
+        background-image:
+          radial-gradient(circle at 18% 12%, rgba(122, 106, 69, 0.05), transparent 42%),
+          radial-gradient(circle at 84% 78%, rgba(122, 106, 69, 0.045), transparent 46%);
+        color: var(--ink);
+        font-family: var(--serif);
+        font-size: 17px;
+        line-height: 1.62;
+      }
+      a { color: var(--olive-d); text-decoration: none; }
+      a:hover { text-decoration: underline; text-underline-offset: 2px; }
+      svg { display: block; }
+      code {
+        font-family: var(--mono);
+        font-size: 0.82em;
+        background: rgba(122, 106, 69, 0.11);
+        padding: 1px 5px;
+        border-radius: 3px;
+        color: var(--olive-d);
+      }
+      ::selection { background: var(--olive); color: var(--paper); }
+
+      /* frame the whole page as a bound plate */
+      .sheet {
+        max-width: 940px;
+        margin: 24px auto;
+        background: var(--plate);
+        border: 1px solid var(--rule);
+        box-shadow: 0 0 0 6px var(--plate), 0 0 0 7px var(--rule-soft),
+          0 18px 50px -30px rgba(42, 39, 32, 0.5);
+        position: relative;
+      }
+      .sheet::after {
+        content: "";
+        position: absolute;
+        inset: 12px;
+        border: 1px solid var(--rule-soft);
+        pointer-events: none;
+      }
+      .inner { position: relative; padding: 40px clamp(20px, 5vw, 64px) 0; }
+
+      /* running head */
+      .runhead {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        font-family: var(--sans);
+        font-size: 11px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--sepia);
+        border-bottom: 1px solid var(--rule);
+        padding-bottom: 10px;
+      }
+      .runhead .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--ink);
+        letter-spacing: 0.12em;
+        font-weight: 600;
+      }
+      .runhead .mark { width: 17px; height: 17px; color: var(--olive-d); }
+      .runhead a { color: var(--sepia); }
+
+      /* plate scaffolding */
+      .plate {
+        padding: 40px 0 38px;
+        border-bottom: 1px solid var(--rule);
+      }
+      .plate:last-of-type { border-bottom: none; }
+      .plate-no {
+        font-family: var(--sans);
+        font-size: 11px;
+        letter-spacing: 0.3em;
+        text-transform: uppercase;
+        color: var(--sepia);
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 14px;
+      }
+      .plate-no::after {
+        content: "";
+        flex: 1;
+        height: 1px;
+        background: var(--rule-soft);
+      }
+      .plate h2 {
+        font-family: var(--serif);
+        font-weight: 600;
+        font-style: italic;
+        font-size: clamp(24px, 3.4vw, 31px);
+        letter-spacing: 0.01em;
+        line-height: 1.12;
+      }
+      .caption {
+        font-style: italic;
+        color: var(--ink-soft);
+        max-width: 42em;
+        margin-top: 8px;
+      }
+      .smallcaps {
+        font-family: var(--sans);
+        font-size: 12px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--sepia);
+      }
+      p { max-width: 44em; }
+      .plate > p { margin-top: 14px; color: var(--ink-soft); }
+
+      /* TITLE PLATE */
+      .title-plate { text-align: center; padding: 30px 0 44px; }
+      .title-plate .kicker {
+        font-family: var(--sans);
+        font-size: 12px;
+        letter-spacing: 0.34em;
+        text-transform: uppercase;
+        color: var(--sepia);
+      }
+      .specimen {
+        margin: 22px auto 8px;
+        width: 148px; height: 148px;
+        border: 1px solid var(--rule);
+        border-radius: 50%;
+        display: grid;
+        place-items: center;
+        position: relative;
+        background:
+          repeating-radial-gradient(circle at 50% 50%, transparent 0 5px, rgba(122,106,69,0.05) 5px 6px);
+      }
+      .specimen::before {
+        content: "";
+        position: absolute;
+        inset: 9px;
+        border: 1px solid var(--rule-soft);
+        border-radius: 50%;
+      }
+      .specimen svg { width: 78px; height: 78px; color: var(--olive-d); }
+      .fig-tag {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        letter-spacing: 0.14em;
+        color: var(--sepia);
+        text-transform: uppercase;
+      }
+      h1 {
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: clamp(30px, 5.4vw, 50px);
+        line-height: 1.08;
+        letter-spacing: 0.005em;
+        margin: 18px auto 0;
+        max-width: 16em;
+      }
+      .binomial {
+        font-style: italic;
+        color: var(--sepia);
+        margin-top: 10px;
+        font-size: 18px;
+        letter-spacing: 0.01em;
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        color: var(--olive-d);
+        font-style: italic;
+        transition: width 480ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+        will-change: transform, opacity;
+        border-bottom: 1px solid rgba(60, 71, 31, 0.4);
+      }
+      .rotator-measure {
+        position: absolute; left: 0; top: 0;
+        visibility: hidden; pointer-events: none; white-space: nowrap;
+      }
+      @media (prefers-reduced-motion: reduce) { .rotator { transition: none; } }
+      .lede {
+        font-style: italic;
+        color: var(--ink-soft);
+        font-size: 18.5px;
+        margin: 20px auto 0;
+        max-width: 40em;
+      }
+      .actions {
+        margin-top: 26px;
+        display: flex;
+        gap: 14px;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        font-family: var(--sans);
+        font-size: 12.5px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        padding: 11px 20px;
+        border: 1px solid var(--ink);
+        color: var(--ink);
+        background: transparent;
+      }
+      .btn:hover { background: var(--ink); color: var(--paper); text-decoration: none; }
+      .btn.solid { background: var(--olive-d); border-color: var(--olive-d); color: var(--paper); }
+      .btn.solid:hover { background: var(--ink); border-color: var(--ink); }
+
+      /* classification block */
+      .classis {
+        margin: 34px auto 0;
+        max-width: 480px;
+        border: 1px solid var(--rule);
+        background: rgba(122, 106, 69, 0.05);
+        text-align: left;
+      }
+      .classis .ch {
+        font-family: var(--sans);
+        font-size: 10.5px;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        color: var(--sepia);
+        text-align: center;
+        padding: 9px 0;
+        border-bottom: 1px solid var(--rule-soft);
+      }
+      .classis dl { display: grid; grid-template-columns: auto 1fr; }
+      .classis dt, .classis dd {
+        padding: 7px 16px;
+        border-bottom: 1px solid var(--rule-soft);
+        font-size: 14.5px;
+      }
+      .classis dt {
+        font-family: var(--sans);
+        font-size: 11px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--sepia);
+        border-right: 1px solid var(--rule-soft);
+      }
+      .classis dd { font-style: italic; color: var(--ink); }
+      .classis dl > :nth-last-child(-n + 2) { border-bottom: none; }
+
+      /* specimen boxes / plates figures */
+      pre {
+        background: var(--paper-2);
+        border: 1px solid var(--rule);
+        padding: 16px 18px;
+        overflow-x: auto;
+        margin: 18px 0;
+        font-family: var(--mono);
+      }
+      pre code {
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.85;
+        background: none;
+        padding: 0;
+        color: var(--ink);
+        white-space: pre;
+      }
+      pre code .c { color: var(--sepia); font-style: italic; }
+      .note { color: var(--ink-soft); margin-top: 14px; font-style: italic; }
+      details.manual { margin-top: 18px; }
+      details.manual summary {
+        cursor: pointer;
+        font-family: var(--sans);
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--olive-d);
+        list-style: none;
+      }
+      details.manual summary::-webkit-details-marker { display: none; }
+      details.manual summary::before { content: "❧ "; color: var(--sepia); }
+
+      /* field-notes rows (anatomy) */
+      .entries { margin-top: 20px; }
+      .entry {
+        display: grid;
+        grid-template-columns: 200px 1fr;
+        gap: 22px;
+        padding: 16px 0;
+        border-top: 1px solid var(--rule-soft);
+        align-items: baseline;
+      }
+      .entry:first-child { border-top: none; }
+      @media (max-width: 620px) {
+        .entry { grid-template-columns: 1fr; gap: 5px; }
+      }
+      .entry .term {
+        font-style: italic;
+        font-weight: 600;
+        font-size: 16px;
+      }
+      .entry .term .lat {
+        display: block;
+        font-family: var(--mono);
+        font-style: normal;
+        font-size: 11px;
+        letter-spacing: 0.02em;
+        color: var(--olive-d);
+        margin-top: 3px;
+      }
+      .entry .desc { color: var(--ink-soft); font-size: 15.5px; }
+
+      .list {
+        list-style: none;
+        margin-top: 14px;
+        display: grid;
+        gap: 9px;
+      }
+      .list li {
+        position: relative;
+        padding-left: 22px;
+        color: var(--ink-soft);
+        font-size: 15.5px;
+        max-width: 44em;
+      }
+      .list li::before {
+        content: "❦";
+        position: absolute;
+        left: 0;
+        color: var(--sepia);
+        font-size: 12px;
+        top: 2px;
+      }
+      .list b { color: var(--ink); font-style: italic; font-weight: 600; }
+
+      /* figure frame */
+      figure {
+        margin: 22px 0 6px;
+        border: 1px solid var(--rule);
+        background: var(--plate);
+        padding: 18px 18px 12px;
+      }
+      figure .fh {
+        font-family: var(--sans);
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--sepia);
+        text-align: center;
+        margin-bottom: 14px;
+      }
+      figure svg { width: 100%; height: auto; margin: 0 auto; }
+      figcaption {
+        font-style: italic;
+        text-align: center;
+        color: var(--ink-faint);
+        font-size: 13.5px;
+        margin-top: 12px;
+      }
+      .diagram .node { fill: var(--plate); stroke: var(--ink); stroke-width: 1.3; }
+      .diagram .box { fill: none; stroke: var(--sepia); stroke-width: 1; stroke-dasharray: 3 4; }
+      .diagram .t { font-family: var(--serif); font-style: italic; font-size: 13px; fill: var(--ink); }
+      .diagram .s { font-family: var(--sans); font-size: 10px; fill: var(--ink-soft); letter-spacing: 0.03em; }
+      .diagram .e { font-family: var(--mono); font-size: 10px; fill: var(--sepia); }
+      .diagram .arr { stroke: var(--ink-soft); stroke-width: 1.2; fill: none; }
+
+      /* collected species (connectors) checklist */
+      .species {
+        margin-top: 20px;
+        border: 1px solid var(--rule);
+      }
+      .species .sh {
+        font-family: var(--sans);
+        font-size: 11px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--sepia);
+        padding: 11px 16px;
+        border-bottom: 1px solid var(--rule);
+        background: rgba(122, 106, 69, 0.05);
+        display: flex;
+        align-items: center;
+        gap: 9px;
+      }
+      .species .leaf { width: 12px; height: 12px; color: var(--olive-d); }
+      .species .row2 {
+        display: grid;
+        grid-template-columns: 1.1fr 2fr;
+        gap: 16px;
+        padding: 12px 16px;
+        border-top: 1px solid var(--rule-soft);
+        align-items: baseline;
+      }
+      .species .row2:first-of-type { border-top: none; }
+      .species .row2 .sp {
+        font-style: italic;
+        font-weight: 600;
+      }
+      .species .row2 .sp::before {
+        content: "☑ ";
+        font-style: normal;
+        color: var(--olive-d);
+      }
+      .species .row2 .gl { color: var(--ink-soft); font-size: 14.5px; }
+      @media (max-width: 560px) {
+        .species .row2 { grid-template-columns: 1fr; gap: 3px; }
+      }
+
+      /* field observations (demo) */
+      .obs-step { margin-top: 26px; }
+      .obs-step .oh {
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 18px;
+        margin-bottom: 8px;
+      }
+      .obs-step .on {
+        font-family: var(--sans);
+        font-size: 11px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--sepia);
+        border: 1px solid var(--rule);
+        padding: 3px 8px;
+      }
+      .observations { margin-top: 20px; border-top: 1px solid var(--rule-soft); }
+      .ob {
+        padding: 16px 0;
+        border-bottom: 1px solid var(--rule-soft);
+      }
+      .ob .q { font-style: italic; color: var(--ink-soft); font-size: 16px; }
+      .ob .a {
+        margin-top: 10px;
+        padding-left: 18px;
+        border-left: 2px solid var(--rule);
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 16px;
+        align-items: baseline;
+      }
+      @media (max-width: 560px) { .ob .a { grid-template-columns: 1fr; gap: 4px; } }
+      .ob .a .meas {
+        font-family: var(--serif);
+        font-weight: 700;
+        font-size: 27px;
+        letter-spacing: 0.005em;
+        line-height: 1;
+        white-space: nowrap;
+      }
+      .ob .a .rem { color: var(--ink-soft); font-size: 14px; font-style: italic; }
+      .ob.full .a { display: block; }
+
+      /* colophon / help */
+      .colophon {
+        text-align: center;
+        padding: 36px 0 40px;
+      }
+      .colophon .rule-orn {
+        color: var(--sepia);
+        letter-spacing: 0.4em;
+        font-size: 13px;
+        margin-bottom: 16px;
+      }
+      .colophon p { margin: 0 auto; max-width: 40em; font-style: italic; color: var(--ink-soft); }
+
+      /* footer / plate binding */
+      footer {
+        border-top: 1px solid var(--rule);
+        margin-top: 8px;
+        padding: 22px clamp(20px, 5vw, 64px) 34px;
+        display: flex;
+        justify-content: space-between;
+        gap: 18px;
+        flex-wrap: wrap;
+        align-items: center;
+        font-family: var(--sans);
+        font-size: 11.5px;
+        letter-spacing: 0.08em;
+        color: var(--sepia);
+      }
+      footer .l { display: flex; gap: 18px; flex-wrap: wrap; align-items: center; }
+      footer a { color: var(--ink-soft); }
+      footer .jp {
+        font-family: var(--serif);
+        font-style: italic;
+        letter-spacing: 0.03em;
+        font-size: 13px;
+      }
+      .plate-of {
+        text-align: center;
+        font-family: var(--sans);
+        font-size: 10.5px;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        color: var(--sepia);
+        padding: 0 0 8px;
+      }
+    </style>
+  </head>
+  <body id="top">
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path
+          d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z"
+          fill="currentColor"
+        />
+      </symbol>
+    </svg>
+
+    <div class="sheet">
+      <div class="inner">
+        <div class="runhead">
+          <a class="brand" href="#top">
+            <svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+            Setoku
+          </a>
+          <span>A Field Guide · Apache-2.0</span>
+          <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener"
+            >Repository ↗</a
+          >
+        </div>
+
+        <!-- TITLE PLATE -->
+        <div class="title-plate">
+          <div class="kicker">A Field Guide to the Species</div>
+          <div class="specimen">
+            <svg viewBox="0 0 64 64"><use href="#clover" /></svg>
+          </div>
+          <div class="fig-tag">Plate I · Specimen, life size</div>
+          <h1>Make any AI fluent in your <span
+              class="rotator"
+              data-words="company,family,personal"
+            ><span class="rotator-word">company</span><span
+                class="rotator-measure"
+                aria-hidden="true"
+              ></span></span> data.</h1>
+          <div class="binomial">Setoku officinalis · the self-hosted context server</div>
+          <p class="lede">
+            Setoku is a small self-hosted MCP knowledge server + Claude Code
+            skills for hooking up your data. It does two things: it gives your AI
+            a read-only way to query your data, and it remembers what that data
+            means (the metric definitions, the gotchas), getting better the more
+            you use it. The MCP works with whatever AI you already have, and no
+            model runs on the server, so no added inference cost.
+          </p>
+          <div class="actions">
+            <a class="btn solid" href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">View on GitHub ↗</a>
+            <a class="btn" href="#demo">Try the demo</a>
+          </div>
+
+          <div class="classis">
+            <div class="ch">Classification</div>
+            <dl>
+              <dt>Kingdom</dt><dd>Open source software</dd>
+              <dt>Phylum</dt><dd>Model Context Protocol</dd>
+              <dt>Class</dt><dd>Knowledge &amp; query server</dd>
+              <dt>Order</dt><dd>Self-hosted, single-tenant</dd>
+              <dt>Habitat</dt><dd>One small VPS (~$12/mo)</dd>
+              <dt>Etymology</dt><dd>設 × 奥 · set × oku</dd>
+            </dl>
+          </div>
+        </div>
+
+        <!-- PLATE II — CULTIVATION -->
+        <section class="plate" id="quickstart">
+          <div class="plate-no">Plate II · Cultivation</div>
+          <h2>Quickstart, or how to raise a specimen</h2>
+          <p class="caption">
+            Setoku installs as a Claude Code plugin. Add the plugin, then run
+            onboarding from your main project directory, the codebase you want
+            Setoku to learn from.
+          </p>
+          <pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+          <p>
+            Onboarding stands up the server, auths your Claude, wires your
+            database read-only, and generates the first knowledge from your
+            code. You stay in the loop for anything that touches your data. To
+            start onboarding, run <code>/setoku:onboard</code>.
+          </p>
+          <p>
+            You’ll need somewhere to host it. Something like OVH’s
+            <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener">VPS-2</a>
+            is plenty.
+          </p>
+          <details class="manual">
+            <summary>Or stand up the server by hand</summary>
+            <pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+            <p class="note">
+              Installs Docker, generates secrets, gets an HTTPS certificate, and
+              prints the connect command. Then add the plugin and run
+              /setoku:onboard from your project; it’ll detect the box you just
+              made.
+            </p>
+          </details>
+        </section>
+
+        <!-- PLATE III — ANATOMY -->
+        <section class="plate" id="how">
+          <div class="plate-no">Plate III · Anatomy</div>
+          <h2>How it works</h2>
+          <p class="caption">
+            Setoku gives the AI two kinds of MCP tools, and one rule: look up
+            what the data means before you touch it.
+          </p>
+          <div class="entries">
+            <div class="entry">
+              <div class="term">Context tools<span class="lat">find_context · get_metric</span></div>
+              <div class="desc">
+                The AI reads what your data means first: canonical metric
+                definitions, entity docs, and the gotchas that make a naive
+                query wrong.
+              </div>
+            </div>
+            <div class="entry">
+              <div class="term">Read-only query<span class="lat">get_schema · run_query</span></div>
+              <div class="desc">
+                Read-only, with a row cap, a statement timeout, a table
+                allow-list, and an append-only audit log. Enforced by the
+                database role, not by parsing SQL.
+              </div>
+            </div>
+            <div class="entry">
+              <div class="term">Human-approved<span class="lat">report_correction</span></div>
+              <div class="desc">
+                The AI can only propose changes to what Setoku knows. A person
+                accepts them on the admin page, outside the agent loop, so an
+                injected session can’t rewrite the brain.
+              </div>
+            </div>
+          </div>
+          <p class="note">You set it up with <b style="font-style:normal">Claude Code</b> skills:</p>
+          <ul class="list">
+            <li><code>/setoku:onboard</code> sets Setoku up in a repo for the first time.</li>
+            <li><code>/setoku:connect</code> adds a data source or custom integration.</li>
+            <li><code>/setoku:generate</code> writes business context from your code.</li>
+            <li><code>/setoku:curate</code> reviews and approves pending knowledge.</li>
+          </ul>
+          <p class="note">
+            Once it’s set up, <b style="font-style:normal">any MCP client</b> can use it: Claude, Codex,
+            or whatever you run. Just ask in plain language, and the tools do
+            the rest.
+          </p>
+        </section>
+
+        <!-- PLATE IV — PROPAGATION -->
+        <section class="plate" id="apps">
+          <div class="plate-no">Plate IV · Propagation</div>
+          <h2>Apps: save and share the tools Claude builds you</h2>
+          <p class="caption">
+            Ask Claude to build a dashboard on your data. Then publish it to a
+            link as a Setoku App, the data stays live, and your whole team can
+            view it. Nothing to deploy, no frontend to maintain.
+          </p>
+          <div class="entries">
+            <div class="entry">
+              <div class="term">Built by asking<span class="lat">publish_app</span></div>
+              <div class="desc">
+                Describe it in plain language; the agent writes the app and
+                publishes it to a URL. Edit it the same way, just ask for the
+                change.
+              </div>
+            </div>
+            <div class="entry">
+              <div class="term">Backed by live data<span class="lat">read-only</span></div>
+              <div class="desc">
+                Apps read through the same governed path: row caps, audit, a
+                SELECT-only database role. They never get write access to your
+                sources.
+              </div>
+            </div>
+            <div class="entry">
+              <div class="term">App-private state<span class="lat">no writes to your data</span></div>
+              <div class="desc">
+                Each app keeps its own state (todos, votes, annotations) in a
+                sandbox that belongs to the app, not your database. Worst case,
+                an app messes up its own notes.
+              </div>
+            </div>
+            <div class="entry">
+              <div class="term">Share by link<span class="lat">team or public</span></div>
+              <div class="desc">
+                A team link is login-gated; an admin can flip one public for a
+                credential-free URL. The page runs in a locked-down sandbox with
+                no network, so a published app can’t phone home.
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- PLATE V — ANATOMICAL DIAGRAM -->
+        <section class="plate" id="architecture">
+          <div class="plate-no">Plate V · Anatomical Diagram</div>
+          <h2>Architecture</h2>
+          <p class="caption">
+            You can host this on whatever infra you like. We put it all on one
+            small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+            helps you add custom integrations. Only the proxy is public, so your
+            databases aren’t exposed. Queries are read-only, and knowledge
+            changes pass through a person.
+          </p>
+          <figure>
+            <div class="fh">Figure 1 · General arrangement of parts</div>
+            <div class="diagram" style="overflow-x:auto">
+              <svg
+                viewBox="0 0 680 520"
+                role="img"
+                aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake for analytics, and your sources are ingested into the lake."
+              >
+                <defs>
+                  <marker id="ah" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto-start-reverse">
+                    <path d="M0 0 L6 3 L0 6 Z" fill="#6b6350" />
+                  </marker>
+                </defs>
+                <rect class="node" x="250" y="14" width="180" height="44" rx="4" />
+                <text class="t" x="340" y="41" text-anchor="middle">You + your AI</text>
+                <path class="arr" d="M340 58 L340 142" marker-start="url(#ah)" marker-end="url(#ah)" />
+                <text class="e" x="348" y="86">MCP</text>
+                <rect class="box" x="60" y="110" width="560" height="300" rx="6" />
+                <text class="e" x="76" y="130" fill="#8a7c56">your box</text>
+                <rect class="node" x="250" y="146" width="180" height="58" rx="4" />
+                <text class="t" x="340" y="171" text-anchor="middle">Setoku gateway</text>
+                <text class="s" x="340" y="189" text-anchor="middle">context · query tools</text>
+                <rect class="node" x="452" y="150" width="150" height="50" rx="4" />
+                <text class="t" x="527" y="179" text-anchor="middle">a person</text>
+                <rect class="node" x="92" y="322" width="180" height="66" rx="4" />
+                <text class="t" x="182" y="350" text-anchor="middle">Lake (ClickHouse)</text>
+                <text class="s" x="182" y="368" text-anchor="middle">logs · events · DB mirror</text>
+                <rect class="node" x="408" y="322" width="190" height="66" rx="4" />
+                <text class="t" x="503" y="359" text-anchor="middle">Knowledge store</text>
+                <rect class="node" x="92" y="440" width="180" height="64" rx="4" />
+                <text class="t" x="182" y="468" text-anchor="middle">Your sources</text>
+                <text class="s" x="182" y="486" text-anchor="middle">GitHub · Vercel · Slack…</text>
+                <rect class="node" x="300" y="440" width="180" height="64" rx="4" />
+                <text class="t" x="390" y="468" text-anchor="middle">Your database</text>
+                <text class="s" x="390" y="486" text-anchor="middle">Postgres · read-only</text>
+                <path class="arr" d="M412 204 L508 322" marker-start="url(#ah)" marker-end="url(#ah)" />
+                <text class="e" x="424" y="266" text-anchor="middle">reads ·</text>
+                <text class="e" x="424" y="282" text-anchor="middle">proposes</text>
+                <path class="arr" d="M527 200 L513 322" marker-end="url(#ah)" />
+                <text class="e" x="534" y="262">approves</text>
+                <path class="arr" d="M210 322 L300 204" marker-end="url(#ah)" />
+                <path class="arr" d="M182 440 L182 388" marker-end="url(#ah)" />
+                <text class="e" x="190" y="420">ingest</text>
+                <path class="arr" d="M388 440 L366 206" marker-end="url(#ah)" />
+                <text class="e" x="300" y="300">read-only</text>
+              </svg>
+            </div>
+            <figcaption>
+              The proxy alone faces the outside; the databases sit sheltered
+              within the box, queried read-only, with a person approving what the
+              specimen commits to memory.
+            </figcaption>
+          </figure>
+        </section>
+
+        <!-- PLATE VI — COLLECTED SPECIES -->
+        <section class="plate" id="connectors">
+          <div class="plate-no">Plate VI · Collected Species</div>
+          <h2>Connectors</h2>
+          <p class="caption">
+            Point Setoku at the data you already have. Every source lands in a
+            local
+            <a href="https://clickhouse.com/" target="_blank" rel="noopener">ClickHouse</a>
+            data lake, on purpose: agents write arbitrary queries (scans, GROUP
+            BYs, whole-table aggregations), and a columnar engine answers those
+            in about a second, so the apps and dashboards they build stay quick.
+            Your app database connects read-only and is mirrored in on a cron;
+            the rest is ingested as it happens.
+          </p>
+          <div class="species">
+            <div class="sh">
+              <svg class="leaf" viewBox="0 0 64 64"><use href="#clover" /></svg>
+              ClickHouse · one lake, every source
+            </div>
+            <div class="row2"><span class="sp">PostgreSQL</span><span class="gl">app database, mirrored read-only</span></div>
+            <div class="row2"><span class="sp">GitHub</span><span class="gl">issues, PRs &amp; commits</span></div>
+            <div class="row2"><span class="sp">Vercel</span><span class="gl">deploys &amp; logs</span></div>
+            <div class="row2"><span class="sp">Render</span><span class="gl">deploys &amp; logs</span></div>
+            <div class="row2"><span class="sp">Slack</span><span class="gl">messages</span></div>
+            <div class="row2"><span class="sp">Mercury</span><span class="gl">banking &amp; finance</span></div>
+          </div>
+          <p class="note">
+            No connector for your source yet? The included setup skills give
+            your coding agent the patterns to wire one up itself. See
+            <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">the repo</a>,
+            or open an issue.
+          </p>
+        </section>
+
+        <!-- PLATE VII — FIELD OBSERVATIONS -->
+        <section class="plate" id="demo">
+          <div class="plate-no">Plate VII · Field Observations</div>
+          <h2>Try it on real-ish data</h2>
+          <p class="caption">
+            There’s a live demo wired to a fictional pro sports club, the Bonita
+            Bulldogs (ticketing, sponsorship, concessions, payroll, broadcast
+            rights).
+          </p>
+
+          <div class="obs-step">
+            <div class="oh"><span class="on">Step I</span>Connect to the demo MCP server</div>
+            <p class="note" style="margin-top:0">
+              In Claude (or any MCP client) open Settings → Connectors → Add
+              custom connector, and paste this URL. The token rides in the URL,
+              so there’s no separate key to enter.
+            </p>
+            <pre><code>https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</code></pre>
+          </div>
+
+          <div class="obs-step">
+            <div class="oh"><span class="on">Step II</span>Ask a question</div>
+            <div class="observations">
+              <div class="ob">
+                <div class="q">“How many unique fans do we have?”</div>
+                <div class="a">
+                  <span class="meas">71,204</span>
+                  <span class="rem">deduped by normalized email, internal accounts excluded. Not the raw 92,118.</span>
+                </div>
+              </div>
+              <div class="ob">
+                <div class="q">“What’s our total annual revenue, and how much is media rights?”</div>
+                <div class="a">
+                  <span class="meas">$192M</span>
+                  <span class="rem">five systems reconciled to the same units. Media rights is the biggest line, ~$90M.</span>
+                </div>
+              </div>
+              <div class="ob">
+                <div class="q">“What was ticket revenue this season?”</div>
+                <div class="a">
+                  <span class="meas">$46.8M</span>
+                  <span class="rem">cents reconciled to dollars; refunds, exchanges, and comps excluded.</span>
+                </div>
+              </div>
+              <div class="ob">
+                <div class="q">“What’s our total merchandise revenue?”</div>
+                <div class="a">
+                  <span class="meas">It flags it</span>
+                  <span class="rem">most merch is sold via Fanatics, not in this data, so it says so instead of returning a wrong total.</span>
+                </div>
+              </div>
+              <div class="ob full">
+                <div class="q">“Chart revenue by line.”</div>
+                <div class="a">
+                  <figure>
+                    <div class="fh">Figure 2 · Annual revenue by line · ~$192M total</div>
+                    <div style="overflow-x:auto">
+                      <svg
+                        viewBox="0 0 640 214"
+                        role="img"
+                        aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M."
+                      >
+                        <g fill="#55613a">
+                          <rect x="148" y="14" width="400" height="16" />
+                          <rect x="148" y="48" width="209" height="16" />
+                          <rect x="148" y="82" width="124" height="16" />
+                          <rect x="148" y="116" width="62" height="16" />
+                          <rect x="148" y="150" width="36" height="16" />
+                          <rect x="148" y="184" width="22" height="16" />
+                        </g>
+                        <g font-family="Iowan Old Style, Palatino, Georgia, serif" font-style="italic" font-size="12.5" fill="#4a453a">
+                          <text x="8" y="26">Media rights</text>
+                          <text x="8" y="60">Ticketing</text>
+                          <text x="8" y="94">Sponsorship</text>
+                          <text x="8" y="128">Concessions</text>
+                          <text x="8" y="162">Merch</text>
+                          <text x="8" y="196">Other</text>
+                        </g>
+                        <g font-family="ui-monospace, Menlo, monospace" font-size="12" fill="#2a2720">
+                          <text x="555" y="26">$90M</text>
+                          <text x="364" y="60">$47M</text>
+                          <text x="279" y="94">$28M</text>
+                          <text x="217" y="128">$14M</text>
+                          <text x="191" y="162">$8M</text>
+                          <text x="177" y="196">$5M</text>
+                        </g>
+                      </svg>
+                    </div>
+                  </figure>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="obs-step">
+            <div class="oh"><span class="on">Step III</span>Try an app</div>
+            <p class="note" style="margin-top:0">
+              Ask Claude to build a dashboard on the same data, then publish it
+              to a link. Two live examples, running on the demo data right now:
+            </p>
+            <ul class="list">
+              <li>
+                <a href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d" target="_blank" rel="noopener">Sponsorship pricing table ↗</a>
+                — inventory and rates for sponsorship placements.
+              </li>
+              <li>
+                <a href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea" target="_blank" rel="noopener">Fan lifetime value ↗</a>
+                — segment fans by spend across tickets, merch, and concessions.
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <!-- PLATE VIII — NOTES ON PROVENANCE -->
+        <section class="plate" id="why">
+          <div class="plate-no">Plate VIII · Notes on Provenance</div>
+          <h2>Why we built it</h2>
+          <p style="font-style:italic;color:var(--ink);font-weight:600;margin-top:16px">We’re curious.</p>
+          <p>
+            There are plenty of AI memory stores, and plenty of data gateways.
+            Stapling the two together, and nudging the agent to gather knowledge
+            about the data as it goes, seemed useful and fun to tinker with.
+          </p>
+          <p style="font-style:italic;color:var(--ink);font-weight:600;margin-top:16px">We’re cheap.</p>
+          <p>
+            We wanted something that runs on one small box, works on a Pro/Max
+            subscription or a cheap model with no added inference cost, mostly
+            sets itself up (no field engineer to pay for), stays portable
+            between providers, and is open source.
+          </p>
+          <p style="font-style:italic;color:var(--ink);font-weight:600;margin-top:16px">We’re paranoid.</p>
+          <p>
+            HR platforms, CRMs, and clouds are all announcing “context layers.”
+            They’d like the meaning of your business to accumulate on their
+            servers, where it can never leave. Context is deeper lock-in than
+            data, and a hosted context layer has no export button. Setoku exists
+            so that understanding accumulates on a box you own instead. If we
+            disappear tomorrow, your context doesn’t.
+          </p>
+          <p style="font-style:italic;color:var(--ink);font-weight:600;margin-top:16px">We and some friends wanted the same thing.</p>
+          <ul class="list">
+            <li>
+              <b><a href="https://www.hedgy.works" target="_blank" rel="noopener">Hedgy</a></b>: keep scaling without hiring. Debug from live logs
+              and data, find growth levers, and match candidates and companies
+              better with more data.
+            </li>
+            <li>
+              <b><a href="https://baggu.com" target="_blank" rel="noopener">Baggu</a></b>: give employees state-of-the-art tools. Faster
+              onboarding, and a safe way to vibecode against real data.
+            </li>
+            <li>
+              <b><a href="https://tlon.io" target="_blank" rel="noopener">Tlon</a></b>: experimenting with giving agents curated data to work from.
+            </li>
+            <li><b>Sports analysts</b>: query across data that doesn’t usually sit together.</li>
+            <li><b>Academic labs</b>: think through hypotheses against real papers, data, and drafts.</li>
+          </ul>
+        </section>
+
+        <!-- COLOPHON / HELP -->
+        <section class="colophon" id="help">
+          <div class="rule-orn">❧ ❦ ❧</div>
+          <div class="smallcaps" style="margin-bottom:10px">Setup help</div>
+          <p>
+            It’s open source, so you can self-host it today. If you like, we’re
+            happy to help set it up. Just email
+            <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+          </p>
+        </section>
+      </div>
+
+      <div class="plate-of">Plates I–VIII · Genus Setoku · Hedgy Labs</div>
+      <footer>
+        <div class="l">
+          <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener">GitHub</a>
+          <a href="#demo">Demo</a>
+          <a href="mailto:hello@setoku.com">Contact</a>
+          <span>Apache-2.0</span>
+        </div>
+        <span class="jp">設 × 奥 · set (math) × oku (innermost)</span>
+      </footer>
+    </div>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) { return w.trim(); })
+          .filter(Boolean);
+        if (words.length < 2) return;
+        var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        var LIFT = "0.6em", HALF = 240, HOLD = 2600, i = 0;
+        function widthOf(w) { measure.textContent = w; return measure.getBoundingClientRect().width; }
+        box.style.width = widthOf(words[0]) + "px";
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next; box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length; return;
+          }
+          word.animate(
+            [{ transform: "translateY(0)", opacity: 1 }, { transform: "translateY(-" + LIFT + ")", opacity: 0 }],
+            { duration: HALF, easing: "cubic-bezier(0.4,0,1,1)", fill: "forwards" }
+          ).finished.then(function () {
+            word.textContent = next; box.style.width = widthOf(next) + "px";
+            word.animate(
+              [{ transform: "translateY(" + LIFT + ")", opacity: 0 }, { transform: "translateY(0)", opacity: 1 }],
+              { duration: HALF, easing: "cubic-bezier(0,0,0.2,1)", fill: "forwards" }
+            );
+            i = (i + 1) % words.length;
+          }).catch(function () {});
+        }
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () { box.style.width = widthOf(words[i]) + "px"; });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/8-transit.html
+++ b/site/riffs/8-transit.html
@@ -1,0 +1,1680 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · one line between your AI and your data</title>
+    <meta
+      name="description"
+      content="Setoku is an open-source MCP server that gives your AI a read-only view of your company’s data, plus the context to use it correctly."
+    />
+    <style>
+      :root {
+        --ground: #f5f1e7;
+        --ground-2: #efe9db;
+        --panel: #ffffff;
+        --ink: #18201b;
+        --ink-soft: #3c453f;
+        --ink-faint: #59615a;
+        --line-soft: rgba(24, 32, 27, 0.12);
+        --hair: rgba(24, 32, 27, 0.16);
+        /* muted, transit-authentic route hues on a light ground */
+        --green: #2f8a5f; /* MCP line */
+        --blue: #35689e; /* query / read-only */
+        --amber: #bd8324; /* ingest */
+        --plum: #77558c; /* knowledge */
+        --brick: #b0553f; /* approval */
+        --board: #172019; /* enamel departures board */
+        --board-fig: #e0b45f; /* muted amber figures */
+        --sans: "Helvetica Neue", Helvetica, "Inter", Arial, system-ui,
+          sans-serif;
+        --mono: ui-monospace, "SF Mono", "Roboto Mono", Menlo, Consolas,
+          monospace;
+        --w: 940px;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        scroll-behavior: smooth;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+      body {
+        background: var(--ground);
+        color: var(--ink);
+        font-family: var(--sans);
+        font-size: 16.5px;
+        line-height: 1.6;
+        font-weight: 400;
+      }
+      a {
+        color: var(--blue);
+        text-decoration: none;
+        font-weight: 600;
+      }
+      a:hover {
+        text-decoration: underline;
+        text-underline-offset: 3px;
+      }
+      svg {
+        display: block;
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 0.85em;
+        background: var(--ground-2);
+        padding: 2px 6px;
+        border-radius: 3px;
+        color: var(--ink);
+      }
+      ::selection {
+        background: var(--green);
+        color: #fff;
+      }
+      .wrap {
+        max-width: var(--w);
+        margin: 0 auto;
+        padding-inline: 22px;
+      }
+
+      /* ---- signage primitives ---- */
+      .sign {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        background: var(--ink);
+        color: #fff;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+        padding: 9px 16px 9px 14px;
+        border-radius: 4px;
+        line-height: 1.1;
+      }
+      .sign .tab {
+        width: 10px;
+        align-self: stretch;
+        border-radius: 3px;
+        margin: -9px 2px -9px -14px;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+      .sign .arrow {
+        font-weight: 700;
+        opacity: 0.85;
+      }
+      .bullet {
+        display: inline-block;
+        width: 13px;
+        height: 13px;
+        border-radius: 50%;
+        border: 3px solid currentColor;
+        background: var(--panel);
+        vertical-align: -1px;
+      }
+
+      /* ---- header: station sign bar ---- */
+      header {
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        background: var(--ink);
+        color: #fff;
+        border-bottom: 4px solid var(--green);
+      }
+      .bar {
+        max-width: var(--w);
+        margin: 0 auto;
+        padding: 11px 22px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 14px;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+        color: #fff;
+        font-weight: 800;
+        font-size: 18px;
+        letter-spacing: 0.01em;
+      }
+      .brand:hover {
+        text-decoration: none;
+      }
+      .brand .mark {
+        width: 22px;
+        height: 22px;
+        color: #fff;
+      }
+      .brand .num {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        background: var(--green);
+        color: #fff;
+        font-size: 13px;
+        font-weight: 800;
+      }
+      .nav {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+      .nav a {
+        color: #fff;
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+        padding: 5px 9px;
+        border-radius: 4px;
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+      }
+      .nav a:hover {
+        text-decoration: none;
+        background: rgba(255, 255, 255, 0.12);
+      }
+      .nav a .dot {
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+      }
+      @media (max-width: 640px) {
+        .nav a.hideable {
+          display: none;
+        }
+      }
+
+      /* ---- hero: destination sign ---- */
+      .hero {
+        padding: 46px 0 12px;
+      }
+      .eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: 9px;
+        font-family: var(--mono);
+        font-size: 12px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        margin-bottom: 16px;
+      }
+      .eyebrow .stops {
+        display: inline-flex;
+        gap: 5px;
+      }
+      .eyebrow .stops i {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        display: inline-block;
+      }
+      h1 {
+        font-size: clamp(32px, 5.4vw, 52px);
+        line-height: 1.04;
+        letter-spacing: -0.02em;
+        font-weight: 800;
+        max-width: 15em;
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        color: var(--green);
+        transition: width 460ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+        will-change: transform, opacity;
+        border-bottom: 0.14em solid var(--green);
+        padding-bottom: 0.01em;
+      }
+      .rotator-measure {
+        position: absolute;
+        left: 0;
+        top: 0;
+        visibility: hidden;
+        pointer-events: none;
+        white-space: nowrap;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .rotator {
+          transition: none;
+        }
+      }
+      .lede {
+        color: var(--ink-soft);
+        font-size: 18px;
+        margin-top: 20px;
+        max-width: 42em;
+      }
+      .actions {
+        margin-top: 26px;
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 9px;
+        font-size: 14.5px;
+        font-weight: 700;
+        letter-spacing: 0.01em;
+        padding: 11px 18px;
+        border-radius: 4px;
+        border: 2px solid var(--ink);
+        background: var(--ink);
+        color: #fff;
+      }
+      .btn:hover {
+        text-decoration: none;
+        background: var(--green);
+        border-color: var(--green);
+      }
+      .btn.ghost {
+        background: transparent;
+        color: var(--ink);
+      }
+      .btn.ghost:hover {
+        background: transparent;
+        color: var(--green);
+        border-color: var(--green);
+      }
+
+      /* ---- sections ---- */
+      section {
+        padding: 40px 0;
+        border-top: 2px solid var(--hair);
+      }
+      .sec-head {
+        margin-bottom: 22px;
+      }
+      .lead {
+        color: var(--ink-soft);
+        max-width: 46em;
+        margin-top: 16px;
+      }
+      .note {
+        color: var(--ink-soft);
+        font-size: 14.5px;
+        margin-top: 14px;
+        max-width: 46em;
+      }
+
+      /* ---- line cards (how / apps) ---- */
+      .lines {
+        margin-top: 22px;
+        display: grid;
+        gap: 0;
+        border: 2px solid var(--ink);
+        border-radius: 8px;
+        overflow: hidden;
+        background: var(--panel);
+      }
+      .lrow {
+        display: grid;
+        grid-template-columns: 210px 1fr;
+        gap: 0;
+        border-top: 1px solid var(--line-soft);
+      }
+      .lrow:first-child {
+        border-top: none;
+      }
+      .lrow .stop {
+        padding: 16px 16px 16px 44px;
+        position: relative;
+        border-right: 1px solid var(--line-soft);
+        font-weight: 700;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        background: var(--ground);
+      }
+      .lrow .stop::before {
+        content: "";
+        position: absolute;
+        left: 20px;
+        top: 20px;
+        width: 13px;
+        height: 13px;
+        border-radius: 50%;
+        border: 3px solid var(--rc, var(--green));
+        background: var(--panel);
+      }
+      /* running track down the stop column */
+      .lrow .stop::after {
+        content: "";
+        position: absolute;
+        left: 25.5px;
+        top: -1px;
+        bottom: -1px;
+        width: 4px;
+        background: var(--rc, var(--green));
+        z-index: -0;
+      }
+      .lines .lrow:first-child .stop::after {
+        top: 20px;
+      }
+      .lines .lrow:last-child .stop::after {
+        bottom: calc(100% - 20px);
+      }
+      .lrow .stop .code {
+        font-family: var(--mono);
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--ink-faint);
+        letter-spacing: 0.01em;
+      }
+      .lrow .desc {
+        padding: 16px 18px;
+        color: var(--ink-soft);
+        font-size: 15px;
+      }
+      @media (max-width: 560px) {
+        .lrow {
+          grid-template-columns: 1fr;
+        }
+        .lrow .stop {
+          border-right: none;
+          border-bottom: 1px solid var(--line-soft);
+        }
+        .lrow .stop::after {
+          display: none;
+        }
+      }
+
+      .uses {
+        list-style: none;
+        margin-top: 16px;
+        display: grid;
+        gap: 10px;
+      }
+      .uses li {
+        color: var(--ink-soft);
+        font-size: 15px;
+        line-height: 1.5;
+        padding-left: 24px;
+        position: relative;
+        max-width: 48em;
+      }
+      .uses li::before {
+        content: "";
+        position: absolute;
+        left: 2px;
+        top: 7px;
+        width: 11px;
+        height: 11px;
+        border-radius: 50%;
+        border: 3px solid var(--green);
+        background: var(--panel);
+      }
+      .uses b {
+        color: var(--ink);
+      }
+
+      /* ---- code / ticket ---- */
+      pre {
+        background: var(--panel);
+        border: 2px solid var(--ink);
+        border-radius: 8px;
+        padding: 16px 18px;
+        overflow-x: auto;
+        margin: 16px 0;
+      }
+      pre code {
+        font-family: var(--mono);
+        font-size: 13.5px;
+        line-height: 1.85;
+        background: none;
+        padding: 0;
+        color: var(--ink);
+        white-space: pre;
+      }
+      pre code .c {
+        color: var(--ink-faint);
+      }
+      details.manual {
+        margin-top: 14px;
+      }
+      details.manual summary {
+        cursor: pointer;
+        font-weight: 700;
+        font-size: 14px;
+        color: var(--ink-soft);
+      }
+
+      /* ---- route map (architecture) ---- */
+      .mapframe {
+        margin-top: 22px;
+        border: 2px solid var(--ink);
+        border-radius: 10px;
+        background: var(--panel);
+        overflow: hidden;
+      }
+      .maptop {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 11px 16px;
+        background: var(--ink);
+        color: #fff;
+        font-weight: 700;
+        font-size: 13px;
+        letter-spacing: 0.03em;
+      }
+      .maptop .scale {
+        font-family: var(--mono);
+        font-weight: 500;
+        opacity: 0.8;
+        font-size: 12px;
+      }
+      .mapscroll {
+        overflow-x: auto;
+        padding: 8px;
+      }
+      .mapscroll svg {
+        width: 100%;
+        min-width: 640px;
+        height: auto;
+      }
+      .legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 20px;
+        padding: 14px 16px;
+        border-top: 1px solid var(--line-soft);
+        background: var(--ground);
+      }
+      .legend .lg {
+        display: inline-flex;
+        align-items: center;
+        gap: 9px;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--ink-soft);
+      }
+      .legend .lg i {
+        width: 22px;
+        height: 5px;
+        border-radius: 3px;
+      }
+
+      /* ---- connectors: route legend / stops list ---- */
+      .stopslist {
+        margin-top: 20px;
+        border: 2px solid var(--ink);
+        border-radius: 8px;
+        overflow: hidden;
+        background: var(--panel);
+      }
+      .stopslist .interchange {
+        display: flex;
+        align-items: center;
+        gap: 11px;
+        padding: 13px 16px;
+        background: var(--ink);
+        color: #fff;
+        font-weight: 700;
+        font-size: 14px;
+        letter-spacing: 0.02em;
+      }
+      .stopslist .interchange .ring {
+        width: 15px;
+        height: 15px;
+        border-radius: 50%;
+        border: 3px solid #fff;
+        background: transparent;
+      }
+      .stop-line {
+        display: grid;
+        grid-template-columns: 180px 1fr;
+        gap: 0;
+        border-top: 1px solid var(--line-soft);
+        align-items: center;
+      }
+      .stop-line .name {
+        position: relative;
+        padding: 13px 14px 13px 42px;
+        font-weight: 700;
+        border-right: 1px solid var(--line-soft);
+      }
+      .stop-line .name::before {
+        content: "";
+        position: absolute;
+        left: 18px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        border: 3px solid var(--amber);
+        background: var(--panel);
+      }
+      .stop-line .about {
+        padding: 13px 16px;
+        color: var(--ink-soft);
+        font-size: 14.5px;
+      }
+      @media (max-width: 560px) {
+        .stop-line {
+          grid-template-columns: 1fr;
+        }
+        .stop-line .name {
+          border-right: none;
+        }
+      }
+
+      /* ---- demo: arrivals board ---- */
+      .board {
+        margin-top: 18px;
+        background: var(--board);
+        border-radius: 10px;
+        padding: 8px 8px 12px;
+        border: 2px solid var(--board);
+      }
+      .board-h {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        color: #cfd6cf;
+        font-family: var(--mono);
+        font-size: 11.5px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        padding: 8px 12px 12px;
+      }
+      .arr {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 14px;
+        align-items: center;
+        padding: 13px 12px;
+        border-top: 1px solid rgba(255, 255, 255, 0.09);
+      }
+      .arr .q {
+        color: #eef2ec;
+        font-weight: 600;
+        font-size: 15.5px;
+      }
+      .arr .cav {
+        color: #9aa79c;
+        font-size: 13px;
+        margin-top: 4px;
+        max-width: 42em;
+        line-height: 1.45;
+      }
+      .arr .fig {
+        color: var(--board-fig);
+        font-family: var(--mono);
+        font-weight: 700;
+        font-size: clamp(22px, 4vw, 30px);
+        letter-spacing: 0.01em;
+        text-align: right;
+        white-space: nowrap;
+        line-height: 1;
+      }
+      .arr .fig.flag {
+        font-size: 15px;
+        color: #e7c98a;
+      }
+      .step {
+        margin-top: 26px;
+      }
+      .step-h {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-weight: 800;
+        font-size: 19px;
+        letter-spacing: -0.01em;
+        margin-bottom: 8px;
+      }
+      .step-n {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 27px;
+        height: 27px;
+        border-radius: 50%;
+        background: var(--ink);
+        color: #fff;
+        font-size: 14px;
+        font-weight: 800;
+        flex: none;
+      }
+      .chart {
+        margin-top: 6px;
+        padding: 14px 14px 6px;
+        border-top: 1px solid rgba(255, 255, 255, 0.09);
+      }
+      .chart .cl {
+        color: #cfd6cf;
+        font-family: var(--mono);
+        font-size: 12px;
+        letter-spacing: 0.04em;
+        margin-bottom: 12px;
+      }
+      .chart svg {
+        width: 100%;
+        height: auto;
+      }
+
+      /* ---- why ---- */
+      .why-block {
+        margin-top: 22px;
+      }
+      .why h3 {
+        font-weight: 800;
+        font-size: 17px;
+        margin: 24px 0 5px;
+        display: inline-flex;
+        align-items: center;
+        gap: 9px;
+      }
+      .why h3 .b {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        border: 3px solid var(--brick);
+        background: var(--panel);
+      }
+      .why p {
+        color: var(--ink-soft);
+        max-width: 46em;
+      }
+
+      /* ---- footer: title block ---- */
+      footer {
+        border-top: 4px solid var(--green);
+        background: var(--ink);
+        color: #cfd6cf;
+        margin-top: 20px;
+      }
+      .foot {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 24px 22px;
+      }
+      .foot .l {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 16px;
+        font-size: 14px;
+      }
+      .foot .l a {
+        color: #fff;
+      }
+      .foot .brand {
+        color: #fff;
+        font-size: 15px;
+      }
+      .foot .brand .mark {
+        width: 18px;
+        height: 18px;
+      }
+      .foot .jp {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: #9aa79c;
+        letter-spacing: 0.03em;
+      }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path
+          d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z"
+          fill="currentColor"
+        />
+      </symbol>
+    </svg>
+
+    <header>
+      <div class="bar">
+        <a class="brand" href="#top">
+          <svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+          Setoku
+        </a>
+        <nav class="nav">
+          <a class="hideable" href="#how"
+            ><span class="dot" style="background: var(--green)"></span>How it
+            works</a
+          >
+          <a class="hideable" href="#apps"
+            ><span class="dot" style="background: var(--plum)"></span>Apps</a
+          >
+          <a class="hideable" href="#connectors"
+            ><span class="dot" style="background: var(--amber)"></span
+            >Connectors</a
+          >
+          <a
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            ><span class="dot" style="background: var(--blue)"></span>GitHub
+            ↗</a
+          >
+        </nav>
+      </div>
+    </header>
+
+    <main id="top">
+      <div class="hero wrap">
+        <span class="eyebrow">
+          <span class="stops">
+            <i style="background: var(--green)"></i>
+            <i style="background: var(--blue)"></i>
+            <i style="background: var(--amber)"></i>
+            <i style="background: var(--plum)"></i>
+            <i style="background: var(--brick)"></i>
+          </span>
+          Open source · MCP server · Apache-2.0
+        </span>
+        <h1>
+          Make any AI fluent in your <span
+            class="rotator"
+            data-words="company,family,personal"
+            ><span class="rotator-word">company</span
+            ><span class="rotator-measure" aria-hidden="true"></span></span
+          > data.
+        </h1>
+        <p class="lede">
+          Setoku is a small self-hosted MCP knowledge server + Claude Code
+          skills for hooking up your data. It does two things: it gives your AI
+          a read-only way to query your data, and it remembers what that data
+          means (the metric definitions, the gotchas), getting better the more
+          you use it. The MCP works with whatever AI you already have, and no
+          model runs on the server, so no added inference cost.
+        </p>
+        <div class="actions">
+          <a
+            class="btn"
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >View on GitHub ↗</a
+          >
+          <a class="btn ghost" href="#demo">Try the demo →</a>
+        </div>
+      </div>
+
+      <!-- QUICKSTART -->
+      <section id="quickstart">
+        <div class="wrap">
+          <div class="sec-head">
+            <span class="sign"
+              ><span class="tab" style="background: var(--green)"></span
+              ><span class="arrow">→</span> QUICKSTART · BOARD HERE</span
+            >
+          </div>
+          <p class="lead">
+            Setoku installs as a Claude Code plugin. Add the plugin, then run
+            onboarding from your main project directory, the codebase you want
+            Setoku to learn from:
+          </p>
+          <pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+          <p class="note">
+            Onboarding stands up the server, auths your Claude, wires your
+            database read-only, and generates the first knowledge from your
+            code. You stay in the loop for anything that touches your data. To
+            start onboarding, run <code>/setoku:onboard</code>.
+          </p>
+          <p class="note">
+            You’ll need somewhere to host it. Something like OVH’s
+            <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener"
+              >VPS-2</a
+            >
+            is plenty.
+          </p>
+          <details class="manual">
+            <summary>Or stand up the server by hand</summary>
+            <pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+            <p class="note">
+              Installs Docker, generates secrets, gets an HTTPS certificate, and
+              prints the connect command. Then add the plugin and run
+              /setoku:onboard from your project; it’ll detect the box you just
+              made.
+            </p>
+          </details>
+        </div>
+      </section>
+
+      <!-- HOW IT WORKS -->
+      <section id="how">
+        <div class="wrap">
+          <div class="sec-head">
+            <span class="sign"
+              ><span class="tab" style="background: var(--green)"></span
+              ><span class="arrow">→</span> HOW IT WORKS · THREE STOPS</span
+            >
+          </div>
+          <p class="lead">
+            Setoku gives the AI two kinds of MCP tools, and one rule: look up
+            what the data means before you touch it.
+          </p>
+          <div class="lines">
+            <div class="lrow" style="--rc: var(--green)">
+              <div class="stop">
+                Context tools
+                <span class="code">find_context · get_metric</span>
+              </div>
+              <div class="desc">
+                The AI reads what your data means first: canonical metric
+                definitions, entity docs, and the gotchas that make a naive
+                query wrong.
+              </div>
+            </div>
+            <div class="lrow" style="--rc: var(--blue)">
+              <div class="stop">
+                Read-only query
+                <span class="code">get_schema · run_query</span>
+              </div>
+              <div class="desc">
+                Read-only, with a row cap, a statement timeout, a table
+                allow-list, and an append-only audit log. Enforced by the
+                database role, not by parsing SQL.
+              </div>
+            </div>
+            <div class="lrow" style="--rc: var(--brick)">
+              <div class="stop">
+                Human-approved
+                <span class="code">report_correction</span>
+              </div>
+              <div class="desc">
+                The AI can only propose changes to what Setoku knows. A person
+                accepts them on the admin page, outside the agent loop, so an
+                injected session can’t rewrite the brain.
+              </div>
+            </div>
+          </div>
+          <p class="note">You set it up with <b>Claude Code</b> skills:</p>
+          <ul class="uses">
+            <li>
+              <code>/setoku:onboard</code> sets Setoku up in a repo for the
+              first time.
+            </li>
+            <li>
+              <code>/setoku:connect</code> adds a data source or custom
+              integration.
+            </li>
+            <li>
+              <code>/setoku:generate</code> writes business context from your
+              code.
+            </li>
+            <li>
+              <code>/setoku:curate</code> reviews and approves pending
+              knowledge.
+            </li>
+          </ul>
+          <p class="note">
+            Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex,
+            or whatever you run. Just ask in plain language, and the tools do
+            the rest.
+          </p>
+        </div>
+      </section>
+
+      <!-- APPS -->
+      <section id="apps">
+        <div class="wrap">
+          <div class="sec-head">
+            <span class="sign"
+              ><span class="tab" style="background: var(--plum)"></span
+              ><span class="arrow">→</span> APPS · SAVE &amp; SHARE THE
+              LINE</span
+            >
+          </div>
+          <p class="lead">
+            Ask Claude to build a dashboard on your data. Then publish it to a
+            link as a Setoku App — the data stays live, and your whole team can
+            view it. Nothing to deploy, no frontend to maintain.
+          </p>
+          <div class="lines">
+            <div class="lrow" style="--rc: var(--plum)">
+              <div class="stop">
+                Built by asking <span class="code">publish_app</span>
+              </div>
+              <div class="desc">
+                Describe it in plain language; the agent writes the app and
+                publishes it to a URL. Edit it the same way, just ask for the
+                change.
+              </div>
+            </div>
+            <div class="lrow" style="--rc: var(--blue)">
+              <div class="stop">
+                Backed by live data <span class="code">read-only</span>
+              </div>
+              <div class="desc">
+                Apps read through the same governed path: row caps, audit, a
+                SELECT-only database role. They never get write access to your
+                sources.
+              </div>
+            </div>
+            <div class="lrow" style="--rc: var(--green)">
+              <div class="stop">
+                App-private state
+                <span class="code">no writes to your data</span>
+              </div>
+              <div class="desc">
+                Each app keeps its own state (todos, votes, annotations) in a
+                sandbox that belongs to the app, not your database. Worst case,
+                an app messes up its own notes.
+              </div>
+            </div>
+            <div class="lrow" style="--rc: var(--amber)">
+              <div class="stop">
+                Share by link <span class="code">team or public</span>
+              </div>
+              <div class="desc">
+                A team link is login-gated; an admin can flip one public for a
+                credential-free URL. The page runs in a locked-down sandbox with
+                no network, so a published app can’t phone home.
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ARCHITECTURE -->
+      <section id="architecture">
+        <div class="wrap">
+          <div class="sec-head">
+            <span class="sign"
+              ><span class="tab" style="background: var(--blue)"></span
+              ><span class="arrow">→</span> ARCHITECTURE · THE NETWORK MAP</span
+            >
+          </div>
+          <p class="lead">
+            You can host this on whatever infra you like. We put it all on one
+            small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+            helps you add custom integrations. Only the proxy is public, so your
+            databases aren’t exposed. Queries are read-only, and knowledge
+            changes pass through a person.
+          </p>
+
+          <div class="mapframe">
+            <div class="maptop">
+              <span>SETOKU NETWORK · one box, one interchange</span>
+              <span class="scale">not to scale</span>
+            </div>
+            <div class="mapscroll">
+              <svg
+                viewBox="0 0 680 580"
+                role="img"
+                aria-label="Setoku shown as a transit map: you and your AI ride the MCP line into the Setoku gateway interchange, which connects to the ClickHouse lake, the knowledge store, and a person who approves. Your Postgres database is queried read-only down the middle, your sources feed the lake on the ingest line, and the database is mirrored into the lake."
+              >
+                <!-- station zone: the box -->
+                <rect
+                  x="70"
+                  y="150"
+                  width="540"
+                  height="300"
+                  rx="16"
+                  fill="none"
+                  stroke="var(--hair)"
+                  stroke-width="2"
+                  stroke-dasharray="3 6"
+                />
+                <text
+                  x="86"
+                  y="176"
+                  font-family="var(--mono)"
+                  font-size="12"
+                  letter-spacing="0.1em"
+                  fill="#8a938b"
+                >
+                  YOUR BOX
+                </text>
+
+                <!-- ROUTE LINES (drawn under stations) -->
+                <g
+                  fill="none"
+                  stroke-width="9"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <!-- MCP (green): You -> Gateway -->
+                  <path d="M360 90 L360 220" stroke="var(--green)" />
+                  <!-- Query / read-only (blue): Lake -> Gateway -> Database -->
+                  <path
+                    d="M200 360 L360 220 L360 500"
+                    stroke="var(--blue)"
+                  />
+                  <!-- Ingest (amber): Sources -> Lake -->
+                  <path d="M120 500 L120 360 L200 360" stroke="var(--amber)" />
+                  <!-- Mirror (green, dashed): Database -> Lake -->
+                  <path
+                    d="M360 500 L250 500 L200 450 L200 360"
+                    stroke="var(--green)"
+                    stroke-dasharray="2 13"
+                    stroke-width="7"
+                  />
+                  <!-- Knowledge (plum): Gateway -> Knowledge store -->
+                  <path d="M360 220 L520 360" stroke="var(--plum)" />
+                  <!-- Approval (brick): a person -> Knowledge store -->
+                  <path d="M520 220 L520 360" stroke="var(--brick)" />
+                </g>
+
+                <!-- line labels -->
+                <g
+                  font-family="var(--mono)"
+                  font-size="11"
+                  fill="#59615a"
+                  letter-spacing="0.04em"
+                >
+                  <text x="372" y="150" transform="rotate(-90 372 150)">
+                    MCP
+                  </text>
+                  <text x="372" y="380">read-only</text>
+                  <text x="98" y="440" transform="rotate(-90 98 440)">
+                    ingest
+                  </text>
+                  <text x="426" y="292" transform="rotate(45 426 292)">
+                    propose
+                  </text>
+                  <text x="532" y="300">approve</text>
+                  <text x="250" y="480">mirror</text>
+                </g>
+
+                <!-- STATIONS -->
+                <g>
+                  <!-- You + your AI (terminus) -->
+                  <circle
+                    cx="360"
+                    cy="82"
+                    r="10"
+                    fill="#fff"
+                    stroke="var(--green)"
+                    stroke-width="5"
+                  />
+                  <!-- Gateway interchange (double ring) -->
+                  <circle
+                    cx="360"
+                    cy="220"
+                    r="17"
+                    fill="#fff"
+                    stroke="var(--ink)"
+                    stroke-width="6"
+                  />
+                  <circle
+                    cx="360"
+                    cy="220"
+                    r="7"
+                    fill="var(--ink)"
+                  />
+                  <!-- Lake interchange -->
+                  <circle
+                    cx="200"
+                    cy="360"
+                    r="13"
+                    fill="#fff"
+                    stroke="var(--amber)"
+                    stroke-width="6"
+                  />
+                  <!-- Knowledge store -->
+                  <circle
+                    cx="520"
+                    cy="360"
+                    r="10"
+                    fill="#fff"
+                    stroke="var(--plum)"
+                    stroke-width="5"
+                  />
+                  <!-- a person (signal box: square) -->
+                  <rect
+                    x="510"
+                    y="210"
+                    width="20"
+                    height="20"
+                    rx="3"
+                    fill="#fff"
+                    stroke="var(--brick)"
+                    stroke-width="5"
+                  />
+                  <!-- Your database (terminus) -->
+                  <circle
+                    cx="360"
+                    cy="500"
+                    r="10"
+                    fill="#fff"
+                    stroke="var(--blue)"
+                    stroke-width="5"
+                  />
+                  <!-- Your sources (terminus) -->
+                  <circle
+                    cx="120"
+                    cy="500"
+                    r="10"
+                    fill="#fff"
+                    stroke="var(--amber)"
+                    stroke-width="5"
+                  />
+                </g>
+
+                <!-- STATION LABELS -->
+                <g
+                  font-family="var(--sans)"
+                  fill="var(--ink)"
+                  font-weight="700"
+                >
+                  <text x="380" y="80" font-size="15">You + your AI</text>
+                  <text x="386" y="216" font-size="15">Setoku gateway</text>
+                  <text
+                    x="386"
+                    y="234"
+                    font-size="11.5"
+                    font-weight="400"
+                    fill="#59615a"
+                  >
+                    context · query tools
+                  </text>
+                  <text x="200" y="398" font-size="15" text-anchor="middle">
+                    Lake
+                  </text>
+                  <text
+                    x="200"
+                    y="414"
+                    font-size="11.5"
+                    font-weight="400"
+                    fill="#59615a"
+                    text-anchor="middle"
+                  >
+                    ClickHouse · mirror
+                  </text>
+                  <text x="504" y="392" font-size="14" text-anchor="end">
+                    Knowledge store
+                  </text>
+                  <text x="500" y="205" font-size="14" text-anchor="end">
+                    a person
+                  </text>
+                  <text x="360" y="530" font-size="15" text-anchor="middle">
+                    Your database
+                  </text>
+                  <text
+                    x="360"
+                    y="546"
+                    font-size="11.5"
+                    font-weight="400"
+                    fill="#59615a"
+                    text-anchor="middle"
+                  >
+                    Postgres · read-only
+                  </text>
+                  <text x="120" y="530" font-size="15" text-anchor="middle">
+                    Your sources
+                  </text>
+                  <text
+                    x="120"
+                    y="546"
+                    font-size="11.5"
+                    font-weight="400"
+                    fill="#59615a"
+                    text-anchor="middle"
+                  >
+                    GitHub · Vercel · Slack…
+                  </text>
+                </g>
+              </svg>
+            </div>
+            <div class="legend">
+              <span class="lg"
+                ><i style="background: var(--green)"></i>MCP line · you ↔
+                gateway</span
+              >
+              <span class="lg"
+                ><i style="background: var(--blue)"></i>Query line ·
+                read-only</span
+              >
+              <span class="lg"
+                ><i style="background: var(--amber)"></i>Ingest line · sources →
+                lake</span
+              >
+              <span class="lg"
+                ><i style="background: var(--plum)"></i>Knowledge line ·
+                propose</span
+              >
+              <span class="lg"
+                ><i style="background: var(--brick)"></i>Approval line · a
+                person</span
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- CONNECTORS -->
+      <section id="connectors">
+        <div class="wrap">
+          <div class="sec-head">
+            <span class="sign"
+              ><span class="tab" style="background: var(--amber)"></span
+              ><span class="arrow">→</span> CONNECTORS · STOPS ON THE INGEST
+              LINE</span
+            >
+          </div>
+          <p class="lead">
+            Point Setoku at the data you already have. Every source lands in a
+            local
+            <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+              >ClickHouse</a
+            >
+            data lake, on purpose: agents write arbitrary queries (scans, GROUP
+            BYs, whole-table aggregations), and a columnar engine answers those
+            in about a second, so the apps and dashboards they build stay quick.
+            Your app database connects read-only and is mirrored in on a cron;
+            the rest is ingested as it happens.
+          </p>
+          <div class="stopslist">
+            <div class="interchange">
+              <span class="ring"></span>ClickHouse · one lake, every source
+            </div>
+            <div class="stop-line">
+              <div class="name">PostgreSQL</div>
+              <div class="about">app database, mirrored read-only</div>
+            </div>
+            <div class="stop-line">
+              <div class="name">GitHub</div>
+              <div class="about">issues, PRs &amp; commits</div>
+            </div>
+            <div class="stop-line">
+              <div class="name">Vercel</div>
+              <div class="about">deploys &amp; logs</div>
+            </div>
+            <div class="stop-line">
+              <div class="name">Render</div>
+              <div class="about">deploys &amp; logs</div>
+            </div>
+            <div class="stop-line">
+              <div class="name">Slack</div>
+              <div class="about">messages</div>
+            </div>
+            <div class="stop-line">
+              <div class="name">Mercury</div>
+              <div class="about">banking &amp; finance</div>
+            </div>
+          </div>
+          <p class="note">
+            No connector for your source yet? The included setup skills give
+            your coding agent the patterns to wire one up itself. See
+            <a
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >the repo</a
+            >, or open an issue.
+          </p>
+        </div>
+      </section>
+
+      <!-- DEMO -->
+      <section id="demo">
+        <div class="wrap">
+          <div class="sec-head">
+            <span class="sign"
+              ><span class="tab" style="background: var(--board-fig)"></span
+              ><span class="arrow">→</span> DEMO · ARRIVALS BOARD</span
+            >
+          </div>
+          <p class="lead">
+            There’s a live demo wired to a fictional pro sports club, the Bonita
+            Bulldogs (ticketing, sponsorship, concessions, payroll, broadcast
+            rights).
+          </p>
+
+          <div class="step">
+            <h3 class="step-h">
+              <span class="step-n">1</span>Connect to the demo MCP server
+            </h3>
+            <p class="note" style="margin-top: 0">
+              In Claude (or any MCP client) open Settings → Connectors → Add
+              custom connector, and paste this URL. The token rides in the URL,
+              so there’s no separate key to enter.
+            </p>
+            <pre><code>https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</code></pre>
+          </div>
+
+          <div class="step">
+            <h3 class="step-h"><span class="step-n">2</span>Ask a question</h3>
+            <div class="board">
+              <div class="board-h">
+                <span>Question</span><span>Answer · platform</span>
+              </div>
+              <div class="arr">
+                <div>
+                  <div class="q">“How many unique fans do we have?”</div>
+                  <div class="cav">
+                    deduped by normalized email, internal accounts excluded. Not
+                    the raw 92,118.
+                  </div>
+                </div>
+                <div class="fig">71,204</div>
+              </div>
+              <div class="arr">
+                <div>
+                  <div class="q">
+                    “What’s our total annual revenue, and how much is media
+                    rights?”
+                  </div>
+                  <div class="cav">
+                    five systems reconciled to the same units. Media rights is
+                    the biggest line, ~$90M.
+                  </div>
+                </div>
+                <div class="fig">$192M</div>
+              </div>
+              <div class="arr">
+                <div>
+                  <div class="q">“What was ticket revenue this season?”</div>
+                  <div class="cav">
+                    cents reconciled to dollars; refunds, exchanges, and comps
+                    excluded.
+                  </div>
+                </div>
+                <div class="fig">$46.8M</div>
+              </div>
+              <div class="arr">
+                <div>
+                  <div class="q">“What’s our total merchandise revenue?”</div>
+                  <div class="cav">
+                    most merch is sold via Fanatics, not in this data, so it
+                    says so instead of returning a wrong total.
+                  </div>
+                </div>
+                <div class="fig flag">It flags it</div>
+              </div>
+              <div class="chart">
+                <div class="cl">“Chart revenue by line.” · ~$192M total</div>
+                <svg
+                  viewBox="0 0 640 214"
+                  role="img"
+                  aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M."
+                >
+                  <rect x="148" y="14" width="400" height="16" rx="2" fill="#2f8a5f" />
+                  <rect x="148" y="48" width="209" height="16" rx="2" fill="#35689e" />
+                  <rect x="148" y="82" width="124" height="16" rx="2" fill="#bd8324" />
+                  <rect x="148" y="116" width="62" height="16" rx="2" fill="#77558c" />
+                  <rect x="148" y="150" width="36" height="16" rx="2" fill="#b0553f" />
+                  <rect x="148" y="184" width="22" height="16" rx="2" fill="#8a938b" />
+                  <g
+                    font-family="Helvetica Neue, Arial, sans-serif"
+                    font-size="12.5"
+                    fill="#cfd6cf"
+                  >
+                    <text x="8" y="26">Media rights</text>
+                    <text x="8" y="60">Ticketing</text>
+                    <text x="8" y="94">Sponsorship</text>
+                    <text x="8" y="128">Concessions</text>
+                    <text x="8" y="162">Merch</text>
+                    <text x="8" y="196">Other</text>
+                  </g>
+                  <g
+                    font-family="ui-monospace, Menlo, monospace"
+                    font-size="12"
+                    fill="#e0b45f"
+                  >
+                    <text x="555" y="26">$90M</text>
+                    <text x="364" y="60">$47M</text>
+                    <text x="279" y="94">$28M</text>
+                    <text x="217" y="128">$14M</text>
+                    <text x="191" y="162">$8M</text>
+                    <text x="177" y="196">$5M</text>
+                  </g>
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          <div class="step">
+            <h3 class="step-h"><span class="step-n">3</span>Try an app</h3>
+            <p class="note" style="margin-top: 0">
+              Ask Claude to build a dashboard on the same data, then publish it
+              to a link. Two live examples, running on the demo data right now:
+            </p>
+            <ul class="uses">
+              <li>
+                <a
+                  href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+                  target="_blank"
+                  rel="noopener"
+                  >Sponsorship pricing table ↗</a
+                >
+                — inventory and rates for sponsorship placements.
+              </li>
+              <li>
+                <a
+                  href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+                  target="_blank"
+                  rel="noopener"
+                  >Fan lifetime value ↗</a
+                >
+                — segment fans by spend across tickets, merch, and concessions.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- WHY -->
+      <section id="why" class="why">
+        <div class="wrap">
+          <div class="sec-head">
+            <span class="sign"
+              ><span class="tab" style="background: var(--brick)"></span
+              ><span class="arrow">→</span> WHY WE BUILT IT</span
+            >
+          </div>
+          <div class="why-block">
+            <h3><span class="b"></span>We’re curious.</h3>
+            <p>
+              There are plenty of AI memory stores, and plenty of data gateways.
+              Stapling the two together, and nudging the agent to gather
+              knowledge about the data as it goes, seemed useful and fun to
+              tinker with.
+            </p>
+            <h3><span class="b"></span>We’re cheap.</h3>
+            <p>
+              We wanted something that runs on one small box, works on a Pro/Max
+              subscription or a cheap model with no added inference cost, mostly
+              sets itself up (no field engineer to pay for), stays portable
+              between providers, and is open source.
+            </p>
+            <h3><span class="b"></span>We’re paranoid.</h3>
+            <p>
+              HR platforms, CRMs, and clouds are all announcing “context
+              layers.” They’d like the meaning of your business to accumulate on
+              their servers, where it can never leave. Context is deeper lock-in
+              than data, and a hosted context layer has no export button. Setoku
+              exists so that understanding accumulates on a box you own instead.
+              If we disappear tomorrow, your context doesn’t.
+            </p>
+            <h3><span class="b"></span>We and some friends wanted the same thing.</h3>
+            <ul class="uses">
+              <li>
+                <b
+                  ><a
+                    href="https://www.hedgy.works"
+                    target="_blank"
+                    rel="noopener"
+                    >Hedgy</a
+                  ></b
+                >: keep scaling without hiring. Debug from live logs and data,
+                find growth levers, and match candidates and companies better
+                with more data.
+              </li>
+              <li>
+                <b
+                  ><a href="https://baggu.com" target="_blank" rel="noopener"
+                    >Baggu</a
+                  ></b
+                >: give employees state-of-the-art tools. Faster onboarding, and
+                a safe way to vibecode against real data.
+              </li>
+              <li>
+                <b
+                  ><a href="https://tlon.io" target="_blank" rel="noopener"
+                    >Tlon</a
+                  ></b
+                >: experimenting with giving agents curated data to work from.
+              </li>
+              <li>
+                <b>Sports analysts</b>: query across data that doesn’t usually
+                sit together.
+              </li>
+              <li>
+                <b>Academic labs</b>: think through hypotheses against real
+                papers, data, and drafts.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- SETUP HELP -->
+      <section id="help">
+        <div class="wrap">
+          <div class="sec-head">
+            <span class="sign"
+              ><span class="tab" style="background: var(--green)"></span
+              ><span class="arrow">→</span> SETUP HELP · TICKET OFFICE</span
+            >
+          </div>
+          <p class="lead">
+            It’s open source, so you can self-host it today. If you like, we’re
+            happy to help set it up. Just email
+            <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="wrap foot">
+        <div class="l">
+          <a class="brand" href="#top">
+            <svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+            Setoku
+          </a>
+          <a
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >GitHub</a
+          >
+          <a href="#demo">Demo</a>
+          <a href="mailto:hello@setoku.com">Contact</a>
+          <span>Apache-2.0</span>
+        </div>
+        <span class="jp">設 × 奥 · set (math) × oku (innermost)</span>
+      </div>
+    </footer>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) {
+            return w.trim();
+          })
+          .filter(Boolean);
+        if (words.length < 2) return;
+
+        var reduce = window.matchMedia(
+          "(prefers-reduced-motion: reduce)"
+        ).matches;
+        var LIFT = "0.72em";
+        var HALF = 240;
+        var HOLD = 2400;
+        var i = 0;
+
+        function widthOf(w) {
+          measure.textContent = w;
+          return measure.getBoundingClientRect().width;
+        }
+
+        box.style.width = widthOf(words[0]) + "px";
+
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next;
+            box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length;
+            return;
+          }
+          word
+            .animate(
+              [
+                { transform: "translateY(0)", opacity: 1 },
+                { transform: "translateY(-" + LIFT + ")", opacity: 0 },
+              ],
+              {
+                duration: HALF,
+                easing: "cubic-bezier(0.4, 0, 1, 1)",
+                fill: "forwards",
+              }
+            )
+            .finished.then(function () {
+              word.textContent = next;
+              box.style.width = widthOf(next) + "px";
+              word.animate(
+                [
+                  { transform: "translateY(" + LIFT + ")", opacity: 0 },
+                  { transform: "translateY(0)", opacity: 1 },
+                ],
+                {
+                  duration: HALF,
+                  easing: "cubic-bezier(0, 0, 0.2, 1)",
+                  fill: "forwards",
+                }
+              );
+              i = (i + 1) % words.length;
+            })
+            .catch(function () {});
+        }
+
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () {
+          box.style.width = widthOf(words[i]) + "px";
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/9-riso.html
+++ b/site/riffs/9-riso.html
@@ -1,0 +1,1595 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · a zine about your data</title>
+    <style>
+      :root {
+        /* Paper stock + two riso spot inks (green + warm red). Their
+           multiply overprint makes the third, darker tone. */
+        --paper: #f3ecdb;
+        --paper-2: #ece2cb;
+        --green: #2f6f4e;
+        --green-soft: #6f9a80;
+        --red: #c1543a;
+        --red-soft: #d6836e;
+        --ink: #241d17;
+        --ink-soft: #4a3f34;
+        --line: rgba(36, 29, 23, 0.24);
+        --disp: "Arial Narrow", "Helvetica Neue Condensed",
+          "Roboto Condensed", "Oswald", sans-serif;
+        --type: "Courier New", "Courier", ui-monospace, monospace;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        scroll-behavior: smooth;
+        -webkit-text-size-adjust: 100%;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family: var(--type);
+        font-size: 15.5px;
+        line-height: 1.62;
+        position: relative;
+        overflow-x: hidden;
+      }
+      /* Paper grain + a faint xerox tooth over everything. */
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+        pointer-events: none;
+        opacity: 0.5;
+        mix-blend-mode: multiply;
+        background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix type='saturate' values='0'/></filter><rect width='160' height='160' filter='url(%23n)' opacity='0.42'/></svg>");
+      }
+      /* Halftone dot field, very faint, behind content. */
+      body::after {
+        content: "";
+        position: fixed;
+        inset: 0;
+        z-index: -1;
+        pointer-events: none;
+        opacity: 0.5;
+        background-image: radial-gradient(
+          var(--green-soft) 0.9px,
+          transparent 1px
+        );
+        background-size: 7px 7px;
+        background-position: 0 0;
+      }
+      a {
+        color: var(--red);
+        text-decoration: underline;
+        text-underline-offset: 2px;
+        text-decoration-thickness: 1.5px;
+      }
+      a:hover {
+        background: var(--red);
+        color: var(--paper);
+        text-decoration: none;
+      }
+      svg {
+        display: block;
+      }
+      .wrap {
+        max-width: 940px;
+        margin: 0 auto;
+        padding-inline: 20px;
+      }
+      .disp {
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        font-weight: 700;
+        letter-spacing: 0.01em;
+        line-height: 0.98;
+      }
+      code {
+        font-family: var(--type);
+        font-weight: 700;
+        background: var(--paper-2);
+        border: 1.5px solid var(--line);
+        padding: 0 5px;
+        color: var(--green);
+      }
+
+      /* misregistration: colored ghosts of the ink plates */
+      .misreg {
+        color: var(--ink);
+        text-shadow: 1.6px 0.5px 0 var(--red-soft),
+          -1.6px -0.6px 0 var(--green-soft);
+      }
+
+      /* rubber-stamp section tag */
+      .stamp {
+        display: inline-block;
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        font-weight: 700;
+        letter-spacing: 0.14em;
+        font-size: 13px;
+        color: var(--red);
+        border: 2.5px solid var(--red);
+        padding: 3px 10px 2px;
+        transform: rotate(-1.6deg);
+        box-shadow: 2px 2px 0 rgba(193, 84, 58, 0.18);
+      }
+      .stamp.g {
+        color: var(--green);
+        border-color: var(--green);
+        transform: rotate(1.3deg);
+        box-shadow: 2px 2px 0 rgba(47, 111, 78, 0.18);
+      }
+
+      /* MASTHEAD */
+      header.mast {
+        border-bottom: 3px solid var(--ink);
+        background: var(--paper);
+        position: sticky;
+        top: 0;
+        z-index: 50;
+      }
+      .mast .bar {
+        max-width: 940px;
+        margin: 0 auto;
+        padding: 9px 20px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 7px;
+        font-family: var(--disp);
+        font-stretch: condensed;
+        font-weight: 700;
+        text-transform: uppercase;
+        font-size: 22px;
+        letter-spacing: 0.02em;
+        color: var(--ink);
+        text-decoration: none;
+      }
+      .brand:hover {
+        background: none;
+        color: var(--ink);
+      }
+      .brand .mark {
+        width: 24px;
+        height: 24px;
+        color: var(--green);
+      }
+      .mast nav {
+        display: flex;
+        gap: 14px;
+        align-items: center;
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        font-size: 14px;
+        letter-spacing: 0.04em;
+      }
+      .mast nav a {
+        color: var(--ink);
+        text-decoration: none;
+      }
+      .mast nav a:hover {
+        background: var(--green);
+        color: var(--paper);
+      }
+      @media (max-width: 620px) {
+        .mast nav a.hideable {
+          display: none;
+        }
+      }
+
+      /* zine issue strip */
+      .issue {
+        border-bottom: 1.5px solid var(--line);
+        background: var(--paper-2);
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-size: 11.5px;
+        color: var(--ink-soft);
+      }
+      .issue .in {
+        max-width: 940px;
+        margin: 0 auto;
+        padding: 5px 20px;
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+
+      /* HERO */
+      .hero {
+        padding: 40px 0 30px;
+        border-bottom: 3px solid var(--ink);
+      }
+      .hero .kick {
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 14px;
+        color: var(--green);
+        margin-bottom: 8px;
+      }
+      h1 {
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        font-weight: 700;
+        font-size: clamp(46px, 12vw, 108px);
+        line-height: 0.9;
+        letter-spacing: -0.005em;
+      }
+      .rotator {
+        position: relative;
+        display: inline-block;
+        text-align: left;
+        vertical-align: baseline;
+        color: var(--red);
+        transition: width 460ms cubic-bezier(0.22, 1, 0.36, 1);
+      }
+      .rotator-word {
+        display: inline-block;
+        white-space: nowrap;
+        will-change: transform, opacity;
+      }
+      .rotator-measure {
+        position: absolute;
+        left: 0;
+        top: 0;
+        visibility: hidden;
+        pointer-events: none;
+        white-space: nowrap;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .rotator {
+          transition: none;
+        }
+      }
+      .lede {
+        margin-top: 20px;
+        max-width: 40em;
+        font-size: 16.5px;
+        border-left: 4px solid var(--green);
+        padding-left: 14px;
+      }
+      .actions {
+        margin-top: 22px;
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .btn {
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        font-weight: 700;
+        letter-spacing: 0.05em;
+        font-size: 16px;
+        padding: 9px 18px;
+        border: 2.5px solid var(--ink);
+        background: var(--ink);
+        color: var(--paper);
+        text-decoration: none;
+        box-shadow: 3px 3px 0 var(--green);
+      }
+      .btn:hover {
+        background: var(--green);
+        border-color: var(--green);
+        color: var(--paper);
+        box-shadow: 3px 3px 0 var(--ink);
+      }
+      .btn.ghost {
+        background: transparent;
+        color: var(--ink);
+        box-shadow: 3px 3px 0 var(--red);
+      }
+      .btn.ghost:hover {
+        background: var(--red);
+        border-color: var(--red);
+        color: var(--paper);
+        box-shadow: 3px 3px 0 var(--ink);
+      }
+
+      /* SECTIONS */
+      section {
+        padding: 34px 0;
+        border-bottom: 2.5px dashed var(--line);
+      }
+      .h2 {
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        font-weight: 700;
+        font-size: clamp(30px, 6vw, 46px);
+        line-height: 0.95;
+        margin: 12px 0 4px;
+      }
+      .lead {
+        max-width: 44em;
+        margin-top: 10px;
+      }
+      p {
+        max-width: 46em;
+      }
+      .note {
+        margin-top: 12px;
+        max-width: 46em;
+      }
+      b {
+        color: var(--ink);
+      }
+
+      /* stacked cut-paper cards */
+      .cards {
+        margin-top: 20px;
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(2, 1fr);
+      }
+      @media (max-width: 640px) {
+        .cards {
+          grid-template-columns: 1fr;
+        }
+      }
+      .card {
+        background: var(--paper);
+        border: 2.5px solid var(--ink);
+        padding: 14px 15px 15px;
+        box-shadow: 4px 4px 0 rgba(47, 111, 78, 0.22);
+        position: relative;
+      }
+      .card:nth-child(2n) {
+        box-shadow: 4px 4px 0 rgba(193, 84, 58, 0.22);
+      }
+      .card .ct {
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        font-weight: 700;
+        font-size: 20px;
+        line-height: 1;
+        color: var(--ink);
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 8px;
+      }
+      .card .tag {
+        font-family: var(--type);
+        text-transform: none;
+        font-weight: 700;
+        font-size: 11.5px;
+        color: var(--green);
+      }
+      .card .cv {
+        margin-top: 8px;
+        font-size: 14px;
+        color: var(--ink-soft);
+      }
+
+      pre {
+        background: var(--ink);
+        color: var(--paper);
+        border: 2.5px solid var(--ink);
+        padding: 14px 16px;
+        overflow-x: auto;
+        margin: 16px 0;
+        box-shadow: 5px 5px 0 rgba(47, 111, 78, 0.3);
+      }
+      pre code {
+        font-family: var(--type);
+        font-weight: 400;
+        font-size: 13.5px;
+        line-height: 1.8;
+        background: none;
+        border: none;
+        padding: 0;
+        color: var(--paper);
+        white-space: pre;
+      }
+      pre code .c {
+        color: var(--green-soft);
+      }
+      details.manual {
+        margin-top: 10px;
+        border: 2px dashed var(--line);
+        padding: 10px 12px;
+      }
+      details.manual summary {
+        cursor: pointer;
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        color: var(--red);
+      }
+
+      ul.checklist {
+        list-style: none;
+        margin-top: 14px;
+        display: grid;
+        gap: 9px;
+      }
+      ul.checklist li {
+        padding-left: 32px;
+        position: relative;
+        max-width: 46em;
+      }
+      ul.checklist li::before {
+        content: "\2713";
+        position: absolute;
+        left: 0;
+        top: -1px;
+        width: 21px;
+        height: 21px;
+        line-height: 19px;
+        text-align: center;
+        font-weight: 700;
+        color: var(--green);
+        border: 2px solid var(--green);
+        transform: rotate(-4deg);
+      }
+      ul.checklist li:nth-child(2n)::before {
+        color: var(--red);
+        border-color: var(--red);
+        transform: rotate(3deg);
+      }
+
+      /* ART: framed riso plate */
+      .plate {
+        margin-top: 20px;
+        border: 2.5px solid var(--ink);
+        background: var(--paper);
+        padding: 12px;
+        box-shadow: 5px 5px 0 rgba(193, 84, 58, 0.22);
+        overflow-x: auto;
+      }
+      .plate svg {
+        width: 100%;
+        min-width: 520px;
+        height: auto;
+      }
+
+      /* connectors: stamped BOM checklist */
+      .lakebox {
+        margin-top: 18px;
+        border: 2.5px solid var(--ink);
+        padding: 14px;
+        background: var(--paper);
+        box-shadow: 5px 5px 0 rgba(47, 111, 78, 0.22);
+      }
+      .lk {
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 700;
+        color: var(--green);
+        border-bottom: 2px solid var(--line);
+        padding-bottom: 8px;
+        margin-bottom: 10px;
+      }
+      .chips {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 8px 18px;
+      }
+      @media (max-width: 560px) {
+        .chips {
+          grid-template-columns: 1fr;
+        }
+      }
+      .chip {
+        display: flex;
+        gap: 8px;
+        align-items: baseline;
+        padding-left: 26px;
+        position: relative;
+      }
+      .chip::before {
+        content: "\2713";
+        position: absolute;
+        left: 0;
+        font-weight: 700;
+        color: var(--red);
+        border: 1.8px solid var(--red);
+        width: 18px;
+        height: 18px;
+        text-align: center;
+        line-height: 15px;
+        font-size: 12px;
+        transform: rotate(-3deg);
+      }
+      .chip b {
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        font-weight: 700;
+        color: var(--ink);
+      }
+      .chip span {
+        color: var(--ink-soft);
+        font-size: 13px;
+      }
+
+      /* DEMO */
+      .step {
+        margin-top: 26px;
+      }
+      .step-h {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        font-weight: 700;
+        font-size: 24px;
+        margin-bottom: 8px;
+      }
+      .step-n {
+        position: relative;
+        flex: none;
+        width: 42px;
+        height: 42px;
+        display: grid;
+        place-items: center;
+        font-size: 22px;
+        color: var(--red);
+      }
+      .step-n svg {
+        position: absolute;
+        inset: -4px;
+        width: calc(100% + 8px);
+        height: calc(100% + 8px);
+      }
+      .examples {
+        margin-top: 12px;
+        display: grid;
+        gap: 14px;
+      }
+      .ex {
+        border: 2.5px solid var(--ink);
+        background: var(--paper);
+        padding: 12px 14px;
+        box-shadow: 4px 4px 0 rgba(47, 111, 78, 0.18);
+      }
+      .ex:nth-child(2n) {
+        box-shadow: 4px 4px 0 rgba(193, 84, 58, 0.18);
+      }
+      .ex .q {
+        font-weight: 700;
+        color: var(--green);
+      }
+      .ex .a {
+        margin-top: 8px;
+        display: flex;
+        gap: 12px;
+        align-items: baseline;
+        flex-wrap: wrap;
+      }
+      .ex .a b {
+        position: relative;
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        font-weight: 700;
+        font-size: 30px;
+        color: var(--ink);
+        line-height: 1;
+        padding: 2px 6px;
+      }
+      /* hand-circle around the headline number */
+      .ex .a b::after {
+        content: "";
+        position: absolute;
+        inset: -8px -10px -6px -8px;
+        border: 2.5px solid var(--red);
+        border-radius: 60% 40% 55% 45% / 55% 50% 50% 45%;
+        transform: rotate(-2deg);
+        pointer-events: none;
+      }
+      .ex .a span {
+        font-size: 13.5px;
+        color: var(--ink-soft);
+        max-width: 34em;
+      }
+      .chart .cl {
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        font-weight: 700;
+        color: var(--ink);
+        margin-bottom: 8px;
+      }
+      .chart {
+        width: 100%;
+        overflow-x: auto;
+      }
+      .chart svg {
+        width: 100%;
+        min-width: 460px;
+        height: auto;
+      }
+
+      /* WHY */
+      .why h3 {
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        font-weight: 700;
+        font-size: 26px;
+        color: var(--red);
+        margin: 22px 0 4px;
+      }
+      .why h3:nth-of-type(2n) {
+        color: var(--green);
+      }
+
+      /* FOOTER */
+      footer {
+        border-top: 3px solid var(--ink);
+        background: var(--paper-2);
+        margin-top: 6px;
+      }
+      .foot {
+        max-width: 940px;
+        margin: 0 auto;
+        padding: 20px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 14px 20px;
+        align-items: center;
+        justify-content: space-between;
+        font-family: var(--disp);
+        font-stretch: condensed;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        font-size: 14px;
+      }
+      .foot .l {
+        display: flex;
+        gap: 16px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .foot a {
+        color: var(--ink);
+        text-decoration: none;
+      }
+      .foot a:hover {
+        background: var(--green);
+        color: var(--paper);
+      }
+      .foot .jp {
+        font-family: var(--type);
+        text-transform: none;
+        letter-spacing: 0;
+        color: var(--ink-soft);
+        font-size: 13px;
+      }
+      .colophon {
+        border-top: 1.5px solid var(--line);
+        text-align: center;
+        padding: 10px 20px 16px;
+        font-family: var(--type);
+        font-size: 12px;
+        color: var(--ink-soft);
+      }
+    </style>
+  </head>
+  <body>
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="clover" viewBox="0 0 64 64">
+        <path
+          d="M32 35 Q24.8 27.88 11.47 25.91 A11 11 0 1 1 26.61 13.21 Q32.37 21.53 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M32 35 Q32.37 25.88 35.79 19.33 A8 8 0 1 1 46.77 28.54 Q37.86 30.49 32 35 Z"
+          fill="currentColor"
+        />
+        <path
+          d="M29.86 35.18 L29.87 36.49 L29.83 37.72 L29.76 38.89 L29.65 40.02 L29.51 41.12 L29.34 42.17 L29.15 43.2 L28.93 44.2 L28.7 45.17 L28.45 46.13 L28.2 47.08 L27.93 48.02 L27.66 48.96 L27.39 49.9 L27.12 50.84 L26.86 51.8 L26.61 52.77 L26.38 53.76 L26.16 54.78 L25.97 55.82 L25.82 56.9 L25.7 57.92 L34.3 58.08 L34.22 57.2 L34.16 56.4 L34.14 55.58 L34.13 54.74 L34.15 53.88 L34.19 52.99 L34.25 52.08 L34.32 51.14 L34.39 50.18 L34.47 49.19 L34.55 48.17 L34.63 47.12 L34.7 46.04 L34.75 44.93 L34.78 43.79 L34.8 42.61 L34.78 41.4 L34.73 40.15 L34.65 38.87 L34.52 37.55 L34.35 36.19 L34.14 34.82 Z"
+          fill="currentColor"
+        />
+      </symbol>
+    </svg>
+
+    <header class="mast">
+      <div class="bar">
+        <a class="brand" href="#top">
+          <svg class="mark" viewBox="0 0 64 64"><use href="#clover" /></svg>
+          Setoku
+        </a>
+        <nav>
+          <a class="hideable" href="#how">How it works</a>
+          <a class="hideable" href="#apps">Apps</a>
+          <a class="hideable" href="#connectors">Connectors</a>
+          <a
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >GitHub ↗</a
+          >
+        </nav>
+      </div>
+    </header>
+
+    <div class="issue">
+      <div class="in">
+        <span>Issue №1 · self-published</span>
+        <span>Open source · MCP server · Apache-2.0</span>
+        <span>Print at 100%</span>
+      </div>
+    </div>
+
+    <main id="top">
+      <!-- HERO -->
+      <div class="hero">
+        <div class="wrap">
+          <div class="kick">A zine about your data</div>
+          <h1 class="disp misreg">
+            Make any AI<br />fluent in your<br /><span
+              class="rotator"
+              data-words="company,family,personal"
+              ><span class="rotator-word">company</span
+              ><span class="rotator-measure" aria-hidden="true"></span></span
+            ><br />data.
+          </h1>
+          <p class="lede">
+            Setoku is a small self-hosted MCP knowledge server + Claude Code
+            skills for hooking up your data. It does two things: it gives your
+            AI a read-only way to query your data, and it remembers what that
+            data means (the metric definitions, the gotchas), getting better the
+            more you use it. The MCP works with whatever AI you already have, and
+            no model runs on the server, so no added inference cost.
+          </p>
+          <div class="actions">
+            <a
+              class="btn"
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >View on GitHub ↗</a
+            >
+            <a class="btn ghost" href="#demo">Try the demo</a>
+          </div>
+        </div>
+      </div>
+
+      <!-- QUICKSTART -->
+      <section id="quickstart">
+        <div class="wrap">
+          <span class="stamp">Quickstart</span>
+          <h2 class="h2">Cut here, glue there</h2>
+          <p class="lead">
+            Setoku installs as a Claude Code plugin. Add the plugin, then run
+            onboarding from your main project directory, the codebase you want
+            Setoku to learn from:
+          </p>
+          <pre><code><span class="c"># 1 · add the plugin (skills only)</span>
+/plugin marketplace add Hedgy-Labs/setoku
+/plugin install setoku@setoku
+
+<span class="c"># 2 · from your project directory</span>
+/setoku:onboard</code></pre>
+          <p class="note">
+            Onboarding stands up the server, auths your Claude, wires your
+            database read-only, and generates the first knowledge from your
+            code. You stay in the loop for anything that touches your data. To
+            start onboarding, run <code>/setoku:onboard</code>.
+          </p>
+          <p class="note">
+            You’ll need somewhere to host it. Something like OVH’s
+            <a href="https://us.ovhcloud.com/vps/" target="_blank" rel="noopener"
+              >VPS-2</a
+            >
+            is plenty.
+          </p>
+          <details class="manual">
+            <summary>Or stand up the server by hand</summary>
+            <pre><code><span class="c"># on a fresh Ubuntu VPS</span>
+git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+cd /opt/setoku
+SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
+            <p class="note" style="margin-top: 12px">
+              Installs Docker, generates secrets, gets an HTTPS certificate, and
+              prints the connect command. Then add the plugin and run
+              /setoku:onboard from your project; it’ll detect the box you just
+              made.
+            </p>
+          </details>
+        </div>
+      </section>
+
+      <!-- HOW IT WORKS -->
+      <section id="how">
+        <div class="wrap">
+          <span class="stamp g">How it works</span>
+          <h2 class="h2">Two tools, one rule</h2>
+          <p class="lead">
+            Setoku gives the AI two kinds of MCP tools, and one rule: look up
+            what the data means before you touch it.
+          </p>
+          <div class="cards">
+            <div class="card">
+              <div class="ct">
+                Context tools<span class="tag">find_context · get_metric</span>
+              </div>
+              <div class="cv">
+                The AI reads what your data means first: canonical metric
+                definitions, entity docs, and the gotchas that make a naive
+                query wrong.
+              </div>
+            </div>
+            <div class="card">
+              <div class="ct">
+                Read-only query<span class="tag">get_schema · run_query</span>
+              </div>
+              <div class="cv">
+                Read-only, with a row cap, a statement timeout, a table
+                allow-list, and an append-only audit log. Enforced by the
+                database role, not by parsing SQL.
+              </div>
+            </div>
+            <div class="card">
+              <div class="ct">
+                Human-approved<span class="tag">report_correction</span>
+              </div>
+              <div class="cv">
+                The AI can only propose changes to what Setoku knows. A person
+                accepts them on the admin page, outside the agent loop, so an
+                injected session can’t rewrite the brain.
+              </div>
+            </div>
+            <div class="card">
+              <div class="ct">
+                Set up with skills<span class="tag">Claude Code</span>
+              </div>
+              <div class="cv">
+                <code>/setoku:onboard</code> sets it up in a repo the first
+                time. <code>/setoku:connect</code> adds a source.
+                <code>/setoku:generate</code> writes context from your code.
+                <code>/setoku:curate</code> reviews and approves pending
+                knowledge.
+              </div>
+            </div>
+          </div>
+          <p class="note">
+            Once it’s set up, <b>any MCP client</b> can use it: Claude, Codex,
+            or whatever you run. Just ask in plain language, and the tools do
+            the rest.
+          </p>
+        </div>
+      </section>
+
+      <!-- APPS -->
+      <section id="apps">
+        <div class="wrap">
+          <span class="stamp">Apps</span>
+          <h2 class="h2">Save and share the tools Claude builds you</h2>
+          <p class="lead">
+            Ask Claude to build a dashboard on your data. Then publish it to a
+            link as a Setoku App, the data stays live, and your whole team can
+            view it. Nothing to deploy, no frontend to maintain.
+          </p>
+          <div class="cards">
+            <div class="card">
+              <div class="ct">
+                Built by asking<span class="tag">publish_app</span>
+              </div>
+              <div class="cv">
+                Describe it in plain language; the agent writes the app and
+                publishes it to a URL. Edit it the same way, just ask for the
+                change.
+              </div>
+            </div>
+            <div class="card">
+              <div class="ct">
+                Backed by live data<span class="tag">read-only</span>
+              </div>
+              <div class="cv">
+                Apps read through the same governed path: row caps, audit, a
+                SELECT-only database role. They never get write access to your
+                sources.
+              </div>
+            </div>
+            <div class="card">
+              <div class="ct">
+                App-private state<span class="tag">no writes to your data</span>
+              </div>
+              <div class="cv">
+                Each app keeps its own state (todos, votes, annotations) in a
+                sandbox that belongs to the app, not your database. Worst case,
+                an app messes up its own notes.
+              </div>
+            </div>
+            <div class="card">
+              <div class="ct">
+                Share by link<span class="tag">team or public</span>
+              </div>
+              <div class="cv">
+                A team link is login-gated; an admin can flip one public for a
+                credential-free URL. The page runs in a locked-down sandbox with
+                no network, so a published app can’t phone home.
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ARCHITECTURE -->
+      <section id="architecture">
+        <div class="wrap">
+          <span class="stamp g">Architecture</span>
+          <h2 class="h2">One small box, drawn by hand</h2>
+          <p class="lead">
+            You can host this on whatever infra you like. We put it all on one
+            small box (a ~$12/mo VPS). The <code>/setoku:connect</code> skill
+            helps you add custom integrations. Only the proxy is public, so your
+            databases aren’t exposed. Queries are read-only, and knowledge
+            changes pass through a person.
+          </p>
+          <div class="plate">
+            <svg
+              viewBox="0 0 680 540"
+              role="img"
+              aria-label="Setoku architecture and data flow: you and your AI connect over MCP to the gateway on your box, which holds a ClickHouse lake, a knowledge store, and a person who approves. Below the box, your Postgres database is queried read-only and mirrored into the lake for analytics, and your sources (GitHub, Vercel, Render, Slack, Mercury) are ingested into the lake."
+            >
+              <defs>
+                <marker
+                  id="rah"
+                  markerWidth="11"
+                  markerHeight="11"
+                  refX="6"
+                  refY="4"
+                  orient="auto-start-reverse"
+                >
+                  <path d="M0 0 L8 4 L0 8 Z" fill="#241d17" />
+                </marker>
+                <pattern
+                  id="halfg"
+                  width="6"
+                  height="6"
+                  patternUnits="userSpaceOnUse"
+                >
+                  <circle cx="1.6" cy="1.6" r="1.5" fill="#2f6f4e" />
+                </pattern>
+                <pattern
+                  id="halfr"
+                  width="6"
+                  height="6"
+                  patternUnits="userSpaceOnUse"
+                >
+                  <circle cx="1.6" cy="1.6" r="1.5" fill="#c1543a" />
+                </pattern>
+              </defs>
+
+              <style>
+                .rn {
+                  fill: #f3ecdb;
+                  stroke: #241d17;
+                  stroke-width: 2.5;
+                }
+                .rt {
+                  font-family: "Arial Narrow", sans-serif;
+                  font-stretch: condensed;
+                  text-transform: uppercase;
+                  font-weight: 700;
+                  font-size: 14px;
+                  fill: #241d17;
+                }
+                .rs {
+                  font-family: "Courier New", monospace;
+                  font-size: 11px;
+                  fill: #4a3f34;
+                }
+                .re {
+                  font-family: "Courier New", monospace;
+                  font-weight: 700;
+                  font-size: 11px;
+                  fill: #c1543a;
+                }
+                .rarr {
+                  stroke: #241d17;
+                  stroke-width: 2.2;
+                  fill: none;
+                }
+              </style>
+
+              <!-- you + your AI -->
+              <rect class="rn" x="248" y="14" width="184" height="46" />
+              <text class="rt" x="340" y="42" text-anchor="middle">
+                You + your AI
+              </text>
+              <path
+                class="rarr"
+                d="M340 60 L340 150"
+                marker-start="url(#rah)"
+                marker-end="url(#rah)"
+              />
+              <text class="re" x="348" y="90">MCP</text>
+
+              <!-- the box -->
+              <rect
+                x="56"
+                y="112"
+                width="568"
+                height="316"
+                fill="none"
+                stroke="#241d17"
+                stroke-width="2.5"
+                stroke-dasharray="9 7"
+              />
+              <text class="re" x="72" y="132" fill="#2f6f4e">your box</text>
+
+              <rect
+                x="248"
+                y="150"
+                width="184"
+                height="62"
+                fill="url(#halfg)"
+                stroke="#241d17"
+                stroke-width="2.5"
+              />
+              <rect
+                class="rn"
+                x="248"
+                y="150"
+                width="184"
+                height="62"
+                fill="#f3ecdb"
+                opacity="0.72"
+              />
+              <text class="rt" x="340" y="176" text-anchor="middle">
+                Setoku gateway
+              </text>
+              <text class="rs" x="340" y="195" text-anchor="middle">
+                context · query tools
+              </text>
+
+              <rect class="rn" x="452" y="152" width="150" height="52" />
+              <text class="rt" x="527" y="183" text-anchor="middle">
+                a person
+              </text>
+
+              <rect
+                x="88"
+                y="330"
+                width="184"
+                height="68"
+                fill="url(#halfg)"
+                stroke="#241d17"
+                stroke-width="2.5"
+              />
+              <rect
+                x="88"
+                y="330"
+                width="184"
+                height="68"
+                fill="#f3ecdb"
+                opacity="0.68"
+                stroke="none"
+              />
+              <text class="rt" x="180" y="358" text-anchor="middle">
+                Lake (ClickHouse)
+              </text>
+              <text class="rs" x="180" y="377" text-anchor="middle">
+                logs · events · DB mirror
+              </text>
+
+              <rect
+                x="404"
+                y="330"
+                width="196"
+                height="68"
+                fill="url(#halfr)"
+                stroke="#241d17"
+                stroke-width="2.5"
+              />
+              <rect
+                x="404"
+                y="330"
+                width="196"
+                height="68"
+                fill="#f3ecdb"
+                opacity="0.68"
+                stroke="none"
+              />
+              <text class="rt" x="502" y="368" text-anchor="middle">
+                Knowledge store
+              </text>
+
+              <!-- your external data -->
+              <rect class="rn" x="88" y="458" width="184" height="66" />
+              <text class="rt" x="180" y="486" text-anchor="middle">
+                Your sources
+              </text>
+              <text class="rs" x="180" y="505" text-anchor="middle">
+                GitHub · Vercel · Slack…
+              </text>
+
+              <rect class="rn" x="304" y="458" width="184" height="66" />
+              <text class="rt" x="396" y="486" text-anchor="middle">
+                Your database
+              </text>
+              <text class="rs" x="396" y="505" text-anchor="middle">
+                Postgres · read-only
+              </text>
+
+              <!-- flows -->
+              <path
+                class="rarr"
+                d="M414 212 L512 330"
+                marker-start="url(#rah)"
+                marker-end="url(#rah)"
+              />
+              <text class="re" x="430" y="272">reads ·</text>
+              <text class="re" x="430" y="287">proposes</text>
+              <path class="rarr" d="M527 204 L516 330" marker-end="url(#rah)" />
+              <text class="re" x="536" y="270">approves</text>
+              <path class="rarr" d="M212 330 L300 212" marker-end="url(#rah)" />
+              <path class="rarr" d="M180 458 L180 398" marker-end="url(#rah)" />
+              <text class="re" x="188" y="435">ingest</text>
+              <path class="rarr" d="M396 458 L372 214" marker-end="url(#rah)" />
+              <text class="re" x="300" y="316">read-only</text>
+            </svg>
+          </div>
+        </div>
+      </section>
+
+      <!-- CONNECTORS -->
+      <section id="connectors">
+        <div class="wrap">
+          <span class="stamp">Connectors</span>
+          <h2 class="h2">Everything into one lake</h2>
+          <p class="lead">
+            Point Setoku at the data you already have. Every source lands in a
+            local
+            <a href="https://clickhouse.com/" target="_blank" rel="noopener"
+              >ClickHouse</a
+            >
+            data lake, on purpose: agents write arbitrary queries (scans,
+            GROUP&nbsp;BYs, whole-table aggregations), and a columnar engine
+            answers those in about a second, so the apps and dashboards they
+            build stay quick. Your app database connects read-only and is
+            mirrored in on a cron; the rest is ingested as it happens.
+          </p>
+          <div class="lakebox">
+            <div class="lk">ClickHouse · one lake, every source</div>
+            <div class="chips">
+              <div class="chip">
+                <b>PostgreSQL</b><span>app database, mirrored read-only</span>
+              </div>
+              <div class="chip">
+                <b>GitHub</b><span>issues, PRs &amp; commits</span>
+              </div>
+              <div class="chip"><b>Vercel</b><span>deploys &amp; logs</span></div>
+              <div class="chip"><b>Render</b><span>deploys &amp; logs</span></div>
+              <div class="chip"><b>Slack</b><span>messages</span></div>
+              <div class="chip">
+                <b>Mercury</b><span>banking &amp; finance</span>
+              </div>
+            </div>
+          </div>
+          <p class="note">
+            No connector for your source yet? The included setup skills give
+            your coding agent the patterns to wire one up itself. See
+            <a
+              href="https://github.com/Hedgy-Labs/setoku"
+              target="_blank"
+              rel="noopener"
+              >the repo</a
+            >, or open an issue.
+          </p>
+        </div>
+      </section>
+
+      <!-- DEMO -->
+      <section id="demo">
+        <div class="wrap">
+          <span class="stamp g">Demo</span>
+          <h2 class="h2">Try it on real-ish data</h2>
+          <p class="lead">
+            There’s a live demo wired to a fictional pro sports club, the Bonita
+            Bulldogs (ticketing, sponsorship, concessions, payroll, broadcast
+            rights).
+          </p>
+
+          <div class="step">
+            <h3 class="step-h">
+              <span class="step-n"
+                ><svg viewBox="0 0 50 50" aria-hidden="true">
+                  <ellipse
+                    cx="25"
+                    cy="25"
+                    rx="21"
+                    ry="19"
+                    fill="none"
+                    stroke="#2f6f4e"
+                    stroke-width="2.5"
+                    transform="rotate(-6 25 25)"
+                  /></svg
+                >1</span
+              >Connect to the demo MCP server
+            </h3>
+            <p class="note" style="margin-top: 0">
+              In Claude (or any MCP client) open Settings → Connectors → Add
+              custom connector, and paste this URL. The token rides in the URL,
+              so there’s no separate key to enter.
+            </p>
+            <pre><code>https://demo.setoku.com/i/55e767ea376aa3783cfb4653e2bf81772876b9b5c36339d9</code></pre>
+          </div>
+
+          <div class="step">
+            <h3 class="step-h">
+              <span class="step-n"
+                ><svg viewBox="0 0 50 50" aria-hidden="true">
+                  <ellipse
+                    cx="25"
+                    cy="25"
+                    rx="21"
+                    ry="19"
+                    fill="none"
+                    stroke="#c1543a"
+                    stroke-width="2.5"
+                    transform="rotate(5 25 25)"
+                  /></svg
+                >2</span
+              >Ask a question
+            </h3>
+            <div class="examples">
+              <div class="ex">
+                <div class="q">“How many unique fans do we have?”</div>
+                <div class="a">
+                  <b>71,204</b>
+                  <span
+                    >deduped by normalized email, internal accounts excluded.
+                    Not the raw 92,118.</span
+                  >
+                </div>
+              </div>
+              <div class="ex">
+                <div class="q">
+                  “What’s our total annual revenue, and how much is media
+                  rights?”
+                </div>
+                <div class="a">
+                  <b>$192M</b>
+                  <span
+                    >five systems reconciled to the same units. Media rights is
+                    the biggest line, ~$90M.</span
+                  >
+                </div>
+              </div>
+              <div class="ex">
+                <div class="q">“What was ticket revenue this season?”</div>
+                <div class="a">
+                  <b>$46.8M</b>
+                  <span
+                    >cents reconciled to dollars; refunds, exchanges, and comps
+                    excluded.</span
+                  >
+                </div>
+              </div>
+              <div class="ex">
+                <div class="q">“What’s our total merchandise revenue?”</div>
+                <div class="a">
+                  <b>It flags it</b>
+                  <span
+                    >most merch is sold via Fanatics, not in this data, so it
+                    says so instead of returning a wrong total.</span
+                  >
+                </div>
+              </div>
+              <div class="ex">
+                <div class="q">“Chart revenue by line.”</div>
+                <div class="chart" style="margin-top: 12px">
+                  <div class="cl">Annual revenue by line · ~$192M total</div>
+                  <svg
+                    viewBox="0 0 640 214"
+                    role="img"
+                    aria-label="Annual revenue by line: media rights $90M, ticketing $47M, sponsorship $28M, concessions $14M, merch $8M, other $5M."
+                  >
+                    <defs>
+                      <pattern
+                        id="barhalf"
+                        width="6"
+                        height="6"
+                        patternUnits="userSpaceOnUse"
+                      >
+                        <rect width="6" height="6" fill="#2f6f4e" />
+                        <circle cx="4.4" cy="4.4" r="1.7" fill="#245c40" />
+                      </pattern>
+                    </defs>
+                    <g fill="url(#barhalf)" stroke="#241d17" stroke-width="2">
+                      <rect x="148" y="14" width="400" height="18" />
+                      <rect x="148" y="48" width="209" height="18" />
+                      <rect x="148" y="82" width="124" height="18" />
+                      <rect x="148" y="116" width="62" height="18" />
+                      <rect x="148" y="150" width="36" height="18" />
+                      <rect x="148" y="184" width="22" height="18" />
+                    </g>
+                    <g
+                      font-family="'Arial Narrow', sans-serif"
+                      font-size="13"
+                      font-weight="700"
+                      fill="#4a3f34"
+                    >
+                      <text x="8" y="27">MEDIA RIGHTS</text>
+                      <text x="8" y="61">TICKETING</text>
+                      <text x="8" y="95">SPONSORSHIP</text>
+                      <text x="8" y="129">CONCESSIONS</text>
+                      <text x="8" y="163">MERCH</text>
+                      <text x="8" y="197">OTHER</text>
+                    </g>
+                    <g
+                      font-family="'Courier New', monospace"
+                      font-size="13"
+                      font-weight="700"
+                      fill="#c1543a"
+                    >
+                      <text x="556" y="28">$90M</text>
+                      <text x="365" y="62">$47M</text>
+                      <text x="280" y="96">$28M</text>
+                      <text x="218" y="130">$14M</text>
+                      <text x="192" y="164">$8M</text>
+                      <text x="178" y="198">$5M</text>
+                    </g>
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="step">
+            <h3 class="step-h">
+              <span class="step-n"
+                ><svg viewBox="0 0 50 50" aria-hidden="true">
+                  <ellipse
+                    cx="25"
+                    cy="25"
+                    rx="21"
+                    ry="19"
+                    fill="none"
+                    stroke="#2f6f4e"
+                    stroke-width="2.5"
+                    transform="rotate(-4 25 25)"
+                  /></svg
+                >3</span
+              >Try an app
+            </h3>
+            <p class="note" style="margin-top: 0">
+              Ask Claude to build a dashboard on the same data, then publish it
+              to a link. Two live examples, running on the demo data right now:
+            </p>
+            <ul class="checklist">
+              <li>
+                <a
+                  href="https://demo.setoku.com/admin/p/7e38381ced6517329947b14d"
+                  target="_blank"
+                  rel="noopener"
+                  >Sponsorship pricing table ↗</a
+                >
+                — inventory and rates for sponsorship placements.
+              </li>
+              <li>
+                <a
+                  href="https://demo.setoku.com/admin/p/b059da830dcb3e70437d5dea"
+                  target="_blank"
+                  rel="noopener"
+                  >Fan lifetime value ↗</a
+                >
+                — segment fans by spend across tickets, merch, and concessions.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- WHY -->
+      <section id="why" class="why">
+        <div class="wrap">
+          <span class="stamp">Manifesto</span>
+          <h2 class="h2">Why we built it</h2>
+          <h3>We’re curious.</h3>
+          <p>
+            There are plenty of AI memory stores, and plenty of data gateways.
+            Stapling the two together, and nudging the agent to gather knowledge
+            about the data as it goes, seemed useful and fun to tinker with.
+          </p>
+          <h3>We’re cheap.</h3>
+          <p>
+            We wanted something that runs on one small box, works on a Pro/Max
+            subscription or a cheap model with no added inference cost, mostly
+            sets itself up (no field engineer to pay for), stays portable
+            between providers, and is open source.
+          </p>
+          <h3>We’re paranoid.</h3>
+          <p>
+            HR platforms, CRMs, and clouds are all announcing “context layers.”
+            They’d like the meaning of your business to accumulate on their
+            servers, where it can never leave. Context is deeper lock-in than
+            data, and a hosted context layer has no export button. Setoku exists
+            so that understanding accumulates on a box you own instead. If we
+            disappear tomorrow, your context doesn’t.
+          </p>
+          <h3>We and some friends wanted the same thing.</h3>
+          <ul class="checklist">
+            <li>
+              <b
+                ><a href="https://www.hedgy.works" target="_blank" rel="noopener"
+                  >Hedgy</a
+                ></b
+              >: keep scaling without hiring. Debug from live logs and data, find
+              growth levers, and match candidates and companies better with more
+              data.
+            </li>
+            <li>
+              <b
+                ><a href="https://baggu.com" target="_blank" rel="noopener"
+                  >Baggu</a
+                ></b
+              >: give employees state-of-the-art tools. Faster onboarding, and a
+              safe way to vibecode against real data.
+            </li>
+            <li>
+              <b
+                ><a href="https://tlon.io" target="_blank" rel="noopener"
+                  >Tlon</a
+                ></b
+              >: experimenting with giving agents curated data to work from.
+            </li>
+            <li>
+              <b>Sports analysts</b>: query across data that doesn’t usually sit
+              together.
+            </li>
+            <li>
+              <b>Academic labs</b>: think through hypotheses against real papers,
+              data, and drafts.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- SETUP HELP -->
+      <section id="help">
+        <div class="wrap">
+          <span class="stamp g">Setup help</span>
+          <h2 class="h2">Write to us</h2>
+          <p>
+            It’s open source, so you can self-host it today. If you like, we’re
+            happy to help set it up. Just email
+            <a href="mailto:hello@setoku.com">hello@setoku.com</a>.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="foot">
+        <div class="l">
+          <a class="brand" href="#top" style="font-size: 17px">
+            <svg
+              class="mark"
+              viewBox="0 0 64 64"
+              style="width: 19px; height: 19px"
+            >
+              <use href="#clover" />
+            </svg>
+            Setoku
+          </a>
+          <a
+            href="https://github.com/Hedgy-Labs/setoku"
+            target="_blank"
+            rel="noopener"
+            >GitHub</a
+          >
+          <a href="#demo">Demo</a>
+          <a href="mailto:hello@setoku.com">Contact</a>
+          <span>Apache-2.0</span>
+        </div>
+        <span class="jp">設 × 奥 · set (math) × oku (innermost)</span>
+      </div>
+      <div class="colophon">
+        Printed on one small box · two inks, one lake · risograph riff №9
+      </div>
+    </footer>
+
+    <script>
+      (function () {
+        var box = document.querySelector(".rotator");
+        if (!box) return;
+        var word = box.querySelector(".rotator-word");
+        var measure = box.querySelector(".rotator-measure");
+        var words = (box.getAttribute("data-words") || "")
+          .split(",")
+          .map(function (w) {
+            return w.trim();
+          })
+          .filter(Boolean);
+        if (words.length < 2) return;
+
+        var reduce = window.matchMedia(
+          "(prefers-reduced-motion: reduce)"
+        ).matches;
+        var LIFT = "0.72em";
+        var HALF = 220;
+        var HOLD = 2400;
+        var i = 0;
+
+        function widthOf(w) {
+          measure.textContent = w;
+          return measure.getBoundingClientRect().width;
+        }
+
+        box.style.width = widthOf(words[0]) + "px";
+
+        function swap() {
+          var next = words[(i + 1) % words.length];
+          if (reduce || !word.animate) {
+            word.textContent = next;
+            box.style.width = widthOf(next) + "px";
+            i = (i + 1) % words.length;
+            return;
+          }
+          word
+            .animate(
+              [
+                { transform: "translateY(0)", opacity: 1 },
+                { transform: "translateY(-" + LIFT + ")", opacity: 0 },
+              ],
+              {
+                duration: HALF,
+                easing: "cubic-bezier(0.4, 0, 1, 1)",
+                fill: "forwards",
+              }
+            )
+            .finished.then(function () {
+              word.textContent = next;
+              box.style.width = widthOf(next) + "px";
+              word.animate(
+                [
+                  { transform: "translateY(" + LIFT + ")", opacity: 0 },
+                  { transform: "translateY(0)", opacity: 1 },
+                ],
+                {
+                  duration: HALF,
+                  easing: "cubic-bezier(0, 0, 0.2, 1)",
+                  fill: "forwards",
+                }
+              );
+              i = (i + 1) % words.length;
+            })
+            .catch(function () {});
+        }
+
+        setInterval(swap, HOLD);
+        window.addEventListener("resize", function () {
+          box.style.width = widthOf(words[i]) + "px";
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/site/riffs/index.html
+++ b/site/riffs/index.html
@@ -1,0 +1,354 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · 18 divergent design riffs</title>
+    <style>
+      :root {
+        --cream: #faf6ec;
+        --paper: #fff;
+        --ink: #212e26;
+        --ink-soft: #3f4a43;
+        --ink-faint: #4c554e;
+        --line: rgba(33, 46, 38, 0.14);
+        --sage-d: #33543d;
+        --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        --sans: ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+      }
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body {
+        background: var(--cream);
+        color: var(--ink);
+        font-family: var(--sans);
+        line-height: 1.6;
+        -webkit-font-smoothing: antialiased;
+      }
+      .wrap { max-width: 980px; margin: 0 auto; padding: 56px 24px 80px; }
+      .eyebrow {
+        font-family: var(--mono);
+        font-size: 12px;
+        letter-spacing: 0.06em;
+        color: var(--sage-d);
+        text-transform: uppercase;
+      }
+      h1 {
+        font-size: clamp(28px, 5vw, 40px);
+        letter-spacing: -0.02em;
+        line-height: 1.08;
+        margin: 14px 0 12px;
+        max-width: 16em;
+      }
+      .sub { color: var(--ink-soft); max-width: 44em; font-size: 17px; }
+      .batch {
+        font-family: var(--mono);
+        font-size: 11.5px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        margin: 40px 0 -4px;
+        padding-bottom: 6px;
+        border-bottom: 1px solid var(--line);
+      }
+      .grid {
+        margin-top: 16px;
+        display: grid;
+        gap: 14px;
+        grid-template-columns: repeat(3, 1fr);
+      }
+      @media (max-width: 820px) { .grid { grid-template-columns: repeat(2, 1fr); } }
+      @media (max-width: 540px) { .grid { grid-template-columns: 1fr; } }
+      .card {
+        display: block;
+        background: var(--paper);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 18px 18px 16px;
+        color: inherit;
+        text-decoration: none;
+        transition: border-color 140ms ease, transform 140ms ease;
+      }
+      .card:hover { border-color: var(--sage-d); transform: translateY(-2px); }
+      .num {
+        font-family: var(--mono);
+        font-size: 11.5px;
+        color: var(--ink-faint);
+        letter-spacing: 0.04em;
+      }
+      .card h2 {
+        font-size: 18.5px;
+        letter-spacing: -0.01em;
+        margin: 5px 0 7px;
+      }
+      .card p { color: var(--ink-soft); font-size: 13.5px; line-height: 1.5; }
+      .card .open {
+        display: inline-block;
+        margin-top: 12px;
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--sage-d);
+      }
+      .dark { background: #1b201d; border-color: #2c332e; }
+      .dark .card h2 { color: #f1ece0; }
+      .dark .num { color: #8fa090; }
+      .dark p { color: #c3ccc2; }
+      .dark .open { color: #7fae86; }
+      .dark:hover { border-color: #7fae86; }
+      footer {
+        margin-top: 44px;
+        padding-top: 20px;
+        border-top: 1px solid var(--line);
+        font-size: 13.5px;
+        color: var(--ink-faint);
+      }
+      footer code {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        background: rgba(33, 46, 38, 0.06);
+        padding: 1px 5px;
+        border-radius: 5px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <span class="eyebrow">Setoku · design exploration</span>
+      <h1>Eighteen divergent riffs on the landing page</h1>
+      <p class="sub">
+        Same copy, eighteen aesthetics, each committing hard to a single idea and
+        steering well clear of the usual AI-SaaS look. Built for a Bookface / HN
+        audience that has seen every gradient. Open each in a new tab and
+        compare. Riffs 01 and 10 are refined; 10 has two variations of its own.
+      </p>
+
+      <div class="batch">Batch 1 · the first five</div>
+      <div class="grid">
+        <a class="card" href="1-manpage.html">
+          <span class="num">01 · manual page</span>
+          <h2>setoku(1)</h2>
+          <p>
+            The page as a premium Unix man page. NAME / SYNOPSIS / EXAMPLES, a
+            running header, architecture and revenue chart redrawn in box-drawing
+            characters, demo questions as <code>$ ask</code> examples.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="2-whitepaper.html">
+          <span class="num">02 · preprint</span>
+          <h2>Technical whitepaper</h2>
+          <p>
+            An academic preprint: title block, abstract, numbered sections,
+            Figure 1 / Figure 2, worked examples, footnotes, a serif measure with
+            a drop cap. Confident and un-hyped.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="3-blueprint.html">
+          <span class="num">03 · drawing sheet</span>
+          <h2>Engineering blueprint</h2>
+          <p>
+            One draftsman’s drawing: graph-paper ground, hairline linework, a
+            title block with drawing number, dimensioned architecture, a
+            bill-of-materials parts list, revision notes.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="4-spreadsheet.html">
+          <span class="num">04 · data grid</span>
+          <h2>Spreadsheet-native</h2>
+          <p>
+            The site as a real spreadsheet: formula bar, A–H columns, sheet tabs,
+            a status bar. Demo answers become cells with comment triangles and
+            sticky-note caveats. The product’s native habitat.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="5-swiss-brutalist.html">
+          <span class="num">05 · typographic</span>
+          <h2>Swiss brutalist</h2>
+          <p>
+            International Typographic Style pushed hard: giant grotesk, a strict
+            12-column grid, hairline rules, margin section numbers, one muted
+            accent. A manifesto poster, not a SaaS page.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+      </div>
+
+      <div class="batch">Batch 2 · going wider</div>
+      <div class="grid">
+        <a class="card" href="6-notebook.html">
+          <span class="num">06 · literate computing</span>
+          <h2>Jupyter notebook</h2>
+          <p>
+            Rendered as <code>setoku.ipynb</code>: a kernel status bar, In[n] /
+            Out[n] cells, the quickstart as code cells, and the demo Q&amp;As as
+            <code>ask(…)</code> cells whose outputs are the real numbers + a
+            matplotlib-style chart.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="7-fieldguide.html">
+          <span class="num">07 · specimen plate</span>
+          <h2>Naturalist field guide</h2>
+          <p>
+            A Victorian botanical monograph: aged paper, the clover as a
+            classified specimen (Kingdom → Etymology), numbered plates, engraved
+            captions, connectors as a checklist of collected species.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="8-transit.html">
+          <span class="num">08 · wayfinding</span>
+          <h2>Transit map</h2>
+          <p>
+            Vignelli signage: the architecture becomes a subway map (ride the MCP
+            line into the gateway interchange), enamel-sign section headers, and
+            an arrivals board for the demo figures.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="9-riso.html">
+          <span class="num">09 · zine</span>
+          <h2>Risograph print</h2>
+          <p>
+            A self-published two-ink riso zine: paper grain, halftone dots, a
+            misregistered headline, rubber-stamped labels, hand-circled numbers.
+            The open-source ethos, made tactile.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="10-classicmac.html">
+          <span class="num">10 · 1-bit GUI · polished</span>
+          <h2>Classic Macintosh</h2>
+          <p>
+            A black-and-white System 7 desktop, now with real embedded Chicago /
+            Geneva / Monaco bitmap fonts, window scrollbars + grow box,
+            active/inactive title bars, hover-invert menus, a live clock. Two
+            variations below.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+      </div>
+
+      <div class="batch">Batch 3 · wide + a couple of mono / hacker</div>
+      <div class="grid">
+        <a class="card" href="11-nfo.html">
+          <span class="num">11 · mono / hacker</span>
+          <h2>Scene .nfo</h2>
+          <p>
+            A Phrack-style e-zine text file: a figlet SETOKU masthead, a
+            <code>release.nfo</code> block, <code>.-=[ ]=-.</code> dividers, ASCII
+            architecture and chart. Ink on cream, not neon-on-black.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card dark" href="12-terminal.html">
+          <span class="num">12 · mono / hacker</span>
+          <h2>Dev terminal (TUI)</h2>
+          <p>
+            A tasteful dark tiling-terminal: tmux status bar, boxed panes, the
+            demo as a <code>❯</code> REPL, block-glyph bar chart. Warm charcoal,
+            one muted-sage accent, blinking caret.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="13-japanese.html">
+          <span class="num">13 · wabi-sabi</span>
+          <h2>Japanese editorial</h2>
+          <p>
+            Leans into 設×奥: sumi ink on washi cream, vast negative space,
+            tategaki section markers, a giant ghosted 奥, an inkan seal as the
+            mark, one muted vermilion accent.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="14-chart.html">
+          <span class="num">14 · cartography</span>
+          <h2>Nautical chart</h2>
+          <p>
+            The <em>data lake</em> as an antique Admiralty sea chart: compass
+            rose, rhumb lines, a title cartouche, the architecture as a harbour
+            survey, demo answers as recorded soundings.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="15-ledger.html">
+          <span class="num">15 · bookkeeping</span>
+          <h2>Accounting ledger</h2>
+          <p>
+            A bound double-entry daybook: ruled paper, red margin rule, folio
+            headings, the demo Q&amp;As as line-items ruled off to a
+            double-underlined $192M total. Ties to the finance data.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="16-exhibition.html">
+          <span class="num">16 · curatorial</span>
+          <h2>Museum exhibition</h2>
+          <p>
+            Presented as a curated show (ties to <code>/curate</code>): a title
+            wall, numbered gallery rooms, didactic wall labels with accession
+            numbers, the architecture hung as the principal work.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+      </div>
+
+      <div class="batch">Classic Mac family · two variations on riff 10</div>
+      <div class="grid">
+        <a class="card" href="10-classicmac.html">
+          <span class="num">10 · System 7</span>
+          <h2>Classic Macintosh (polished)</h2>
+          <p>
+            The one you liked, refined: real bitmap fonts, scrollbars, grow box,
+            active/inactive windows, a live clock, a Trash icon, window-shade
+            roll-up. The stark 1-bit original.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="10b-platinum.html">
+          <span class="num">10b · Mac OS 8</span>
+          <h2>Platinum</h2>
+          <p>
+            The refined grayscale-3D cousin: pinstripe title bars, beveled
+            buttons and wells, Platinum scrollbars, an application menu. More
+            legible, more “designed,” one muted-sage accent.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+        <a class="card" href="10c-compactmac.html">
+          <span class="num">10c · 1984</span>
+          <h2>Compact Macintosh</h2>
+          <p>
+            The original, as a showpiece: a molded beige Mac 128K case, its CRT
+            glowing a “Welcome to Setoku” Happy-Mac boot screen, the sections
+            spilling onto the desktop below.
+          </p>
+          <span class="open">open riff ↗</span>
+        </a>
+      </div>
+
+      <div class="batch">Reference</div>
+      <div class="grid">
+        <a class="card" href="../index.html">
+          <span class="num">00 · current</span>
+          <h2>The live site</h2>
+          <p>
+            The existing cream-and-sage page, so you can weigh each riff against
+            what ships today.
+          </p>
+          <span class="open">open current ↗</span>
+        </a>
+      </div>
+
+      <footer>
+        Preview locally with <code>bun x serve site</code> (or any static
+        server), then visit <code>/riffs/</code>. Every riff keeps all the copy
+        and follows the house rules: curly apostrophes, no em-dashes, no
+        accent-on-black (riff 12 is the one dark treatment, kept to a muted
+        charcoal with a single desaturated accent).
+      </footer>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Eighteen design riffs of the landing page under `site/riffs/` (gallery at [/riffs/](https://setoku.com/riffs/)), with two promoted to easter-egg URLs: [/man](https://setoku.com/man) and [/mac](https://setoku.com/mac), linked from the homepage footer as **Man** / **Mac**.

Homepage changes:
- hero rotator flips the full phrase (*company data / family data / personal data*) so the underline hugs it; trailing period dropped
- footer: added Man + Mac links, removed the Apache-2.0 chip (still in the hero eyebrow)

Notes:
- Mac riffs embed free Chicago/Geneva/Monaco clone fonts (system.css project, base64 woff2) — re-verify licenses before promoting beyond easter eggs
- `deploy:site` ships only `index.html` + `assets`; riffs and the `/man` + `/mac` copies go to the box via separate rsync/cp (already deployed)