### PR TITLE
site/man: title the running header "User Manual"

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -745,8 +745,10 @@
           skills for hooking up your data. It does two things: it gives your AI
           a read-only way to query your data, and it remembers what that data
           means (the metric definitions, the gotchas), getting better the more
-          you use it. The MCP works with whatever AI you already have, and no
-          model runs on the server, so no added inference cost.
+          you use it. Ask for a dashboard and publish it to a link your whole
+          team can view, on live data. The MCP works with whatever AI you
+          already have, and no model runs on the server, so no added inference
+          cost.
         </p>
         <div class="actions">
           <a

--- a/site/riffs/1-manpage.html
+++ b/site/riffs/1-manpage.html
@@ -326,6 +326,7 @@
       <span
         ><svg class="mark"><use href="#clover" /></svg>SETOKU(7)</span
       >
+      <span class="mid">User Manual</span>
       <span>SETOKU(7)</span>
     </div>
 
@@ -369,8 +370,10 @@
             skills for hooking up your data. It does two things: it gives your
             AI a read-only way to query your data, and it remembers what that
             data means (the metric definitions, the gotchas), getting better the
-            more you use it. The MCP works with whatever AI you already have, and
-            no model runs on the server, so no added inference cost.
+            more you use it. Ask for a dashboard and publish it to a link your
+            whole team can view, on live data. The MCP works with whatever AI
+            you already have, and no model runs on the server, so no added
+            inference cost.
           </p>
           <p class="dim">
             Open source &middot; MCP server &middot; Apache-2.0 &middot;

--- a/site/riffs/10-classicmac.html
+++ b/site/riffs/10-classicmac.html
@@ -906,8 +906,10 @@
               skills for hooking up your data. It does two things: it gives your
               AI a read-only way to query your data, and it remembers what that
               data means (the metric definitions, the gotchas), getting better the
-              more you use it. The MCP works with whatever AI you already have, and
-              no model runs on the server, so no added inference cost.
+              more you use it. Ask for a dashboard and publish it to a link your
+              whole team can view, on live data. The MCP works with whatever AI
+              you already have, and no model runs on the server, so no added
+              inference cost.
             </p>
             <div class="actions">
               <a


### PR DESCRIPTION
The /man running header center now reads "User Manual". Already deployed.