### PR TITLE
demo: follow the gateway image rename (deploy:demo was restarting a stale image)

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -107,8 +107,9 @@ coverage caveats) — so `find_context` has something real to return.
 
 ## Boot / re-seed on the box
 
-The box already runs production Setoku and has the `setoku-server` image built, so the demo
-reuses it. From `/opt/setoku/demo`:
+The box already runs production Setoku and has the gateway image
+(`ghcr.io/hedgy-labs/setoku-gateway:latest`) built or pulled, so the demo reuses it.
+From `/opt/setoku/demo`:
 
 ```bash
 ./boot.sh            # first run generates .env.bulldogs (tokens + PG password), seeds, starts the gateway

--- a/demo/docker-compose.demo.yml
+++ b/demo/docker-compose.demo.yml
@@ -3,8 +3,9 @@
 # Setoku DEMO stack — a self-contained, throwaway Setoku instance pointed at the
 # synthetic "Bonita Bulldogs" sports dataset. Runs ALONGSIDE a production Setoku
 # stack on the same box without touching it: its own project name, network,
-# volumes, and Postgres. The gateway reuses the already-built `setoku-server`
-# image (override with DEMO_IMAGE).
+# volumes, and Postgres. The gateway reuses the already-built gateway image
+# (`ghcr.io/hedgy-labs/setoku-gateway:latest` — the same tag the production
+# compose builds/pulls; override with DEMO_IMAGE).
 #
 # Local / standalone:
 #   docker compose -p setoku-demo -f docker-compose.demo.yml --env-file .env.demo up -d
@@ -102,7 +103,7 @@ services:
   # and the sports knowledge seed. A separate /data volume keeps its knowledge
   # store isolated from production.
   demo-server:
-    image: ${DEMO_IMAGE:-setoku-server}
+    image: ${DEMO_IMAGE:-ghcr.io/hedgy-labs/setoku-gateway:latest}
     restart: unless-stopped
     environment:
       SETOKU_PROJECT_DIR: /demo-project

--- a/scripts/deploy-demo.sh
+++ b/scripts/deploy-demo.sh
@@ -3,7 +3,7 @@
 #
 # Deploy the Setoku DEMO (demo.setoku.com — the Bonita Bulldogs instance) to a box.
 # The demo runs ALONGSIDE production as its own compose project and reuses the
-# `setoku-server` image. This script: rsyncs the code, rebuilds that image WITHOUT
+# gateway image. This script: rsyncs the code, rebuilds that image WITHOUT
 # touching the running production gateway, then restarts the demo gateway on the
 # fresh image via boot.sh (reseed OFF by default — a code deploy keeps the data).
 #
@@ -44,7 +44,7 @@ rsync -az \
   plugin deploy demo ingest docker-compose.yml \
   "${SSH}:${DIR}/"
 
-echo "→ rebuild the setoku-server image (does NOT restart production)"
+echo "→ rebuild the gateway image (does NOT restart production)"
 ssh "$SSH" "cd ${DIR} && docker compose build server"
 
 echo "→ restart the demo gateway on the fresh image (${DEMO_ENV})"


### PR DESCRIPTION
## Problem
Since PR #53 renamed the gateway image to `ghcr.io/hedgy-labs/setoku-gateway:latest`, `bun run deploy:demo` has been a silent no-op for the demo gateway: it rebuilt the ghcr image, but `demo/docker-compose.demo.yml` still defaulted `DEMO_IMAGE` to the old `setoku-server` tag, so boot.sh kept restarting the demo on a frozen July 4 image. demo.setoku.com never picked up the sources redesign (#79/#82/#83), the team page (#77), etc. `/health` couldn't catch it because the version has been 0.21.0 since before the rename.

## Fix
- `demo/docker-compose.demo.yml`: default `DEMO_IMAGE` to `ghcr.io/hedgy-labs/setoku-gateway:latest`, matching the root compose (still overridable).
- Update stale `setoku-server` mentions in `scripts/deploy-demo.sh` comments and `demo/README.md`.

## Verified
Deployed to the box: `setoku-bulldogs-demo-server-1` now runs `ghcr.io/hedgy-labs/setoku-gateway:latest` (today's build), health OK, new admin design live at demo.setoku.com. The orphaned `setoku-server:latest`/`:embed` images were removed from the box.