### PR TITLE
Self-heal: autoheal service restarts unhealthy containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,26 @@ x-logging: &default-logging
     max-file: "3"
 
 services:
+  # Self-heal: restart any container Docker marks unhealthy — e.g. a Vector
+  # wedged mid-shutdown by a transient disk-full, which otherwise stays "up but
+  # unhealthy" and silently stops ingest until a human restarts it. Watches the
+  # Docker health status of EVERY container with a HEALTHCHECK (label=all) and
+  # restarts the sick one in place. Needs the Docker socket (root-equivalent on
+  # the host); acceptable on a single-tenant self-hosted box (I6) — it publishes
+  # no ports and never faces the internet (I1). Off-box /healthz alerting still
+  # pages, so a restart loop (e.g. a genuinely full disk) is visible, not masked.
+  autoheal:
+    image: willfarrell/autoheal@sha256:d1392205b4463b4f2adeaf0983c3acd9eb57784c58904e0d40f62a385b74e608
+    restart: always
+    logging: *default-logging
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: all # every container that declares a healthcheck
+      AUTOHEAL_INTERVAL: 15 # seconds between health scans
+      AUTOHEAL_START_PERIOD: 120 # grace after boot before the first restart
+      CURL_TIMEOUT: 30
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
   caddy:
     image: caddy:2-alpine@sha256:77c07d5ebfa5be9fd6c820d2094ae662c9e7eeb9bf98346b7f639900263ee2a2
     restart: unless-stopped


### PR DESCRIPTION
Closes #90. Follow-up to #89 (the disk-full incident).

## Why

When the disk filled (#89), **Vector** got wedged mid-shutdown and sat **"up but unhealthy" for ~14h**, silently stalling ingest. Nothing acted on the unhealthy state; it only surfaced via a downstream freshness alert.

## What

Adds an `autoheal` service (willfarrell/autoheal, pinned by digest) that restarts any container Docker marks unhealthy (`AUTOHEAL_CONTAINER_LABEL=all`). Vector would have recovered in ~1 min instead of 14 h. One autoheal per host covers every compose project on it (it talks to the Docker daemon, not a single project), so hedgy's covers the bulldogs demo too.

**Architectural note (docker.sock):** autoheal mounts `/var/run/docker.sock` (root-equivalent on the host). Acceptable under I6 (single-tenant, self-hosted) — no published ports, never internet-facing (I1), tiny widely-used image pinned by digest. Rationale recorded in #90.

## Verified live

Applied to both boxes; confirmed healing with a throwaway failing-healthcheck container — autoheal detected and restarted it:
```
Container /autoheal-test found to be unhealthy - Restarting container now with 10s timeout
```

## Paired operator-side alerting (not in this PR)

An off-box Mac `launchd` job (`com.setoku.healthz`, every 5 min) now polls each box's public `/healthz` and pages Slack on 503 / disk ≥75% — off-box so it also catches a fully dead box (which on-box `alert.sh` can't). Auto-heal fixes sick containers; the pager catches what heal can't (a genuinely full disk in a restart loop). Kept operator-side, mirroring the existing `com.setoku.hedgy-curate` launchd pattern.