### PR TITLE
pg-mirror: skip verifiably-unchanged tables; denyColumns excludes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -351,6 +351,10 @@ services:
       # config` valid for non-mirror deploys (matches the other connectors).
       SETOKU_DATABASE_URL: ${SETOKU_DATABASE_URL:-}
       SETOKU_MIRROR_INTERVAL_MS: ${SETOKU_MIRROR_INTERVAL_MS:-900000}
+      # Per-box column excludes (comma-separated "schema.table.column" globs,
+      # merged with the baked config's denyColumns) — real column names are
+      # tenant data (I3), so they live in the box's .env, not the repo.
+      SETOKU_MIRROR_DENY_COLUMNS: ${SETOKU_MIRROR_DENY_COLUMNS:-}
       CLICKHOUSE_URL: http://clickhouse:8123
       CLICKHOUSE_USER: ${CLICKHOUSE_USER:-setoku}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?set in .env}

--- a/ingest/pg-mirror/README.md
+++ b/ingest/pg-mirror/README.md
@@ -13,6 +13,36 @@ dropped from prod or from the allowlist is **pruned** from the mirror on the
 next pass, so revoking a grant removes the lake copy too. Incremental cursors
 are a later optimization for append-only tables only if size demands.
 
+## Skip-unchanged: egress scales with change, not size × cadence
+
+Hosted Postgres meters egress, and a naive full reload bills the whole DB every
+interval (the 2026-07 Supabase overage: ~15 tables' worth of quiet data
+restreamed 96×/day). So each pass first reads the table's cumulative write
+counters from `pg_stat_user_tables` (`n_tup_ins/upd/del`, plus `n_live_tup` to
+catch TRUNCATE, which moves no counter) and combines them with a hash of the
+mirrored shape (columns/types/PK — so DDL-only drift and `denyColumns` edits
+still reload). If that signature equals the one the current mirror was built
+from (`setoku.pg_mirror_state`), the table is **verifiably unchanged**: the
+pass records a status `unchanged` run and streams nothing. Freshness surfaces
+treat `unchanged` like `ok` — the mirror provably equals the source at check
+time (`_mirrored_at` inside the rows still marks the last actual restream).
+Counters are read *before* a reload streams, so a change racing the copy can
+only cause one extra reload next pass, never a skipped stale mirror; a missing
+stats row disables the skip for that table (reload rather than guess).
+
+## denyColumns: leave the fat columns out
+
+`.setoku/config.json` `"denyColumns": ["public.scrapes.raw_html", …]` excludes
+columns from the mirror with the same glob semantics as the table lists (`*`
+within a dot-segment). This is an egress/size control, **not** a security
+boundary — grants still govern access (I9), and an excluded column stays
+readable at the source via `run_query force_postgres: true`. Because every
+reload is full, un-excluding is one config edit: the next pass repopulates the
+column completely. Excluding a column with an unmappable type also rescues its
+table. Real column names are tenant data (I3), so on a template-baked box they
+go in `SETOKU_MIRROR_DENY_COLUMNS` (comma-separated, in the box's `.env`,
+which deploys don't overwrite) — the env list merges into the config's.
+
 ## How a run works (per table, staged swap)
 
 1. DDL is derived from the pg catalog through an **explicit type map**
@@ -71,8 +101,9 @@ docker compose up -d --build pg-mirror
 ```
 
 Env: `SETOKU_DATABASE_URL` (required, the read-only role),
-`SETOKU_MIRROR_INTERVAL_MS` (default 900000 = 15 min), `CLICKHOUSE_*` (like
-every connector).
+`SETOKU_MIRROR_INTERVAL_MS` (default 900000 = 15 min),
+`SETOKU_MIRROR_DENY_COLUMNS` (extra per-box `denyColumns`, comma-separated),
+`CLICKHOUSE_*` (like every connector).
 
 The allow/deny list comes from the baked `.setoku/config.json` (same
 `deploy/project-template` bake as the gateway image) and **fails closed**: a

--- a/ingest/pg-mirror/mirror.test.ts
+++ b/ingest/pg-mirror/mirror.test.ts
@@ -19,7 +19,10 @@ import path from "node:path";
 import {
   tableMatches,
   isTableAllowed,
+  isColumnDenied,
   loadMirrorConfig,
+  schemaSignature,
+  fetchChangeCounters,
   mapColumn,
   numericTypmod,
   bizTableName,
@@ -48,10 +51,17 @@ describe("allowlist semantics (parity with gateway lib/config.ts)", () => {
     expect(tableMatches("public.*", "public.a.b")).toBe(false);
   });
   it("deny wins over allow", () => {
-    const cfg = { allowTables: ["public.*"], denyTables: ["public.internal_notes"] };
+    const cfg = { allowTables: ["public.*"], denyTables: ["public.internal_notes"], denyColumns: [] };
     expect(isTableAllowed(cfg, "public", "orders")).toBe(true);
     expect(isTableAllowed(cfg, "public", "internal_notes")).toBe(false);
     expect(isTableAllowed(cfg, "ticketing", "seat_txn")).toBe(false);
+  });
+  it("denyColumns matches schema.table.column with the same glob semantics", () => {
+    const cfg = { allowTables: ["public.*"], denyTables: [], denyColumns: ["public.orders.blob", "public.*.raw_html"] };
+    expect(isColumnDenied(cfg, "public", "orders", "blob")).toBe(true);
+    expect(isColumnDenied(cfg, "public", "orders", "note")).toBe(false);
+    expect(isColumnDenied(cfg, "public", "scrapes", "raw_html")).toBe(true);
+    expect(isColumnDenied(cfg, "crm", "scrapes", "raw_html")).toBe(false); // * stays within a segment
   });
 });
 
@@ -74,7 +84,20 @@ describe("loadMirrorConfig fails closed (I2 — never mirror with an unknown lis
     fs.writeFileSync(path.join(dir, ".setoku", "config.json"), "{not json");
     expect(() => loadMirrorConfig(dir)).toThrow(/refusing to mirror/);
     fs.writeFileSync(path.join(dir, ".setoku", "config.json"), JSON.stringify({ denyTables: ["public.x"] }));
-    expect(loadMirrorConfig(dir)).toEqual({ allowTables: ["public.*"], denyTables: ["public.x"] });
+    expect(loadMirrorConfig(dir)).toEqual({ allowTables: ["public.*"], denyTables: ["public.x"], denyColumns: [] });
+  });
+  it("SETOKU_MIRROR_DENY_COLUMNS merges into (never replaces) the config's denyColumns", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "setoku-mirror-cfg-"));
+    fs.mkdirSync(path.join(dir, ".setoku"));
+    fs.writeFileSync(path.join(dir, ".setoku", "config.json"), JSON.stringify({ denyColumns: ["public.a.b"] }));
+    const prev = process.env.SETOKU_MIRROR_DENY_COLUMNS;
+    process.env.SETOKU_MIRROR_DENY_COLUMNS = " public.c.d ,,public.e.f ";
+    try {
+      expect(loadMirrorConfig(dir).denyColumns).toEqual(["public.a.b", "public.c.d", "public.e.f"]);
+    } finally {
+      if (prev === undefined) delete process.env.SETOKU_MIRROR_DENY_COLUMNS;
+      else process.env.SETOKU_MIRROR_DENY_COLUMNS = prev;
+    }
   });
 });
 
@@ -225,6 +248,7 @@ class FakeClickHouse {
   queries: string[] = [];
   heartbeats: Record<string, unknown>[] = [];
   runs: Record<string, unknown>[] = [];
+  state: Record<string, unknown>[] = []; // pg_mirror_state, insert order
   failInserts = false;
 
   constructor() {
@@ -256,6 +280,7 @@ class FakeClickHouse {
       const rows = body.split("\n").filter(Boolean).map((l) => JSON.parse(l));
       if (key.endsWith(".ingest_heartbeats")) this.heartbeats.push(...rows);
       else if (key.endsWith(".pg_mirror_runs")) this.runs.push(...rows);
+      else if (key.endsWith(".pg_mirror_state")) this.state.push(...rows);
       else {
         if (this.failInserts) return new Response("boom", { status: 500 });
         if (!this.tables.has(key)) return new Response(`no such table ${key}`, { status: 404 });
@@ -293,6 +318,12 @@ class FakeClickHouse {
       const rows = this.tables.get(this.key(m[1]));
       if (!rows) return new Response("missing table", { status: 404 });
       return ok(JSON.stringify({ data: [{ c: String(rows.length) }] }));
+    }
+    if ((m = q.match(/^SELECT target, signature FROM \S+\.pg_mirror_state FINAL/i))) {
+      // ReplacingMergeTree(checked_at) ORDER BY target — last write per target wins
+      const latest = new Map<string, Record<string, unknown>>();
+      for (const r of this.state) latest.set(String(r.target), r);
+      return ok(JSON.stringify({ data: [...latest.values()].map((r) => ({ target: r.target, signature: r.signature })) }));
     }
     if ((m = q.match(/^SELECT name FROM system\.tables WHERE database = '([^']*)'/i))) {
       const db = m[1];
@@ -353,7 +384,17 @@ const SCHEMA_STATEMENTS = [
   `INSERT INTO public.internal_notes VALUES (1, 'do not mirror')`,
 ];
 
-const CFG = { allowTables: ["public.*", "ticketing.*"], denyTables: ["public.internal_notes"] };
+const CFG = { allowTables: ["public.*", "ticketing.*"], denyTables: ["public.internal_notes"], denyColumns: [] as string[] };
+
+/** pg flushes pg_stat counters asynchronously (on backend idle/exit) — poll
+ *  until a write becomes visible so the unchanged-skip tests can't flake. */
+async function waitForCounterChange(pgc: unknown, schema: string, name: string, before: string | null): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if ((await fetchChangeCounters(pgc as never, schema, name)) !== before) return;
+    await Bun.sleep(50);
+  }
+  throw new Error(`pg_stat counters for ${schema}.${name} never moved`);
+}
 
 async function pgAdmin(statements: string[], database: string): Promise<void> {
   const sql = new SQL(pgOptions(`postgresql:///${database}?host=${encodeURIComponent(PG_HOST)}`) as never);
@@ -431,13 +472,24 @@ describe("mirror integration (real Postgres → FakeClickHouse)", () => {
     expect(okRun.source_table).toBe("ticketing.seat_txn");
   });
 
-  it("second run swaps atomically via EXCHANGE and picks up new rows", async () => {
+  it("second run reloads only what changed (EXCHANGE swap), skips the rest as unchanged", async () => {
+    const before = await fetchChangeCounters(pg as never, "public", "no_pk");
     await pgAdmin([`INSERT INTO public.no_pk VALUES ('c')`], DB_NAME);
+    await waitForCounterChange(pg, "public", "no_pk", before);
     fake.queries.length = 0;
+    fake.runs.length = 0;
     const r = await runOnce(pg as never, ch, CFG);
-    expect(r.ok).toBe(3);
+    // no_pk changed → restreamed via EXCHANGE; orders and seat_txn are
+    // verifiably unchanged → no restream (the egress point of the skip)
+    expect(r.ok).toBe(1);
+    expect(r.unchanged).toBe(2);
     expect(fake.tables.get("biz.no_pk")!.length).toBe(3);
     expect(fake.queries.some((q) => q.startsWith("EXCHANGE TABLES `biz`.`no_pk` AND `biz`.`no_pk__staging`"))).toBe(true);
+    expect(fake.queries.some((q) => q.includes("`biz`.`orders__staging`"))).toBe(false);
+    expect(fake.queries.some((q) => q.includes("`biz`.`ticketing_seat_txn__staging`"))).toBe(false);
+    // unchanged checks still land in pg_mirror_runs — freshness advances
+    const unchangedRuns = fake.runs.filter((r2) => r2.status === "unchanged").map((r2) => r2.target_table).sort();
+    expect(unchangedRuns).toEqual(["orders", "ticketing_seat_txn"]);
     // staging never survives a run
     expect([...fake.tables.keys()].filter((k) => k.includes("__staging"))).toEqual([]);
   });
@@ -452,21 +504,60 @@ describe("mirror integration (real Postgres → FakeClickHouse)", () => {
 
   it("zero-discovery guard: an empty discovery never prunes the mirror", async () => {
     const before = [...fake.tables.keys()].sort();
-    const r = await runOnce(pg as never, ch, { allowTables: ["nosuch.*"], denyTables: [] });
-    expect(r).toEqual({ ok: 0, failed: 0, rows: 0 });
+    const r = await runOnce(pg as never, ch, { allowTables: ["nosuch.*"], denyTables: [], denyColumns: [] });
+    expect(r).toEqual({ ok: 0, failed: 0, rows: 0, unchanged: 0 });
     expect([...fake.tables.keys()].sort()).toEqual(before); // nothing dropped
   });
 
-  it("a failed load keeps the previous good mirror and records the error", async () => {
+  it("a failed load keeps the previous good mirror, records the error, and retries (no skip on a stale signature)", async () => {
+    // touch orders so the unchanged-skip can't bypass the failing load
+    const counters = await fetchChangeCounters(pg as never, "public", "orders");
+    // id 2: the e2e below re-mirrors this fixture and asserts id 1's original note
+    await pgAdmin([`UPDATE public.orders SET note = 'touched' WHERE id = 2`], DB_NAME);
+    await waitForCounterChange(pg, "public", "orders", counters);
     const before = fake.tables.get("biz.orders")!;
     fake.failInserts = true;
     fake.runs.length = 0;
-    const r = await runOnce(pg as never, ch, { allowTables: ["public.orders"], denyTables: [] });
+    const cfg = { allowTables: ["public.orders"], denyTables: [], denyColumns: [] };
+    const r = await runOnce(pg as never, ch, cfg);
     fake.failInserts = false;
     expect(r.failed).toBe(1);
     expect(fake.tables.get("biz.orders")).toBe(before); // untouched
     expect(fake.runs.length).toBe(1);
     expect(fake.runs[0].status).toBe("error");
+    // the failure must NOT have stored the new signature — the next pass
+    // reloads instead of skipping on a mirror that never got the change
+    const retry = await runOnce(pg as never, ch, cfg);
+    expect(retry.ok).toBe(1);
+    expect(retry.unchanged).toBe(0);
+    expect(fake.tables.get("biz.orders")!.find((o) => String(o.id) === "2")!.note).toBe("touched");
+  });
+
+  it("denyColumns drops the column from the mirror and can rescue an unmappable table", async () => {
+    await pgAdmin([`INSERT INTO public.has_interval VALUES (1, interval '1 day')`], DB_NAME);
+    const cfg = {
+      allowTables: ["public.orders", "public.has_interval"],
+      denyTables: [],
+      denyColumns: ["public.orders.blob", "public.has_interval.span"],
+    };
+    const r = await runOnce(pg as never, ch, cfg);
+    // orders reloads (its shape changed vs the stored signature) without blob;
+    // has_interval becomes mirrorable once its interval column is excluded
+    expect(r.ok).toBe(2);
+    expect(r.failed).toBe(0);
+    const o1 = fake.tables.get("biz.orders")!.find((o) => String(o.id) === "1")!;
+    expect("blob" in o1).toBe(false);
+    expect(fake.tables.get("biz.orders")!.find((o) => String(o.id) === "2")!.note).toBe("touched");
+    expect(fake.tables.get("biz.has_interval")!.length).toBe(1);
+    expect("span" in fake.tables.get("biz.has_interval")![0]).toBe(false);
+    // a table with EVERY column denied fails loudly instead of mirroring nothing
+    const { failed } = await discoverTables(pg as never, { ...cfg, denyColumns: ["public.has_interval.*"] });
+    expect(failed.find((f) => f.name === "has_interval")!.error).toContain("every column is deny-listed");
+    // same source, same config → the denyColumns shape is IN the signature, so
+    // an immediate re-run skips both
+    const again = await runOnce(pg as never, ch, cfg);
+    expect(again.unchanged).toBe(2);
+    expect(again.ok).toBe(0);
   });
 });
 
@@ -564,14 +655,24 @@ describe.skipIf(!CH_URL)("mirror e2e (real ClickHouse)", () => {
     const key = await adminRows(`SELECT sorting_key FROM system.tables WHERE database = '${rch.mirrorDb}' AND name = 'ticketing_seat_txn'`);
     expect(key[0].sorting_key).toBe("acct_id, seq");
 
-    // second run: EXCHANGE path, still consistent, no staging leftovers
+    // second run: the changed table takes the EXCHANGE path, the quiet ones
+    // are verified unchanged and skipped — no staging leftovers either way
+    const before = await fetchChangeCounters(rpg as never, "public", "no_pk");
+    await rpg.unsafe(`INSERT INTO public.no_pk VALUES ('d')`);
+    await waitForCounterChange(rpg, "public", "no_pk", before);
     const r2 = await runOnce(rpg as never, rch, CFG);
-    expect(r2.ok).toBe(3);
+    expect(r2.ok).toBe(1);
+    expect(r2.unchanged).toBe(2);
     const tables = await adminRows(`SELECT name FROM system.tables WHERE database = '${rch.mirrorDb}' ORDER BY name`);
     expect(tables.map((t) => t.name)).toEqual(["no_pk", "orders", "ticketing_seat_txn"]);
 
-    // runs + heartbeat metadata landed in the meta db
+    // runs + heartbeat + state metadata landed in the meta db; unchanged
+    // checks advance freshness the way the gateway reads it (ok OR unchanged)
     const runs = await adminRows(`SELECT count() AS c FROM ${rch.db}.pg_mirror_runs WHERE status = 'ok'`);
-    expect(Number(runs[0].c)).toBeGreaterThanOrEqual(6);
+    expect(Number(runs[0].c)).toBeGreaterThanOrEqual(4);
+    const unchangedRuns = await adminRows(`SELECT count() AS c FROM ${rch.db}.pg_mirror_runs WHERE status = 'unchanged'`);
+    expect(Number(unchangedRuns[0].c)).toBe(2);
+    const stateRows = await adminRows(`SELECT target, signature FROM ${rch.db}.pg_mirror_state FINAL ORDER BY target`);
+    expect(stateRows.map((s) => s.target)).toEqual(["no_pk", "orders", "ticketing_seat_txn"]);
   });
 });

--- a/ingest/pg-mirror/mirror.ts
+++ b/ingest/pg-mirror/mirror.ts
@@ -8,18 +8,27 @@
  *
  *   1. derive DDL from the pg catalog (explicit type map — unmapped types fail
  *      that table LOUDLY, they never guess),
- *   2. create `biz.<table>__staging` and SELECT-stream rows in through a
+ *   2. skip the table if it is verifiably UNCHANGED since its last successful
+ *      reload — the pg_stat_user_tables write counters plus the mirrored shape
+ *      haven't moved (see `fetchChangeCounters`/`schemaSignature`). The check
+ *      costs one tiny stats read instead of restreaming the table, which is
+ *      what keeps prod egress (metered on hosted Postgres — the Supabase
+ *      overage of 2026-07) proportional to CHANGE, not to size × cadence.
+ *      A skip is recorded as status "unchanged" in `setoku.pg_mirror_runs`
+ *      (the mirror provably equals the source, so freshness advances),
+ *   3. create `biz.<table>__staging` and SELECT-stream rows in through a
  *      cursor (bounded memory) using the SAME read-only role the gateway
  *      queries with — the allow/deny list and the role's grants are inherited,
  *      so a table denied to run_query never leaves prod (I1/I2 unchanged),
- *   3. verify the staged row count, then atomically EXCHANGE/RENAME into
+ *   4. verify the staged row count, then atomically EXCHANGE/RENAME into
  *      place — readers never see a half-loaded table,
- *   4. record the reload in `setoku.pg_mirror_runs` (freshness + failure
+ *   5. record the reload in `setoku.pg_mirror_runs` (freshness + failure
  *      legibility for /healthz, /admin, and the app frame's "as of" stamp)
  *      and beat `ingest_heartbeats` like every other connector.
  *
  * Full reload every run = no CDC, no replica-identity footguns; schema drift
- * is a non-event (the next run picks up the new shape), and a table dropped
+ * is a non-event (the next run picks up the new shape — a DDL-only change
+ * defeats the unchanged-skip via the schema signature), and a table dropped
  * from prod or from the allowlist is pruned from the mirror on the next run.
  * Mirrored tables are re-derivable from prod, so `biz` is deliberately a
  * SEPARATE ClickHouse database: excluded from clickhouse-backup
@@ -33,7 +42,10 @@
  *   CLICKHOUSE_PASSWORD        default ""
  *   CLICKHOUSE_DB              metadata db (heartbeats, runs), default setoku
  *   SETOKU_MIRROR_INTERVAL_MS  default 900000 (15 min between full reloads)
- *   SETOKU_PROJECT_DIR         default /project — reads .setoku/config.json for allow/denyTables
+ *   SETOKU_MIRROR_DENY_COLUMNS extra denyColumns patterns, comma-separated — the
+ *                              per-box channel for column names that must not
+ *                              land in the repo-baked config template (I3)
+ *   SETOKU_PROJECT_DIR         default /project — reads .setoku/config.json for allow/denyTables/denyColumns
  *   SETOKU_PG_SSL_STRICT       "1" = verify TLS certs (default: encrypt, don't verify — matches gateway lib/db.ts)
  */
 import fs from "node:fs";
@@ -45,6 +57,13 @@ import { SQL } from "bun";
 export interface MirrorConfig {
   allowTables: string[];
   denyTables: string[];
+  /** "schema.table.column" globs whose columns are left out of the mirror.
+   *  An egress/size control, NOT a security boundary: access is enforced by
+   *  the engines' grants (I9), and an excluded column stays readable at the
+   *  source via `run_query force_postgres`. Because the mirror is a full
+   *  reload, un-excluding a column is one config edit — the next pass
+   *  repopulates it completely. */
+  denyColumns: string[];
 }
 
 /** Same allow/deny source of truth as the gateway: .setoku/config.json in the
@@ -56,15 +75,23 @@ export interface MirrorConfig {
  *  (`docker compose up -d --build server pg-mirror`) or the lists drift. */
 export function loadMirrorConfig(projectDir: string): MirrorConfig {
   const file = path.join(projectDir, ".setoku", "config.json");
-  let raw: { allowTables?: string[]; denyTables?: string[] };
+  let raw: { allowTables?: string[]; denyTables?: string[]; denyColumns?: string[] };
   try {
     raw = JSON.parse(fs.readFileSync(file, "utf8"));
   } catch (e) {
     throw new Error(`cannot read ${file} (${(e as Error).message}) — refusing to mirror with an unknown allow/deny list`);
   }
+  // SETOKU_MIRROR_DENY_COLUMNS merges IN (never replaces): the baked template is
+  // generic, but real column names are tenant data that can't live in the repo
+  // (I3) — the box's .env (rsync-excluded, survives deploys) carries them.
+  const envDeny = (process.env.SETOKU_MIRROR_DENY_COLUMNS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
   return {
     allowTables: raw.allowTables ?? ["public.*"],
     denyTables: raw.denyTables ?? [],
+    denyColumns: [...(raw.denyColumns ?? []), ...envDeny],
   };
 }
 
@@ -86,6 +113,13 @@ export function isTableAllowed(cfg: MirrorConfig, schema: string, table: string)
   const qualified = `${schema}.${table}`;
   if (cfg.denyTables.some((p) => tableMatches(p, qualified))) return false;
   return cfg.allowTables.some((p) => tableMatches(p, qualified));
+}
+
+/** Column-level exclusion: "schema.table.column" with the same glob semantics
+ *  (* stays within one dot-segment). See MirrorConfig.denyColumns. */
+export function isColumnDenied(cfg: MirrorConfig, schema: string, table: string, column: string): boolean {
+  const qualified = `${schema}.${table}.${column}`;
+  return cfg.denyColumns.some((p) => tableMatches(p, qualified));
 }
 
 /* --------------------------- type mapping --------------------------- */
@@ -381,6 +415,12 @@ export async function ensureMirrorObjects(ch: ChOptions): Promise<void> {
      ENGINE = MergeTree ORDER BY (finished_at, target_table)
      TTL toDateTime(finished_at) + INTERVAL 90 DAY`,
   );
+  await chCommand(
+    ch,
+    `CREATE TABLE IF NOT EXISTS ${chIdent(ch.db)}.pg_mirror_state
+     (target LowCardinality(String), source String, signature String, checked_at DateTime64(3))
+     ENGINE = ReplacingMergeTree(checked_at) ORDER BY target`,
+  );
 }
 
 /* ---------------------------- discovery ----------------------------- */
@@ -451,9 +491,17 @@ export async function discoverTables(
   const tables: MirrorTable[] = [];
   const failed: { schema: string; name: string; error: string }[] = [];
   for (const t of wanted) {
-    const raw = colsByTable.get(key(t.schema, t.name)) ?? [];
-    if (!raw.length) {
+    const rawAll = colsByTable.get(key(t.schema, t.name)) ?? [];
+    if (!rawAll.length) {
       failed.push({ schema: t.schema, name: t.name, error: "no columns visible in pg_attribute" });
+      continue;
+    }
+    // Deny-listed columns drop out BEFORE type mapping — excluding a column
+    // with an unmappable type (interval, custom composites) is also the
+    // lightest way to make its table mirrorable.
+    const raw = rawAll.filter((c) => !isColumnDenied(cfg, t.schema, t.name, c.column_name));
+    if (!raw.length) {
+      failed.push({ schema: t.schema, name: t.name, error: "every column is deny-listed (denyColumns) — re-allow at least one or deny the table" });
       continue;
     }
     // "__staging" is the swap workspace — a source table mapping onto it would
@@ -493,6 +541,47 @@ export async function discoverTables(
   return { tables: unique, failed };
 }
 
+/* ------------------------ unchanged detection ------------------------ */
+
+/** Shape signature of the mirrored copy — column names/types + the ORDER BY
+ *  key. Folded into the change signature so DDL-only drift (ADD COLUMN, a
+ *  denyColumns edit) still reloads a table whose tuple counters are quiet.
+ *  Bun.hash (Wyhash) is stable per Bun version; a Bun upgrade at worst costs
+ *  one spurious full reload. */
+export function schemaSignature(t: MirrorTable): string {
+  return Bun.hash(JSON.stringify([t.columns.map((c) => [c.name, c.chType]), t.pk])).toString(36);
+}
+
+const pgString = (s: string): string => "'" + s.replace(/'/g, "''") + "'";
+
+/** Cumulative write counters for one table from pg_stat_user_tables, or null
+ *  when pg has no stats row — the skip is then disabled and the table reloads
+ *  (never guess). n_live_tup is included because TRUNCATE moves no
+ *  ins/upd/del counter; its analyze-driven estimate drift can only cause a
+ *  spurious reload, never a missed change (counters are monotonic, and a
+ *  stats reset changes the string too). Stats views aren't privilege-gated,
+ *  so the read-only role sees them. */
+export async function fetchChangeCounters(pg: Pg, schema: string, name: string): Promise<string | null> {
+  const rows: { sig: string }[] = await pg.unsafe(
+    `SELECT n_tup_ins::text || ':' || n_tup_upd::text || ':' || n_tup_del::text || ':' || n_live_tup::text AS sig
+     FROM pg_stat_user_tables WHERE schemaname = ${pgString(schema)} AND relname = ${pgString(name)}`,
+  );
+  return rows[0]?.sig ?? null;
+}
+
+/** Last stored signature per biz target (what the CURRENT mirror was built
+ *  from). ReplacingMergeTree keyed on target; FINAL collapses to the latest. */
+export async function loadMirrorState(ch: ChOptions): Promise<Map<string, string>> {
+  const rows = await chSelect(ch, `SELECT target, signature FROM ${chIdent(ch.db)}.pg_mirror_state FINAL`);
+  return new Map(rows.map((r) => [String(r.target), String(r.signature)]));
+}
+
+async function saveMirrorState(ch: ChOptions, target: string, source: string, signature: string): Promise<void> {
+  const params = new URLSearchParams({ query: `INSERT INTO ${chIdent(ch.db)}.pg_mirror_state FORMAT JSONEachRow` });
+  const line = JSON.stringify({ target, source, signature, checked_at: runStamp(new Date()) });
+  await chFetch(ch, params, line + "\n", 10_000);
+}
+
 /* ----------------------------- reload ------------------------------- */
 
 const FETCH_ROWS = 10_000; // cursor batch out of pg
@@ -502,7 +591,9 @@ export interface TableResult {
   target: string;
   source: string;
   rows: number;
-  status: "ok" | "error";
+  /** "unchanged" = the source verifiably didn't move since the last reload —
+   *  no restream, but the mirror is known current as of this check. */
+  status: "ok" | "error" | "unchanged";
   error: string;
 }
 
@@ -583,13 +674,14 @@ async function recordRun(ch: ChOptions, startedAt: Date, r: TableResult): Promis
   await chFetch(ch, params, line + "\n", 10_000);
 }
 
-/** One full mirror pass: discover → reload each table → prune stale mirrors. */
+/** One full mirror pass: discover → reload each changed table (skip the
+ *  verifiably unchanged) → prune stale mirrors. */
 export async function runOnce(
   pg: Pg,
   ch: ChOptions,
   cfg: MirrorConfig,
   setState?: (s: string) => void,
-): Promise<{ ok: number; failed: number; rows: number }> {
+): Promise<{ ok: number; failed: number; rows: number; unchanged: number }> {
   const { tables, failed: discoveryFailed } = await discoverTables(pg, cfg);
   const existing = new Set<string>(
     (await chSelect(ch, `SELECT name FROM system.tables WHERE database = ${sqlString(ch.mirrorDb)}`)).map((r) => String(r.name)),
@@ -604,8 +696,16 @@ export async function runOnce(
       console.error(
         `pg-mirror: discovery returned no allowlisted tables — refusing to prune ${existing.size} existing mirror table(s) (revoked grants or misconfig? fix the source, the next pass reconciles)`,
       );
-    return { ok: 0, failed: 0, rows: 0 };
+    return { ok: 0, failed: 0, rows: 0, unchanged: 0 };
   }
+
+  // Signatures the CURRENT mirror tables were built from. A state row whose
+  // biz table is gone is ignored (the skip below also requires the table to
+  // exist), so pruned tables need no state cleanup.
+  const state = await loadMirrorState(ch).catch((e) => {
+    console.error(`pg-mirror: could not load mirror state (skip disabled this pass): ${e}`);
+    return new Map<string, string>();
+  });
 
   const results: TableResult[] = [];
   for (const f of discoveryFailed) {
@@ -622,9 +722,33 @@ export async function runOnce(
     const source = `${t.schema}.${t.name}`;
     setState?.(`reloading ${target} (${n}/${tables.length})`);
     const startedAt = new Date();
+
+    // Counters are read BEFORE the reload streams, so the stored signature can
+    // only UNDERSTATE what the mirror holds — a change racing the copy makes
+    // the next pass reload once more, never skip a stale mirror.
+    const counters = await fetchChangeCounters(pg, t.schema, t.name).catch(() => null);
+    const signature = `${schemaSignature(t)}/${counters ?? "no-stats"}`;
+
+    if (counters !== null && existing.has(target) && state.get(target) === signature) {
+      const r: TableResult = { target, source, rows: 0, status: "unchanged", error: "" };
+      results.push(r);
+      // Re-stamp checked_at: freshness surfaces read "verified equal to the
+      // source at this time" from pg_mirror_runs/pg_mirror_state.
+      await saveMirrorState(ch, target, source, signature).catch((e) =>
+        console.error(`pg-mirror: could not re-stamp state for ${target}: ${e}`),
+      );
+      await recordRun(ch, startedAt, r).catch((e) => console.error(`pg-mirror: could not record run for ${target}: ${e}`));
+      continue;
+    }
+
     try {
       const rows = await mirrorTable(pg, ch, t, existing);
       results.push({ target, source, rows, status: "ok", error: "" });
+      // Only after a successful swap — a failed reload keeps the old signature
+      // so the table retries next pass instead of skipping on a stale mirror.
+      await saveMirrorState(ch, target, source, signature).catch((e) =>
+        console.error(`pg-mirror: could not save state for ${target}: ${e}`),
+      );
     } catch (e) {
       // Best-effort staging cleanup; the previous good copy (if any) stays live.
       await chCommand(ch, `DROP TABLE IF EXISTS ${chIdent(ch.mirrorDb)}.${chIdent(`${target}__staging`)} SYNC`).catch(() => {});
@@ -651,8 +775,9 @@ export async function runOnce(
   }
 
   const ok = results.filter((r) => r.status === "ok");
+  const unchanged = results.filter((r) => r.status === "unchanged").length;
   const rows = ok.reduce((a, r) => a + r.rows, 0);
-  return { ok: ok.length, failed: results.length - ok.length, rows };
+  return { ok: ok.length, failed: results.length - ok.length - unchanged, rows, unchanged };
 }
 
 /* ------------------------------- main -------------------------------- */
@@ -711,7 +836,8 @@ async function main(): Promise<void> {
   const cfg = loadMirrorConfig(PROJECT_DIR); // fail-fast at startup (fails closed)
   console.error(
     `pg-mirror: full reload every ${INTERVAL}ms → ${ch.url} db ${ch.mirrorDb} ` +
-      `(allow ${JSON.stringify(cfg.allowTables)}, deny ${JSON.stringify(cfg.denyTables)})`,
+      `(allow ${JSON.stringify(cfg.allowTables)}, deny ${JSON.stringify(cfg.denyTables)}, ` +
+      `denyColumns ${JSON.stringify(cfg.denyColumns)})`,
   );
 
   await ensureMirrorObjects(ch);
@@ -737,8 +863,8 @@ async function main(): Promise<void> {
           state = s;
         });
         state = r.failed
-          ? `partial: ${r.ok} table(s) ok, ${r.failed} failed — see setoku.pg_mirror_runs`
-          : `ok: ${r.ok} table(s), ${r.rows} row(s) in ${Math.round((Date.now() - t0) / 1000)}s`;
+          ? `partial: ${r.ok} reloaded, ${r.unchanged} unchanged, ${r.failed} failed — see setoku.pg_mirror_runs`
+          : `ok: ${r.ok} reloaded, ${r.unchanged} unchanged, ${r.rows} row(s) in ${Math.round((Date.now() - t0) / 1000)}s`;
         console.error(`pg-mirror: ${state}`);
       } finally {
         await pg.end().catch(() => {});

--- a/ingest/schemas/060_pg_mirror.sql
+++ b/ingest/schemas/060_pg_mirror.sql
@@ -21,10 +21,24 @@ CREATE TABLE IF NOT EXISTS setoku.pg_mirror_runs
     finished_at  DateTime64(3)           COMMENT 'reload end (UTC) — the mirror''s "data as of"',
     target_table LowCardinality(String)  COMMENT 'mirror table name in biz (e.g. ticketing_seat_txn)',
     source_table String                  COMMENT 'source pg table (e.g. ticketing.seat_txn)',
-    rows         UInt64                  COMMENT 'rows loaded (0 on error)',
-    status       LowCardinality(String)  COMMENT 'ok | error',
-    error        String                  COMMENT 'failure detail (empty on ok)'
+    rows         UInt64                  COMMENT 'rows loaded (0 on error/unchanged)',
+    status       LowCardinality(String)  COMMENT 'ok | unchanged | error',
+    error        String                  COMMENT 'failure detail (empty on ok/unchanged)'
 )
 ENGINE = MergeTree
 ORDER BY (finished_at, target_table)
 TTL toDateTime(finished_at) + INTERVAL 90 DAY;
+
+-- Per-target change signature the CURRENT mirror copy was built from (pg_stat
+-- write counters + shape hash) — lets a pass skip restreaming a table whose
+-- source verifiably didn't move. Latest row per target wins; stale rows for
+-- pruned targets are ignored by the reader. Self-healed on startup too.
+CREATE TABLE IF NOT EXISTS setoku.pg_mirror_state
+(
+    target     LowCardinality(String)  COMMENT 'mirror table name in biz',
+    source     String                  COMMENT 'source pg table',
+    signature  String                  COMMENT 'schema-hash/ins:upd:del:live at last reload or verified-unchanged check',
+    checked_at DateTime64(3)           COMMENT 'when the signature was last confirmed (UTC)'
+)
+ENGINE = ReplacingMergeTree(checked_at)
+ORDER BY target;

--- a/plugin/gateway/lib/mirror.ts
+++ b/plugin/gateway/lib/mirror.ts
@@ -53,12 +53,14 @@ async function refresh(lakeUrl: string): Promise<MirroredTable[]> {
   lastRefreshErred = false;
   try {
     // Only tables that still exist in biz count — pg_mirror_runs keeps history
-    // for pruned tables, which must not resurrect steering hints.
+    // for pruned tables, which must not resurrect steering hints. 'unchanged'
+    // runs are verified-fresh checks (the source provably didn't move since
+    // the last reload, so no restream) — they advance "as of" like a reload.
     const res = await runLakeQuery(
       lakeUrl,
       `SELECT r.target_table AS target, anyLast(r.source_table) AS source, toString(max(r.finished_at)) AS as_of
        FROM setoku.pg_mirror_runs AS r
-       WHERE r.status = 'ok' AND r.target_table IN (SELECT name FROM system.tables WHERE database = 'biz')
+       WHERE r.status IN ('ok', 'unchanged') AND r.target_table IN (SELECT name FROM system.tables WHERE database = 'biz')
        GROUP BY r.target_table`,
       { rowCap: 500, statementTimeoutMs: 5_000 },
     );


### PR DESCRIPTION
## Why

The mirror's full reload restreamed every allowlisted table from prod each interval, so hosted-Postgres egress scaled with **size × cadence**. On the pilot that meant ~1.4 GiB/pass × 96 passes/day ≈ **80 GB/day** of Supabase pooler egress against a 250 GB/month plan — the July overage. Measured against ClickHouse's `query_log`, most of those bytes were (a) tables that hadn't changed between passes and (b) two fat columns no query had ever read.

## What

Two changes, both keeping the full-reload model (no CDC, no replication slots, no incremental cursors):

**Skip-unchanged.** Each pass reads the table's cumulative write counters from `pg_stat_user_tables` (`n_tup_ins/upd/del`, plus `n_live_tup` to catch TRUNCATE, which moves no counter) and combines them with a hash of the mirrored shape (columns/types/PK). If the signature equals the one the current mirror was built from (new `setoku.pg_mirror_state`, ReplacingMergeTree), the table streams nothing and the pass records a status **`unchanged`** run. The gateway freshness query counts `unchanged` like `ok` — the mirror provably equals the source at check time.

Safety properties:
- counters are read **before** the copy streams, so a write racing the reload costs one extra reload next pass, never a skipped stale mirror;
- a failed reload keeps the old signature (retry, not skip);
- a missing stats row disables the skip for that table (reload rather than guess);
- DDL-only drift (ADD COLUMN moves no tuple counter) still reloads via the schema hash.

**denyColumns.** `"schema.table.column"` globs (same segment-scoped `*` semantics as the table lists) excluded from the mirror — a config key plus a `SETOKU_MIRROR_DENY_COLUMNS` env merge, because real column names are tenant data that can't live in the repo-baked template (I3) while the box's `.env` survives rsync deploys. This is an egress/size control, **not** a security boundary: engine grants still govern access (I9), and excluded columns stay readable at source via `run_query force_postgres`. Full reload makes it reversible — un-exclude and the next pass repopulates. Excluding a column with an unmappable type also rescues its table.

## Measured result (pilot box, deployed)

| | before | after |
|---|---|---|
| full pass | 1.38 GiB uncompressed | 611 MiB |
| pass over a quiet DB | 1.38 GiB, ~4 min | **0 bytes, 2 s** ("0 reloaded, 55 unchanged") |
| daily egress | ~80 GB | ~2 GB expected (2 h cadence) |

## Tests

- units: denyColumns glob matching, env merge, config parsing
- integration (real pg + FakeClickHouse): changed-table-only reloads, `unchanged` run records, failed-reload-then-retry (no stale skip), column excludes incl. the all-columns-denied loud failure and signature-busting on a denyColumns edit
- e2e (real ClickHouse, `SETOKU_E2E_CH_URL`-gated): ReplacingMergeTree/FINAL state round-trip, skip + EXCHANGE on the real engine — run locally against a throwaway CH 25.3, passes
- full fast suite: 377 pass / 0 fail