### PR TITLE
Caddy: route the site root to the gateway (completes the /admin→/ move)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -87,8 +87,13 @@
 		reverse_proxy server:8787
 	}
 
+	# The web console (React SPA) is served at the site ROOT by the gateway, so
+	# the gateway is the default backend: it renders the SPA shell for its known
+	# routes (/, /apps/<id>, /knowledge, /sources, /team, /audit) and returns 404
+	# for anything else. The specific handles above (ingest/mcp/i/admin/p/health)
+	# still win by matcher specificity.
 	handle {
-		respond "setoku" 404
+		reverse_proxy server:8787
 	}
 }
 

--- a/demo/caddy-bulldogs.snippet
+++ b/demo/caddy-bulldogs.snippet
@@ -38,7 +38,10 @@ demo.setoku.com, demo.51-81-222-176.sslip.io, stags.setoku.com, stags.51-81-222-
 	handle /health* {
 		reverse_proxy setoku-bulldogs-demo-server-1:8787
 	}
+	# The web console is served at the site root by the gateway (see the main
+	# Caddyfile) — route everything not matched above to it; it serves the SPA
+	# shell for its known routes (/, /apps/<id>, …) and 404s the rest.
 	handle {
-		respond "setoku demo (bulldogs)" 404
+		reverse_proxy setoku-bulldogs-demo-server-1:8787
 	}
 }


### PR DESCRIPTION
Follow-up to #85. That PR moved the web console to the site root in the gateway, but Caddy only reverse-proxies specific prefixes (`/mcp`, `/i`, `/admin`, `/p`, `/health`) and 404s everything else at the edge — so `/`, `/apps/<id>`, `/knowledge`, `/sources`, `/team`, `/audit` never reached the gateway. Net effect after #85 alone: `/admin` 302s to `/`, which the edge 404s.

**Fix:** the bare catch-all `handle {}` now `reverse_proxy`s to the gateway instead of `respond 404`, making the gateway the default backend. It serves the SPA shell for its known routes and 404s the rest (unchanged behavior for genuinely-unknown paths). The specific ingest/mcp/p/health handles still win by matcher specificity. Same one-line change in the demo (bulldogs) site snippet.

**Already deployed** to all three boxes with a Caddy force-recreate (the bind-mounts are inode-pinned, so `caddy reload` is a no-op):
- hedgy.setoku.com — `/`→200 shell, `/admin`→`/`, unknown→404
- demo.setoku.com — `/`→200 shell, `/admin`→`/`
- setoku.campsh.com — `/`→200 shell, `/health`→200, `/admin`→`/`

https://claude.ai/code/session_01JmfC5fmG61wDRD4iwpEf56