### PR TITLE
site: invite connector PRs instead of issues

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1150,13 +1150,14 @@ SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
           </div>
           <p class="note">
             No connector for your source yet? The included setup skills give
-            your coding agent the patterns to wire one up itself. See
+            your coding agent the patterns to wire one up itself. If you make
+            a cool one, send a
             <a
               href="https://github.com/Hedgy-Labs/setoku"
               target="_blank"
               rel="noopener"
-              >the repo</a
-            >, or open an issue.
+              >pull request</a
+            >!
           </p>
         </div>
       </section>

--- a/site/riffs/1-manpage.html
+++ b/site/riffs/1-manpage.html
@@ -592,13 +592,14 @@ SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</pre>
           </div>
           <p>
             No connector for your source yet? The included setup skills give your
-            coding agent the patterns to wire one up itself. See
+            coding agent the patterns to wire one up itself. If you make a cool
+            one, send a
             <a
               href="https://github.com/Hedgy-Labs/setoku"
               target="_blank"
               rel="noopener"
-              >the repo</a
-            >, or open an issue.
+              >pull request</a
+            >!
           </p>
         </div>
       </section>

--- a/site/riffs/10-classicmac.html
+++ b/site/riffs/10-classicmac.html
@@ -1293,10 +1293,11 @@ SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</code></pre>
             </ul>
             <p style="margin-top: 14px">
               No connector for your source yet? The included setup skills give your
-              coding agent the patterns to wire one up itself. See
+              coding agent the patterns to wire one up itself. If you make a cool
+              one, send a
               <a href="https://github.com/Hedgy-Labs/setoku" target="_blank" rel="noopener"
-                >the repo</a
-              >, or open an issue.
+                >pull request</a
+              >!
             </p>
           </div>
           <div class="sb" aria-hidden="true">


### PR DESCRIPTION
The connectors note on the homepage, /man, and /mac now ends "If you make a cool one, send a pull request!" (was "See the repo, or open an issue."). Already deployed to all three surfaces.