### PR TITLE
ClickHouse: disable profilers so system.trace_log can't fill the disk

### DIFF
--- a/demo/docker-compose.demo.yml
+++ b/demo/docker-compose.demo.yml
@@ -59,6 +59,7 @@ services:
       - demo_ch:/var/lib/clickhouse
       - ../deploy/clickhouse/small.xml:/etc/clickhouse-server/config.d/zz-setoku-preset.xml:ro
       - ../deploy/clickhouse/system-logs.xml:/etc/clickhouse-server/config.d/zz-setoku-system-logs.xml:ro
+      - ../deploy/clickhouse/trace-off.xml:/etc/clickhouse-server/users.d/zz-setoku-trace-off.xml:ro
       - ../deploy/clickhouse/lake-users.xml:/etc/clickhouse-server/users.d/zz-setoku-lake.xml:ro
       - ../ingest/schemas:/docker-entrypoint-initdb.d:ro
     ulimits:

--- a/deploy/clickhouse/system-logs.xml
+++ b/deploy/clickhouse/system-logs.xml
@@ -9,7 +9,14 @@
 
      14 days is plenty for post-incident debugging. On a fresh box the tables
      grow from empty, so the TTL applies incrementally (no expensive rewrite).
-     Mounted at /etc/clickhouse-server/config.d/ ; applies on (re)start. -->
+     Mounted at /etc/clickhouse-server/config.d/ ; applies on (re)start.
+
+     NOTE: a time-based TTL alone is NOT enough for trace_log — its default
+     accrual rate can fill the disk to 100% (at which point ClickHouse can't
+     even run the TTL) long before the 14-day horizon. trace_off.xml disables
+     the profilers that feed it, so trace_log stays empty; this TTL is the
+     backstop for the telemetry tables that still grow (query_log, text_log,
+     metric_log, …). -->
 <clickhouse>
     <query_log><ttl>event_date + INTERVAL 14 DAY DELETE</ttl></query_log>
     <query_thread_log><ttl>event_date + INTERVAL 14 DAY DELETE</ttl></query_thread_log>

--- a/deploy/clickhouse/trace-off.xml
+++ b/deploy/clickhouse/trace-off.xml
@@ -1,0 +1,33 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Setoku ClickHouse: disable the query/memory profilers on the default profile.
+
+     ClickHouse's profilers write sampled rows into system.trace_log. The memory
+     profiler is the dangerous one: memory_profiler_step defaults to 4 MiB, so
+     every query logs a Memory + MemoryPeak trace for each 4 MiB it allocates. A
+     single heavy scan or a pg-mirror full-reload allocates GBs, i.e. thousands
+     of traces per query — on the campsh box this grew system.trace_log to
+     ~1.3 BILLION rows / 22 GiB and filled a 38 GiB disk to 100%, at which point
+     ClickHouse can't even TRUNCATE (it needs to reserve space first). The
+     time-based TTL in system-logs.xml never saved it: the disk overflows long
+     before the 14-day horizon.
+
+     These are PROFILE settings, not server settings, which is why the config.d
+     TTL file couldn't reach them — they belong in a users.d default profile.
+     Setoku runs no server-side inference (I8) and nobody flamegraphs these
+     boxes, so profiler sampling is pure downside here. Turn it all off; the
+     table then stays empty and trace_log stops being a disk-fill risk.
+     TTL in system-logs.xml still caps the other telemetry tables (query_log,
+     text_log, metric_log, …) that grow from normal activity.
+     Mounted at /etc/clickhouse-server/users.d/ ; applies on (re)start. -->
+<clickhouse>
+    <profiles>
+        <default>
+            <!-- 0 disables each sampler -->
+            <memory_profiler_step>0</memory_profiler_step>
+            <memory_profiler_sample_probability>0</memory_profiler_sample_probability>
+            <query_profiler_real_time_period_ns>0</query_profiler_real_time_period_ns>
+            <query_profiler_cpu_time_period_ns>0</query_profiler_cpu_time_period_ns>
+            <trace_profile_events>0</trace_profile_events>
+        </default>
+    </profiles>
+</clickhouse>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,6 +156,9 @@ services:
       # rolling TTL on ClickHouse's own telemetry tables (system.*_log) so they
       # can't outgrow the lake — see deploy/clickhouse/system-logs.xml
       - ./deploy/clickhouse/system-logs.xml:/etc/clickhouse-server/config.d/zz-setoku-system-logs.xml:ro
+      # disable the query/memory profilers (default profile) so system.trace_log
+      # stops growing at the source — see deploy/clickhouse/trace-off.xml
+      - ./deploy/clickhouse/trace-off.xml:/etc/clickhouse-server/users.d/zz-setoku-trace-off.xml:ro
       # the gateway's read-only lake user (grants + settings constraints)
       - ./deploy/clickhouse/lake-users.xml:/etc/clickhouse-server/users.d/zz-setoku-lake.xml:ro
       - ./ingest/schemas:/docker-entrypoint-initdb.d:ro


### PR DESCRIPTION
## What

The campsh (Monarch dogfood) box hit **100% disk** and `run_query` started failing with `No space left on device`; the Monarch freshness alert surfaced it.

The culprit was ClickHouse's own **`system.trace_log` at ~1.3B rows / 22 GiB** on a 38 GiB disk, not lake data (all Monarch tables total ~1.6 MiB).

## Root cause

ClickHouse's memory profiler logs a `Memory`+`MemoryPeak` trace for every `memory_profiler_step` (4 MiB default) a query allocates. Heavy scans and the pg-mirror full-reload allocate GBs, so `trace_log` grows without bound. The 14-day TTL in `system-logs.xml` never helped: the disk overflows long before the horizon, and at 100% ClickHouse can't even `TRUNCATE` (it must reserve space first).

## Fix

`deploy/clickhouse/trace-off.xml` zeroes the query/memory profilers on the `<default>` profile. These are **profile** settings (users.d), which is why the existing `config.d` TTL file couldn't reach them. `trace_log` then stays empty; the TTL remains the backstop for the telemetry tables that still grow from normal activity (`query_log`, `text_log`, `metric_log`, …). Mounted in both the main and demo compose files so all boxes and the bulldogs demo inherit it.

## Rollout (already applied live)

Config applied and stale telemetry reclaimed on all three ClickHouse instances:

| instance | disk before | disk after | trace_log |
|---|---|---|---|
| campsh `setoku` (38 GiB) | **100%** (0 B free) | **27%** (28 GiB free) | 22 GiB → 0, no longer growing |
| hedgy `setoku` (96 GiB) | 25% (before truncate) | **20%** (78 GiB free) | ~400 MiB → truncated |
| hedgy `setoku-bulldogs` demo (shares hedgy disk) | — | included above | ~400 MiB → truncated |

Verified `memory_profiler_step=0` and trace_log no longer growing on each.

## Fallout from the same disk-full (resolved)

When the disk hit 100%, **Vector** got stuck mid-shutdown — it couldn't flush its ClickHouse sinks (`NOT_ENOUGH_SPACE`), so it hung with its HTTP source (`:8080`) down, showing "Up but unhealthy". The Monarch poller's `postLake → http://vector:8080` calls then failed hourly with Bun's `Unable to connect` (which looked like a Monarch outage but was the local sink). Restarting Vector (now that there's space) brought it back healthy; the poller's next tick forwarded 281 transactions and ingest is fresh again (`monarch_transactions` last_ingest 16:05). No code change needed — just the operational restart — but it underscores why the trace_log fix matters: a full disk cascades into the ingest pipeline.
