### PR TITLE
Deploys don't drop requests or trip the health alerter

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -5,6 +5,21 @@
 # (each gets its own Let's Encrypt cert) — used to keep an old domain alive
 # while migrating to a new one. Empty by default (single-domain deploys).
 
+# Gateway upstream (server:8787), reused by every route below via `import gateway`.
+# lb_try_duration makes Caddy ride out the brief window when the server container
+# is being recreated on deploy (docker compose up --build server stops the old
+# container, then the new one boots + passes /health). A request that lands in
+# that gap is re-dialled every lb_try_interval until the new container is
+# listening, instead of returning a 502 — so deploys don't drop requests or trip
+# the /healthz alerter (deploy/monitor/alert.sh). A dial failure means nothing
+# reached the server, so retrying is safe even for POST/MCP requests.
+(gateway) {
+	reverse_proxy server:8787 {
+		lb_try_duration 30s
+		lb_try_interval 250ms
+	}
+}
+
 {$SETOKU_DOMAIN:localhost} {$SETOKU_ALT_DOMAIN} {
 	encode gzip
 
@@ -69,22 +84,22 @@
 	# MCP gateway (header bearer auth, or token-in-URL-path for the consumer
 	# custom-connector dialog), the one-line installer, and health.
 	handle /mcp* {
-		reverse_proxy server:8787
+		import gateway
 	}
 	handle /i/* {
-		reverse_proxy server:8787
+		import gateway
 	}
 	# web approval surface — the human accept/reject path (Phase 5.5)
 	handle /admin* {
-		reverse_proxy server:8787
+		import gateway
 	}
 	# public reports — credential-free /p/<id> links (the server serves ONLY
 	# reports an admin promoted to public; everything else 404s).
 	handle /p/* {
-		reverse_proxy server:8787
+		import gateway
 	}
 	handle /health* {
-		reverse_proxy server:8787
+		import gateway
 	}
 
 	# The web console (React SPA) is served at the site ROOT by the gateway, so
@@ -93,7 +108,7 @@
 	# for anything else. The specific handles above (ingest/mcp/i/admin/p/health)
 	# still win by matcher specificity.
 	handle {
-		reverse_proxy server:8787
+		import gateway
 	}
 }
 

--- a/deploy/monitor/alert.sh
+++ b/deploy/monitor/alert.sh
@@ -6,6 +6,13 @@
 # disk crosses 75% (disk-full is the #1 predictable incident; /healthz itself
 # only degrades at 90%). Alerts on state CHANGE (plus recovery), not every run.
 #
+# A single failed probe does NOT page: DOWN must be confirmed across
+# SETOKU_ALERT_CONFIRM consecutive runs (default 2 = ~10 min) before it fires.
+# This rides out the brief /healthz outage during a deploy (docker compose
+# up --build restarts the server for ~1 min) without paging, while a genuinely
+# dead box still alerts within a couple of probes. Disk alerts are monotonic
+# and never flap, so they fire immediately.
+#
 # This catches sick-box states. A DEAD box can't report itself — also register
 # https://<domain>/healthz with an external uptime pinger (healthchecks.io,
 # UptimeRobot, a GitHub Actions cron — anything off-box).
@@ -16,6 +23,7 @@ set -a; source .env; set +a
 URL="${SETOKU_HEALTHZ_URL:-https://${SETOKU_DOMAIN:-localhost}/healthz}"
 STATE_FILE="/tmp/setoku-alert.state"
 DISK_PCT_ALERT=75
+CONFIRM="${SETOKU_ALERT_CONFIRM:-2}"  # consecutive DOWN probes before paging
 
 resp="$(curl -skm 10 "$URL" || true)"
 read -r status detail <<< "$(printf '%s' "$resp" | python3 -c '
@@ -32,8 +40,20 @@ if pct is not None and pct >= '"$DISK_PCT_ALERT"':
     print(f"DISK data volume {pct}% full"); raise SystemExit
 print("OK -")')"
 
-prev="$(cat "$STATE_FILE" 2>/dev/null || echo OK)"
-echo "$status" > "$STATE_FILE"
+# State file: "<last-alerted-status> <down-streak>". The streak counts
+# consecutive DOWN probes so a lone deploy-window blip never reaches CONFIRM.
+read -r prev streak <<< "$(cat "$STATE_FILE" 2>/dev/null || echo "OK 0")"
+: "${prev:=OK}"; : "${streak:=0}"
+
+if [[ "$status" == DOWN ]]; then
+  streak=$((streak + 1))
+  # Not yet confirmed: hold the last alerted status, no transition, no page.
+  (( streak < CONFIRM )) && status="$prev"
+else
+  streak=0
+fi
+
+echo "$status $streak" > "$STATE_FILE"
 [[ "$status" == "$prev" ]] && exit 0  # only alert on transitions
 
 msg="setoku ${status}: ${detail} (${URL})"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,6 +29,8 @@ DIR="${SETOKU_DEPLOY_DIR:-/opt/setoku}"
 DOMAIN="${SETOKU_DEPLOY_DOMAIN:-}"
 
 echo "→ rsync code to ${SSH}:${DIR}  (dirs WITHOUT trailing slashes — a slash flattens them into ${DIR}/)"
+# Hash the box's Caddyfile BEFORE rsync so we can tell if this deploy changed it.
+caddy_before="$(ssh "$SSH" "sha256sum ${DIR}/Caddyfile 2>/dev/null | cut -d' ' -f1" || true)"
 rsync -az \
   --exclude='.env' --exclude='.git' --exclude='node_modules' --exclude='seed-mercury-knowledge.ts' \
   plugin deploy ingest docker-compose.yml Caddyfile \
@@ -36,6 +38,18 @@ rsync -az \
 
 echo "→ rebuild + restart the gateway"
 ssh "$SSH" "cd ${DIR} && docker compose up -d --build server"
+
+# The Caddyfile is an inode-pinned bind mount (docker-compose.yml), so rsyncing a
+# new file (temp + rename = new inode) does NOT reach the running caddy container
+# and a reload reads the stale content — caddy must be force-recreated to pick it
+# up. Do that ONLY when the file actually changed, since recreating caddy is a
+# brief (~1–2s) edge blip we don't want on every deploy. --no-deps so the healthy
+# server container is left untouched.
+caddy_after="$(ssh "$SSH" "sha256sum ${DIR}/Caddyfile | cut -d' ' -f1")"
+if [ "$caddy_before" != "$caddy_after" ]; then
+  echo "→ Caddyfile changed — force-recreate caddy (edge, brief blip)"
+  ssh "$SSH" "cd ${DIR} && docker compose up -d --force-recreate --no-deps caddy"
+fi
 
 if [ -n "$DOMAIN" ]; then
   echo "→ verify (give it a moment)…"


### PR DESCRIPTION
The box-health Slack alerts (added on this branch) paged a false `DOWN`/`recovered` pair on every deploy. Root cause: `docker compose up -d --build server` recreates the `server` container, and the ~15–30s gap where Caddy proxies to a dead upstream produced `unreachable or non-JSON` on `/healthz`, which the alerter treated as a state change and paged immediately.

Three fixes:

- **`Caddyfile`** — route every gateway path through a `(gateway)` snippet with `lb_try_duration 30s` / `lb_try_interval 250ms`. A request landing in the container-recreate gap is re-dialled until the new server listens, instead of returning a 502. Safe on dial failure (nothing reached the server), incl. POST/MCP. This is the primary fix — deploys become invisible to real callers *and* the healthz pinger.

- **`deploy/monitor/alert.sh`** — require `SETOKU_ALERT_CONFIRM` (default **2**) consecutive `DOWN` probes before paging, so a single failed probe never fires. Disk alerts stay immediate. State file gains a down-streak field (backward-compatible read). Covers the gaps Caddy retry can't: caddy's own recreate blip on Caddyfile-changing deploys, boots slower than 30s, and probe timeouts under `--build` load on the 4GB boxes.

- **`scripts/deploy.sh`** — force-recreate caddy (`--no-deps`, leaving `server` untouched) **only when the Caddyfile changed**. The Caddyfile is an inode-pinned bind mount, so rsync alone can't reach the running container and a reload reads stale content; recreating every deploy would add a needless ~1–2s edge blip.

## Deployed + verified

Already rsynced to both boxes (they deploy by rsync, not git pull):

| Box | Health | confirmation | Caddy retry |
|---|---|---|---|
| hedgy.setoku.com | ok, v0.21.0 | present | present |
| setoku.campsh.com | ok, v0.21.0 | present | present |

Fast suite: 441 pass, 0 fail.

https://claude.ai/code/session_01LAJAe4p4oNvugPW3BaRV15