### PR TITLE
run_query: actionable, schema-aware error hints + audit-log friction miner

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eval:value": "bun demo/eval/value.ts",
     "eval:retrieval": "bun demo/eval/retrieval.ts",
     "eval:embed": "bun demo/eval/embed-retrieval.ts",
+    "eval:friction": "bun plugin/gateway/friction-cli.ts",
     "knowledge-lint": "bun plugin/gateway/knowledge-lint.ts",
     "setup:hooks": "git config core.hooksPath scripts/hooks",
     "typecheck": "tsc --noEmit",

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -104,6 +104,12 @@ export interface GatewayDeps {
   derivedSynonyms?: DerivedSynonyms | null;
 }
 
+/** Lake table → its source (for family resolution). Built once at module load,
+ *  not per-request: scopedSchema's deny filter runs on the get_schema and the
+ *  run_query unknown-column error paths, so a per-table linear scan of
+ *  LAKE_SOURCES would be O(tables × sources) on a hot path. */
+const LAKE_SOURCE_BY_TABLE = new Map(LAKE_SOURCES.map((s) => [s.table, s.source]));
+
 export function buildServer({
   projectDir,
   store,
@@ -239,7 +245,7 @@ async function scopedSchema(): Promise<{
     t.database === "biz"
       ? !denied.has(BUSINESS_FAMILY.slug)
       : !denied.has(
-          familySlug(familyOf(LAKE_SOURCES.find((s) => s.table === t.table)?.source ?? t.table)),
+          familySlug(familyOf(LAKE_SOURCE_BY_TABLE.get(t.table) ?? t.table)),
         ),
   );
   return { schema, lakeUrl: lakeRes.url, roles };

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -21,6 +21,7 @@ import type { EmbedIndex } from "./lib/embed-index";
 import type { DerivedSynonyms } from "./lib/derived-synonyms";
 import { KnowledgeStore, mintShareId, type AppPanel, type DocType } from "./lib/store";
 import { MAX_PANELS, MIN_REFRESH_SECONDS, MAX_REFRESH_SECONDS, DEFAULT_REFRESH_SECONDS, MAX_RENDER_ROW_BYTES, RENDER_FETCH_CEILING, PG_RETIRED_ERROR, runPanel, trimRowsToBytes, compilePanel, isFullDoc } from "./lib/apps";
+import { queryErrorHint, extractTableRefs, extractUnknownColumn, matchReferencedTables, renderColumnHint } from "./lib/queryhint";
 import { resolveParams, paramsVariant, type AppParam } from "./lib/params";
 import { lintAppTemplate } from "./lib/app-runtime";
 import { extractSql } from "./lib/lint";
@@ -189,6 +190,83 @@ const NO_KNOWLEDGE_HINT =
   "(test accounts not excluded, etc.); say so. Build context with /setoku:generate " +
   "or report_correction; both work on this (analyst) connector and land as pending " +
   "for a human to approve. (upsert_context commits directly but needs a curator connector.)";
+
+interface SchemaTbl {
+  database: string;
+  table: string;
+  columns: { name: string; type: string }[];
+}
+
+/** The queryable schema scoped to THIS session — the single source get_schema
+ *  and the run_query unknown-column augment both read, so the augment can never
+ *  reveal a table or column get_schema wouldn't. Roles ride the system.columns
+ *  read (the engine hides denied families) and the denied-family belt filter
+ *  re-applies in code (parity with list_sources / get_schema). */
+async function scopedSchema(): Promise<{
+  schema: SchemaTbl[];
+  lakeUrl: string;
+  roles: string[] | null;
+}> {
+  const config = requireConfig();
+  const lakeRes = resolveLakeUrl(projectDir, config);
+  if (!lakeRes.ok) throw new Error(lakeRes.error);
+  // Metadata is identifiers + types, never row content, but a big schema can
+  // exceed a small row cap and silently drop trailing tables' columns — cap high.
+  const qopts = { rowCap: 200_000, statementTimeoutMs: config.statementTimeoutMs };
+  const roles = lakeRoles();
+  const res = await runLakeQuery(
+    lakeRes.url,
+    "SELECT database, table, name, type FROM system.columns " +
+      "WHERE database IN ('biz','setoku') " +
+      "AND (database, table) NOT IN (('setoku','ingest_heartbeats'), ('setoku','pg_mirror_runs')) " +
+      "ORDER BY database, table, position",
+    qopts,
+    {},
+    roles,
+  );
+  const byTable = new Map<string, SchemaTbl>();
+  for (const r of res.rows as Array<Record<string, unknown>>) {
+    const key = `${r.database}.${r.table}`;
+    let t = byTable.get(key);
+    if (!t) {
+      t = { database: String(r.database), table: String(r.table), columns: [] };
+      byTable.set(key, t);
+    }
+    t.columns.push({ name: String(r.name), type: String(r.type) });
+  }
+  const denied = deniedFamilies();
+  const schema = [...byTable.values()].filter((t) =>
+    t.database === "biz"
+      ? !denied.has(BUSINESS_FAMILY.slug)
+      : !denied.has(
+          familySlug(familyOf(LAKE_SOURCES.find((s) => s.table === t.table)?.source ?? t.table)),
+        ),
+  );
+  return { schema, lakeUrl: lakeRes.url, roles };
+}
+
+/** On an unknown-column failure, surface the referenced tables' real columns
+ *  (scoped identically to get_schema) + a "did you mean". Returns null when it
+ *  can't add signal (no tables parsed, none matched, or the lake is down). */
+async function unknownColumnSchemaHint(sql: string, errMsg: string): Promise<string | null> {
+  const refs = extractTableRefs(sql);
+  if (!refs.length) return null;
+  let scoped: Awaited<ReturnType<typeof scopedSchema>>;
+  try {
+    scoped = await scopedSchema();
+  } catch {
+    return null; // lake unreachable — fall back to the static hint alone
+  }
+  const matched = matchReferencedTables(
+    refs,
+    scoped.schema.map((t) => ({
+      database: t.database,
+      table: t.table,
+      columns: t.columns.map((c) => c.name),
+    })),
+  );
+  return renderColumnHint(extractUnknownColumn(errMsg), matched);
+}
 
 /* ------------------------------ context tools ------------------------------ */
 
@@ -962,57 +1040,13 @@ server.registerTool(
     const started = Date.now();
     try {
       const config = requireConfig();
-      const lakeRes = resolveLakeUrl(projectDir, config);
-      if (!lakeRes.ok) throw new Error(lakeRes.error);
-      const lakeUrl = lakeRes.url;
-      // Metadata is identifiers + types, never row content, but a big schema
-      // (dozens of biz.* tables) can exceed a small row cap and silently drop
-      // trailing tables' columns — cap high so the listing is never truncated.
-      const qopts = { rowCap: 200_000, statementTimeoutMs: config.statementTimeoutMs };
       // Schema METADATA only — so it runs on every role: a curator needs the
       // business-table shape to write context docs (the I2/I9 membrane gates
-      // lake content, not table shape). ClickHouse filters system.columns to
-      // tables the caller may read, and the session's role subset (per-user
-      // source access) rides on the same request — so a denied family's tables
-      // vanish from this listing by the engine's hand.
-      const roles = lakeRoles();
-      const res = await runLakeQuery(
-        lakeUrl,
-        // Exclude the plumbing tables — heartbeats (core, no data) and the
-        // pg_mirror_runs run-log (its rows enumerate the mirrored business
-        // catalog, so it follows the business deny; the belt-filter below can't
-        // map its label to the 'business' slug, and it's not a queryable source).
-        "SELECT database, table, name, type FROM system.columns " +
-          "WHERE database IN ('biz','setoku') " +
-          "AND (database, table) NOT IN (('setoku','ingest_heartbeats'), ('setoku','pg_mirror_runs')) " +
-          "ORDER BY database, table, position",
-        qopts,
-        {},
-        roles,
-      );
-      type Tbl = { database: string; table: string; columns: { name: string; type: string }[] };
-      const byTable = new Map<string, Tbl>();
-      for (const r of res.rows as Array<Record<string, unknown>>) {
-        const key = `${r.database}.${r.table}`;
-        let t = byTable.get(key);
-        if (!t) {
-          t = { database: String(r.database), table: String(r.table), columns: [] };
-          byTable.set(key, t);
-        }
-        t.columns.push({ name: String(r.name), type: String(r.type) });
-      }
-      // Belt-and-suspenders (parity with list_sources): the engine already
-      // hides denied families, but during a partial rollout — new code, old
-      // lake-users.xml still holding a `setoku.*`/`biz.*` wildcard, or a
-      // ClickHouse that ignores the role param — drop a denied family's tables
-      // in code too, so a denied source's shape never leaks. biz.* follows the
-      // "business" (Postgres) family; lake tables follow their own family.
-      const denied = deniedFamilies();
-      let schema = [...byTable.values()].filter((t) =>
-        t.database === "biz"
-          ? !denied.has(BUSINESS_FAMILY.slug)
-          : !denied.has(familySlug(familyOf(LAKE_SOURCES.find((s) => s.table === t.table)?.source ?? t.table))),
-      );
+      // lake content, not table shape). scopedSchema() applies the session's
+      // role subset + the denied-family belt filter; get_schema and the
+      // run_query unknown-column augment read this same scoped view.
+      const { schema: schema0, lakeUrl, roles } = await scopedSchema();
+      let schema = schema0;
       if (tables?.length) {
         // Match on the qualified biz/setoku name OR a bare table name. A pg-style
         // qualified name copied from an entity doc's meta.table ("public.orders")
@@ -1033,6 +1067,7 @@ server.registerTool(
       if (tables?.length) {
         // ORDER BY key (the ClickHouse analogue of "how is this table keyed") —
         // one metadata fetch, joined in for the detail view.
+        const qopts = { rowCap: 200_000, statementTimeoutMs: config.statementTimeoutMs };
         const sortKeys = new Map<string, string>();
         try {
           const sk = await runLakeQuery(
@@ -1251,7 +1286,24 @@ server.registerTool(
         ms: Date.now() - started, // no SQL completed — wall-clock is all we have
         totalMs: Date.now() - started,
       });
-      return errorText(`run_query failed: ${msg}`);
+      // Append an actionable "→ next step" that points at a discovery tool, so
+      // the agent resolves the blocker in-loop instead of re-guessing. The hint
+      // is membrane-safe (a denied table and a nonexistent one share one hint —
+      // see lib/queryhint.ts). On an unknown-column error, go further and surface
+      // the referenced tables' REAL columns + a "did you mean" — scoped exactly
+      // like get_schema, so it reveals nothing new.
+      const hint = queryErrorHint(msg, sql);
+      const parts = [`run_query failed: ${msg}`];
+      if (hint) parts.push(`→ ${hint.hint}`);
+      if (hint?.code === "unknown_column") {
+        try {
+          const schemaHint = await unknownColumnSchemaHint(sql, msg);
+          if (schemaHint) parts.push(schemaHint);
+        } catch {
+          /* augmentation is best-effort — the static hint still stands */
+        }
+      }
+      return errorText(parts.join("\n\n"));
     }
   },
 );

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -26,7 +26,7 @@ import { resolveParams, paramsVariant, type AppParam } from "./lib/params";
 import { lintAppTemplate } from "./lib/app-runtime";
 import { extractSql } from "./lib/lint";
 import { queryCaptureNudge, panelCaptureNote } from "./lib/nudge";
-import { mirroredTables, type MirroredTable } from "./lib/mirror";
+import { mirroredTables, mirrorNameOf, queryableTableName, type MirroredTable } from "./lib/mirror";
 import { LAKE_SOURCES, BEAT_LIVE_MS, BUSINESS_FAMILY, familyOf, familySlug, lakeFamilies, lakeRolesFor } from "./lib/sources";
 import {
   deniedFamiliesFor,
@@ -381,7 +381,13 @@ server.registerTool(
     }
     for (const { doc } of top) {
       out.push(`## [${doc.type}] ${doc.name}`);
-      if (doc.meta.table) out.push(`table: ${doc.meta.table}`);
+      if (doc.meta.table) {
+        // Show the QUERYABLE name (biz.*); keep the pg provenance name alongside
+        // it when they differ, so the context layer never hands the agent a name
+        // run_query can't use.
+        const q = queryableTableName(String(doc.meta.table));
+        out.push(q === String(doc.meta.table) ? `table: ${q}` : `table: ${q} (source: ${doc.meta.table})`);
+      }
       if (doc.meta.summary) out.push(String(doc.meta.summary));
       if (doc.body.length <= 1500) {
         out.push("", doc.body, "");
@@ -469,7 +475,7 @@ server.registerTool(
       for (const d of ofType) {
         const summary = d.meta.summary ?? d.meta.question ?? "";
         lines.push(
-          `- ${d.name}${d.meta.table ? ` (${d.meta.table})` : ""}${summary ? ` — ${summary}` : ""}`,
+          `- ${d.name}${d.meta.table ? ` (${queryableTableName(String(d.meta.table))})` : ""}${summary ? ` — ${summary}` : ""}`,
         );
       }
     }
@@ -1005,16 +1011,6 @@ server.registerTool(
     return text(lines.join("\n"));
   },
 );
-
-/** Map a documented pg-style entity table name to its biz.* mirror name —
- *  public.orders → orders, ticketing.seat_txn → ticketing_seat_txn, bare names
- *  pass through. The same convention pg-mirror uses to name its targets. */
-function mirrorNameOf(pgName: string): string {
-  const parts = pgName.toLowerCase().split(".");
-  if (parts.length < 2) return parts[0];
-  const [schema, ...rest] = parts;
-  return schema === "public" ? rest.join("_") : [schema, ...rest].join("_");
-}
 
 server.registerTool(
   "get_schema",

--- a/plugin/gateway/friction-cli.ts
+++ b/plugin/gateway/friction-cli.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * run_query friction-report runner.
+ *
+ * Deterministic, model-free, zero-API-cost (I8): mines a box's audit log for
+ * the fail→retry→success pattern and prints where agents get stuck using
+ * run_query. This is the "reflections" loop from the HN "designing APIs for
+ * agents" thread (item 48894874), sourced from BEHAVIOR (the audit log) rather
+ * than self-report — see lib/friction.ts.
+ *
+ *   bun plugin/gateway/friction-cli.ts --db <knowledge.db> [--window <min>] [--json] [--no-sql]
+ *
+ * PII: SQL literals in the audit log can contain customer values. SQL snippets
+ * are shown by default (this is a box-local operator tool, same trust boundary
+ * as the /admin audit page); pass --no-sql to redact them before sharing a
+ * report off the box.
+ */
+import fs from "node:fs";
+import { KnowledgeStore } from "./lib/store";
+import { mineFriction, renderFriction } from "./lib/friction";
+
+function parseArgs(argv: string[]) {
+  const out: {
+    db?: string;
+    window: number;
+    json: boolean;
+    showSql: boolean;
+  } = { window: 15, json: false, showSql: true };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--db") out.db = argv[++i];
+    else if (a === "--window") out.window = Number(argv[++i]);
+    else if (a === "--json") out.json = true;
+    else if (a === "--no-sql") out.showSql = false;
+  }
+  return out;
+}
+
+function main() {
+  const args = parseArgs(Bun.argv.slice(2));
+  if (!args.db) {
+    console.error(
+      "usage: bun plugin/gateway/friction-cli.ts --db <knowledge.db> [--window <min>] [--json] [--no-sql]",
+    );
+    process.exit(2);
+  }
+  // Constructing a KnowledgeStore creates the file if missing, so a typo'd path
+  // would silently mine an empty store. Require it to exist.
+  if (!fs.existsSync(args.db)) {
+    console.error(`--db not found: ${args.db}`);
+    process.exit(2);
+  }
+  if (!Number.isFinite(args.window) || args.window <= 0) {
+    console.error(`--window must be a positive number of minutes`);
+    process.exit(2);
+  }
+
+  const store = new KnowledgeStore(args.db);
+  const rows = store.auditForTool("run_query");
+  const result = mineFriction(rows, { windowMinutes: args.window });
+
+  if (args.json) console.log(JSON.stringify(result, null, 2));
+  else console.log(renderFriction(result, { showSql: args.showSql }));
+}
+
+if (import.meta.main) main();

--- a/plugin/gateway/lib/friction.ts
+++ b/plugin/gateway/lib/friction.ts
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Tool-friction miner — the "reflections" loop, sourced from behavior.
+ *
+ * The HN "designing APIs for agents" thread (item 48894874) splits on whether
+ * you should ASK an agent what confused it: self-report is plausible but
+ * ungrounded (what/rgbrgb/benswerd), and only grounded when there's a
+ * behavioral anchor — tried X, failed, tried Y, worked (simonw/kolinko). Our
+ * audit log already records that anchor for every `run_query` (purpose + sql +
+ * ok + error, in append order), so we can extract the friction WITHOUT asking
+ * the model to introspect, and without a self-report tool the operator would
+ * have to babysit.
+ *
+ * This is deterministic and model-free (I8): it reads the audit log, clusters
+ * failures by cause (the SAME classifier the live hint uses, lib/queryhint.ts),
+ * and detects per-session fail→retry→success recovery. A cause with a LOW
+ * recovery rate is where agents get stuck — the priority for a better error
+ * hint, a schema rename, or a new curated metric.
+ */
+import { classifyQueryError } from "./queryhint";
+import type { AuditRow } from "./store";
+
+export interface FrictionEvent {
+  ts: string;
+  user: string;
+  ok: boolean;
+  error: string;
+  sql: string;
+  purpose: string;
+}
+
+export interface FrictionExample {
+  purpose: string;
+  error: string;
+  sql: string;
+}
+
+export interface BucketStat {
+  code: string;
+  /** failures in this bucket */
+  count: number;
+  /** failures followed by a same-session success */
+  recovered: number;
+  /** count − recovered: agents that stayed blocked */
+  stuck: number;
+  recoveryRate: number;
+  examples: FrictionExample[];
+}
+
+export interface FrictionResult {
+  totalCalls: number;
+  totalFailures: number;
+  failureRate: number;
+  recoveredFailures: number;
+  /** recovered / totalFailures */
+  recoveryRate: number;
+  windowMinutes: number;
+  users: number;
+  /** sorted by `stuck` desc (most-unresolved friction first) */
+  buckets: BucketStat[];
+  /** most common `purpose` among failures — a missing-metric / hard-question
+   *  signal (an intent agents keep failing to express in SQL) */
+  topFailingIntents: { purpose: string; count: number }[];
+}
+
+export interface MineOptions {
+  /** consecutive same-user calls within this gap count as one session; a
+   *  larger gap is a session boundary and stops recovery look-ahead */
+  windowMinutes?: number;
+  /** examples kept per bucket */
+  exampleLimit?: number;
+}
+
+function trunc(s: string, n: number): string {
+  const one = String(s ?? "").replace(/\s+/g, " ").trim();
+  return one.length > n ? one.slice(0, n) + "…" : one;
+}
+
+function gapMinutes(aTs: string, bTs: string): number {
+  return Math.abs(new Date(bTs).getTime() - new Date(aTs).getTime()) / 60000;
+}
+
+/** Parse run_query audit rows into typed events (oldest-first order preserved).
+ *  Rows whose payload won't parse are skipped — a corrupt row must not abort a
+ *  report over months of good data. */
+export function parseRunQueryEvents(rows: AuditRow[]): FrictionEvent[] {
+  const events: FrictionEvent[] = [];
+  for (const r of rows) {
+    if (r.tool !== "run_query") continue;
+    let p: Record<string, unknown>;
+    try {
+      p = JSON.parse(r.payload) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    events.push({
+      ts: r.ts,
+      user: r.user ?? "(unknown)",
+      ok: p.ok === true,
+      error: typeof p.error === "string" ? p.error : "",
+      sql: typeof p.sql === "string" ? p.sql : "",
+      purpose: typeof p.purpose === "string" ? p.purpose : "",
+    });
+  }
+  return events;
+}
+
+export function mineFriction(
+  rows: AuditRow[],
+  opts: MineOptions = {},
+): FrictionResult {
+  const windowMinutes = opts.windowMinutes ?? 15;
+  const exampleLimit = opts.exampleLimit ?? 3;
+  const events = parseRunQueryEvents(rows);
+
+  // Per-user timelines (already oldest-first from auditForTool), so recovery
+  // look-ahead sees each identity's own retries in order.
+  const byUser = new Map<string, FrictionEvent[]>();
+  for (const e of events) {
+    const list = byUser.get(e.user) ?? [];
+    list.push(e);
+    byUser.set(e.user, list);
+  }
+
+  interface Bucket {
+    count: number;
+    recovered: number;
+    examples: FrictionExample[];
+  }
+  const buckets = new Map<string, Bucket>();
+  const intents = new Map<string, { purpose: string; count: number }>();
+  let totalFailures = 0;
+  let recoveredFailures = 0;
+
+  for (const list of byUser.values()) {
+    for (let i = 0; i < list.length; i++) {
+      const e = list[i];
+      if (e.ok) continue;
+      totalFailures++;
+
+      // recovery: a later same-session success before a gap > window
+      let recovered = false;
+      for (let j = i + 1; j < list.length; j++) {
+        if (gapMinutes(list[j - 1].ts, list[j].ts) > windowMinutes) break;
+        if (list[j].ok) {
+          recovered = true;
+          break;
+        }
+      }
+      if (recovered) recoveredFailures++;
+
+      const code = classifyQueryError(e.error);
+      const b = buckets.get(code) ?? { count: 0, recovered: 0, examples: [] };
+      b.count++;
+      if (recovered) b.recovered++;
+      if (b.examples.length < exampleLimit) {
+        b.examples.push({
+          purpose: trunc(e.purpose, 160),
+          error: trunc(e.error, 200),
+          sql: trunc(e.sql, 200),
+        });
+      }
+      buckets.set(code, b);
+
+      if (e.purpose.trim()) {
+        const key = e.purpose.trim().toLowerCase();
+        const rec = intents.get(key) ?? { purpose: e.purpose.trim(), count: 0 };
+        rec.count++;
+        intents.set(key, rec);
+      }
+    }
+  }
+
+  const bucketStats: BucketStat[] = [...buckets.entries()]
+    .map(([code, b]) => ({
+      code,
+      count: b.count,
+      recovered: b.recovered,
+      stuck: b.count - b.recovered,
+      recoveryRate: b.count ? b.recovered / b.count : 0,
+      examples: b.examples,
+    }))
+    // most-unresolved first; ties broken by raw volume
+    .sort((a, b) => b.stuck - a.stuck || b.count - a.count);
+
+  const topFailingIntents = [...intents.values()]
+    .filter((x) => x.count >= 2)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+
+  return {
+    totalCalls: events.length,
+    totalFailures,
+    failureRate: events.length ? totalFailures / events.length : 0,
+    recoveredFailures,
+    recoveryRate: totalFailures ? recoveredFailures / totalFailures : 0,
+    windowMinutes,
+    users: byUser.size,
+    buckets: bucketStats,
+    topFailingIntents,
+  };
+}
+
+function pct(x: number): string {
+  return `${(x * 100).toFixed(1)}%`;
+}
+
+/** One-line, human-readable gloss per bucket for the report header column. */
+const BUCKET_LABEL: Record<string, string> = {
+  table_unavailable: "table not found / not granted",
+  unknown_column: "unknown column",
+  unknown_function: "unknown function",
+  type_mismatch: "type mismatch",
+  correlated_subquery: "correlated subquery (unsupported)",
+  syntax: "SQL syntax (often a Postgres-ism)",
+  mirror_required: "table not yet mirrored (rollout artifact)",
+  timeout: "statement timeout",
+  memory: "memory cap",
+  pg_retired: "used the retired Postgres path",
+  curator_lake_denied: "curator session tried to read the lake",
+  read_only: "tried a write on a read-only conn",
+  multi_statement: "multiple statements in one call",
+  format_clause: "included a FORMAT clause",
+  other: "unclassified",
+};
+
+export function renderFriction(
+  r: FrictionResult,
+  opts: { showSql?: boolean } = {},
+): string {
+  const showSql = opts.showSql ?? true;
+  const lines: string[] = [];
+  lines.push("# run_query friction report\n");
+  lines.push(
+    "Grounded in the audit log — no model, no self-report. A cause with a LOW " +
+      "recovery rate is where agents stay blocked: fix it with a better error " +
+      "hint (lib/queryhint.ts), a schema rename, or a new curated metric.\n",
+  );
+
+  lines.push("## Overall");
+  lines.push(`- run_query calls: **${r.totalCalls}** across **${r.users}** identities`);
+  lines.push(
+    `- failures: **${r.totalFailures}** (${pct(r.failureRate)} of calls)`,
+  );
+  lines.push(
+    `- recovered in-session (≤${r.windowMinutes}m): **${r.recoveredFailures}** (${pct(r.recoveryRate)} of failures) — the rest stayed blocked`,
+  );
+  lines.push("");
+
+  if (!r.buckets.length) {
+    lines.push("_No run_query failures in the audit log. Nothing to mine._");
+    return lines.join("\n");
+  }
+
+  lines.push("## Failure causes (most-unresolved first)");
+  lines.push(`| cause | fails | recovered | stuck | recovery |`);
+  lines.push(`| --- | --- | --- | --- | --- |`);
+  for (const b of r.buckets) {
+    const label = BUCKET_LABEL[b.code] ?? b.code;
+    lines.push(
+      `| \`${b.code}\` — ${label} | ${b.count} | ${b.recovered} | **${b.stuck}** | ${pct(b.recoveryRate)} |`,
+    );
+  }
+  lines.push("");
+
+  lines.push("## Examples");
+  for (const b of r.buckets) {
+    if (!b.examples.length) continue;
+    lines.push(`### \`${b.code}\` (${b.count} fails, ${b.stuck} stuck)`);
+    for (const ex of b.examples) {
+      if (ex.purpose) lines.push(`- purpose: ${ex.purpose}`);
+      lines.push(`  - error: ${ex.error || "(none recorded)"}`);
+      if (showSql && ex.sql) lines.push(`  - sql: \`${ex.sql}\``);
+    }
+    lines.push("");
+  }
+
+  if (r.topFailingIntents.length) {
+    lines.push("## Intents that keep failing (candidate missing metrics)");
+    lines.push(
+      "Stated `purpose` on repeated failed queries — an intent agents can’t reliably turn into SQL is often a metric worth curating.\n",
+    );
+    for (const it of r.topFailingIntents)
+      lines.push(`- ${it.count}× — ${it.purpose}`);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}

--- a/plugin/gateway/lib/mirror.ts
+++ b/plugin/gateway/lib/mirror.ts
@@ -29,6 +29,34 @@ export interface MirroredTable {
   asOf: string;
 }
 
+/** Map a documented pg-style entity table name to its biz.* mirror name —
+ *  public.orders → orders, ticketing.seat_txn → ticketing_seat_txn, bare names
+ *  pass through. The same convention pg-mirror uses to name its targets.
+ *  Lowercases by default (callers match case-insensitively); pass preserveCase
+ *  for a DISPLAY name — ClickHouse table names are case-sensitive, so
+ *  `biz.JobPost` must keep its case to be queryable. */
+export function mirrorNameOf(pgName: string, preserveCase = false): string {
+  const parts = (preserveCase ? pgName : pgName.toLowerCase()).split(".");
+  if (parts.length < 2) return parts[0];
+  const [schema, ...rest] = parts;
+  return schema.toLowerCase() === "public" ? rest.join("_") : [schema, ...rest].join("_");
+}
+
+/** The name an agent should QUERY a documented entity by — bridges the context
+ *  layer to the ClickHouse names run_query/get_schema use. A pg-qualified
+ *  provenance name (public.JobPost) becomes its biz.* mirror (biz.JobPost, case
+ *  preserved). Names that are ALREADY ClickHouse-qualified — the lake db
+ *  (setoku.github_issues) or the mirror itself (biz.orders) — and bare names
+ *  (mercury_transactions, or an unqualified doc) pass through untouched. Keeps
+ *  meta.table's pg provenance intact in the store while showing a queryable
+ *  name. */
+export function queryableTableName(metaTable: string): string {
+  if (!metaTable.includes(".")) return metaTable;
+  const schema = metaTable.split(".")[0].toLowerCase();
+  if (schema === "biz" || schema === "setoku") return metaTable; // already queryable
+  return `biz.${mirrorNameOf(metaTable, true)}`;
+}
+
 /** Lake timestamp ("2026-07-03 12:00:00.000", UTC) → ISO string. */
 const lakeTsToIso = (s: string): string => {
   let t = s.includes("T") ? s : s.replace(" ", "T");

--- a/plugin/gateway/lib/queryhint.ts
+++ b/plugin/gateway/lib/queryhint.ts
@@ -208,10 +208,19 @@ export function extractTableRefs(sql: string): string[] {
  *  then the caller still lists columns, just without a "did you mean". */
 export function extractUnknownColumn(rawMsg: string): string | null {
   const m = String(rawMsg ?? "");
+  // ClickHouse wraps the offending identifier in backticks or single quotes
+  // right after the word "identifier" — across all its phrasings:
+  //   "Unknown expression identifier `x` in scope …"
+  //   "Unknown expression or function identifier `x` …"
+  //   "Identifier 'x' cannot be resolved from table with name u …"
+  // `[\s:]*` (whitespace/colon only) can't run past the quote into a later
+  // quoted token, so we never grab the literal word "identifier".
   const pats = [
-    /unknown (?:expression|identifier)(?: or function identifier)?[:`'\s]+([`"']?[\w.]+)/i,
-    /column\s+"?([\w.]+)"?\s+does not exist/i,
-    /there.?s no column[:`'\s]+([`"']?[\w.]+)/i,
+    /\bidentifier\b[\s:]*`([\w.]+)`/i,
+    /\bidentifier\b[\s:]*'([\w.]+)'/i,
+    /unknown identifier:\s*([\w.]+)/i, // colon form, unquoted
+    /column\s+"?([\w.]+)"?\s+does not exist/i, // Postgres
+    /there.?s no column[\s:]*[`'"]?([\w.]+)/i,
     /missing columns?:?\s*'?([\w.]+)/i,
   ];
   for (const p of pats) {
@@ -219,7 +228,8 @@ export function extractUnknownColumn(rawMsg: string): string | null {
     if (!mm) continue;
     const raw = mm[1].replace(/[`"']/g, "");
     const bare = raw.includes(".") ? raw.split(".").pop()! : raw;
-    if (bare) return bare;
+    // never surface the literal word "identifier" from a malformed match
+    if (bare && bare.toLowerCase() !== "identifier") return bare;
   }
   return null;
 }
@@ -271,13 +281,15 @@ export function matchReferencedTables(
   tables: RefTable[],
 ): { table: string; columns: string[] }[] {
   const norm = (s: string) => s.replace(/["'`\s]/g, "").toLowerCase();
-  const qualified = new Set(refs.map(norm));
-  const bare = new Set(
-    refs.map((r) => {
-      const n = norm(r);
-      return n.includes(".") ? n.split(".").pop()! : n;
-    }),
-  );
+  // A QUALIFIED ref (biz.events) matches only that exact db.table. A ref matches
+  // by bare table name ONLY when the ref itself is bare — otherwise `biz.events`
+  // would also drag in an unrelated `setoku.events` and pool its columns.
+  const qualified = new Set<string>();
+  const bare = new Set<string>();
+  for (const r of refs) {
+    const n = norm(r);
+    (n.includes(".") ? qualified : bare).add(n);
+  }
   return tables
     .filter((t) => {
       const q = `${t.database}.${t.table}`.toLowerCase();

--- a/plugin/gateway/lib/queryhint.ts
+++ b/plugin/gateway/lib/queryhint.ts
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Turn a raw query-engine failure into an agent-actionable one.
+ *
+ * `run_query` used to forward the bare ClickHouse message ("Code: 60. ...
+ * doesn't exist"), which makes the agent re-guess and burn turns. Here we keep
+ * the original message (humans and agents both want the ground truth) and
+ * classify it so the caller can append a "→ next step" hint that points at a
+ * discovery tool. That resolves the blocker IN the agent's loop, which the HN
+ * "designing APIs for agents" thread (item 48894874) argues beats any
+ * after-the-fact feedback channel ("support > feedback").
+ *
+ * The SAME classifier feeds the friction miner (friction-cli.ts), so the codes
+ * here are the vocabulary both the live hint and the offline report speak.
+ *
+ * MEMBRANE (I2/I9). "table not found" and "access denied" MUST collapse to one
+ * code + one hint. The engine returns UNKNOWN_TABLE for a nonexistent table and
+ * ACCESS_DENIED for a denied family's tables (source access is engine-enforced,
+ * per-role GRANTs). If we branched, the denied case would confirm the table
+ * exists — leaking exactly what the membrane hides. Both say the same thing:
+ * it isn't available to you, here's how to see what is.
+ */
+
+export interface QueryHint {
+  /** stable slug — the bucket key for friction clustering */
+  code: string;
+  /** the "→ next step" line appended to the raw error (empty for our own
+   *  already-actionable messages, which need no augmentation) */
+  hint: string;
+}
+
+/**
+ * Ordered most-specific first. `test` matches the raw error text (ClickHouse
+ * surfaces both a `Code: N` and a symbolic name, so we match either). A rule
+ * with an empty `hint` is classified for the miner but adds nothing live —
+ * used where our own gate/engine message is already self-explanatory.
+ */
+const RULES: { code: string; test: RegExp; hint: string }[] = [
+  {
+    // Our own retirement pointer (dialect:"postgres", or a legacy pg panel).
+    // `^pg-retired$` is the short audit sentinel stored on that path.
+    code: "pg_retired",
+    test: /business-Postgres path is retired|biz\.\* ClickHouse mirror|^pg-retired$/i,
+    hint: "",
+  },
+  {
+    // Historical audit sentinel: a query referenced a business table before
+    // pg-mirror had populated it into biz.* (issue #47 rollout). Not a rename —
+    // the mirror just had to catch up. Distinct bucket keeps the `other` pile
+    // honest when mining older audit history.
+    code: "mirror_required",
+    test: /^mirror-required$/i,
+    hint: "",
+  },
+  {
+    // Our own gate messages — already actionable, just bucket them.
+    code: "read_only",
+    test: /connection is READ ONLY|Only read statements are allowed/i,
+    hint: "",
+  },
+  {
+    code: "multi_statement",
+    test: /Multiple statements \(semicolons\)/i,
+    hint: "",
+  },
+  {
+    code: "format_clause",
+    test: /remove any FORMAT clause/i,
+    hint: "",
+  },
+  {
+    // The membrane rejecting a lake read on a curator (write-capable) session
+    // (I2/I9). Expected + already actionable ("use an analyst connector") — just
+    // bucket it so it doesn't dilute the `other` pile.
+    code: "curator_lake_denied",
+    test: /curator session.*reading the lake|reading the lake .*is disabled/i,
+    hint: "",
+  },
+  {
+    // UNKNOWN_TABLE (60) + ACCESS_DENIED (497) + privilege phrasing — UNIFIED on
+    // purpose (see MEMBRANE note above). Never branch these. `relation … does
+    // not exist` is the Postgres phrasing (legacy/retired-path rows in the audit
+    // history); `unknown table expression identifier` is ClickHouse's wording
+    // when the Code isn't in the matched slice.
+    code: "table_unavailable",
+    test:
+      /unknown table|unknown table expression identifier|table .*does\s?n.?t exist|relation .*does not exist|code:\s*60\b|access[_ ]denied|not enough privileges|code:\s*497\b/i,
+    hint:
+      "That table isn’t available on this connector. Business tables are exposed as `biz.<table>` (their raw source names aren’t queryable). Run `get_schema`, or `SHOW TABLES` / `SHOW TABLES FROM biz`, to see what you can query.",
+  },
+  {
+    // UNKNOWN_IDENTIFIER (47), NOT_FOUND_COLUMN_IN_BLOCK (10),
+    // THERE_IS_NO_COLUMN (8), "Missing columns". `column … does not exist` is
+    // the Postgres phrasing (legacy audit rows).
+    code: "unknown_column",
+    test:
+      /unknown identifier|missing column|there.?s no column|column .*does not exist|code:\s*47\b|code:\s*10\b|code:\s*8\b|not_found_column/i,
+    hint:
+      "Unknown column. Run `DESCRIBE <table>` (or `get_schema`) for exact names — ClickHouse identifiers are case-sensitive.",
+  },
+  {
+    // UNKNOWN_FUNCTION (46).
+    code: "unknown_function",
+    test: /unknown function|code:\s*46\b/i,
+    hint:
+      "Unknown function — this is ClickHouse SQL, not Postgres. Check the ClickHouse name (e.g. `toStartOfMonth`, `countIf`, `uniqExact`).",
+  },
+  {
+    // TYPE_MISMATCH (53), NO_COMMON_TYPE (386), ILLEGAL_TYPE_OF_ARGUMENT (43).
+    code: "type_mismatch",
+    test:
+      /type mismatch|no common type|illegal type|code:\s*53\b|code:\s*386\b|code:\s*43\b/i,
+    hint:
+      "Type mismatch. ClickHouse is stricter than Postgres — cast explicitly with `CAST(x AS Int64)` / `toInt64(x)` / `toDate(x)` rather than relying on coercion.",
+  },
+  {
+    // ClickHouse correlated-subquery limitation: "Resolved identifier '…' in
+    // parent scope". A real recurring gotcha (agents port a Postgres correlated
+    // subquery verbatim), so it earns a live hint pointing at the JOIN rewrite.
+    code: "correlated_subquery",
+    test: /resolved identifier .* in parent scope/i,
+    hint:
+      "ClickHouse doesn’t support correlated subqueries (a subquery referencing the outer row). Rewrite it as a JOIN, or use an uncorrelated IN (…) / a window function.",
+  },
+  {
+    // TIMEOUT_EXCEEDED (159) + ClickHouse/Postgres statement-timeout phrasing.
+    code: "timeout",
+    test: /timeout exceeded|timed out|canceling statement due to statement timeout|code:\s*159\b/i,
+    hint:
+      "Query hit the statement timeout. Narrow the scan: add a date/partition filter or aggregate over a smaller range before joining.",
+  },
+  {
+    // MEMORY_LIMIT_EXCEEDED (241).
+    code: "memory",
+    test: /memory limit|code:\s*241\b/i,
+    hint:
+      "Query hit the memory cap. Reduce cardinality — filter before a GROUP BY / DISTINCT / JOIN, or pre-aggregate.",
+  },
+  {
+    // SYNTAX_ERROR (62). Kept last of the engine rules: the more specific codes
+    // above should win when both a code and "syntax" phrasing appear.
+    code: "syntax",
+    test: /syntax error|code:\s*62\b/i,
+    hint:
+      "Syntax error. This is ClickHouse SQL — the Postgres path is retired. Note `x::Type` casts aren’t valid; use `CAST(x AS Type)` or a `toType(x)` function.",
+  },
+];
+
+/** The bucket a raw error falls in — for friction clustering. "other" when
+ *  nothing matches (worth reading manually; often a genuinely novel failure). */
+export function classifyQueryError(rawMsg: string): string {
+  const m = String(rawMsg ?? "");
+  for (const r of RULES) if (r.test.test(m)) return r.code;
+  return "other";
+}
+
+/**
+ * The live augmentation for `run_query`'s catch. Returns a hint to append, or
+ * null when the message is already self-explanatory (our own gate messages) or
+ * unrecognized. `sql` sharpens the syntax hint when a Postgres `::` cast is the
+ * likely culprit (a very common, very fixable miss against ClickHouse).
+ */
+export function queryErrorHint(rawMsg: string, sql = ""): QueryHint | null {
+  const m = String(rawMsg ?? "");
+  for (const r of RULES) {
+    if (!r.test.test(m)) continue;
+    if (!r.hint) return null; // classified, but no augmentation to add
+    if (r.code === "syntax" && /::/.test(sql)) {
+      return {
+        code: "syntax",
+        hint:
+          "Your SQL uses a Postgres `::` cast, which ClickHouse rejects. Use `CAST(x AS Type)` or a `toType(x)` function instead. (This is ClickHouse SQL; the Postgres path is retired.)",
+      };
+    }
+    if (r.code === "type_mismatch" && /cannot be inside nullable/i.test(m)) {
+      return {
+        code: "type_mismatch",
+        hint:
+          "A JSON/array function got a Nullable column. Wrap the column first: `assumeNotNull(col)`, or `coalesce(col, '')` — ClickHouse won’t build an Array inside a Nullable type.",
+      };
+    }
+    return { code: r.code, hint: r.hint };
+  }
+  return null;
+}
+
+/* --------------------- schema-aware unknown-column help --------------------- */
+/* Turn an `unknown_column` failure into an in-loop fix: surface the referenced
+ * tables' REAL columns (scoped by the caller to exactly what get_schema would
+ * show) plus a "did you mean". These helpers are pure so they unit-test without
+ * a lake; app.ts feeds them the session-scoped schema. */
+
+/** Candidate table identifiers — the tokens after FROM / JOIN. Deliberately
+ *  conservative: bare or dotted identifiers (optionally double-quoted), no
+ *  subquery/CTE resolution. Over-extraction is harmless — an unmatched token is
+ *  dropped when matched against the real schema. */
+export function extractTableRefs(sql: string): string[] {
+  const re =
+    /\b(?:from|join)\s+("?[A-Za-z_]\w*"?(?:\s*\.\s*"?[A-Za-z_]\w*"?)?)/gi;
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(String(sql ?? "")))) out.push(m[1].replace(/\s+/g, ""));
+  return [...new Set(out)];
+}
+
+/** The identifier the engine flagged as unknown, normalized to the bare column
+ *  (drops any table-alias prefix + quoting/backticks). null if not extractable —
+ *  then the caller still lists columns, just without a "did you mean". */
+export function extractUnknownColumn(rawMsg: string): string | null {
+  const m = String(rawMsg ?? "");
+  const pats = [
+    /unknown (?:expression|identifier)(?: or function identifier)?[:`'\s]+([`"']?[\w.]+)/i,
+    /column\s+"?([\w.]+)"?\s+does not exist/i,
+    /there.?s no column[:`'\s]+([`"']?[\w.]+)/i,
+    /missing columns?:?\s*'?([\w.]+)/i,
+  ];
+  for (const p of pats) {
+    const mm = m.match(p);
+    if (!mm) continue;
+    const raw = mm[1].replace(/[`"']/g, "");
+    const bare = raw.includes(".") ? raw.split(".").pop()! : raw;
+    if (bare) return bare;
+  }
+  return null;
+}
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  if (!m) return n;
+  if (!n) return m;
+  let prev = Array.from({ length: n + 1 }, (_, i) => i);
+  let curr = new Array(n + 1).fill(0);
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[n];
+}
+
+/** Columns nearest a mistyped identifier (case-insensitive), closest first,
+ *  within an edit budget so we never suggest an unrelated column. An exact
+ *  case-insensitive match sorts first — ClickHouse is case-sensitive, so
+ *  `salaryMin` vs `salarymin` is the likely intended fix. */
+export function nearestColumns(bad: string, columns: string[], max = 3): string[] {
+  const b = bad.toLowerCase();
+  const budget = Math.max(2, Math.ceil(b.length / 3));
+  return columns
+    .map((c) => ({ c, d: levenshtein(b, c.toLowerCase()) }))
+    .filter((x) => x.d <= budget)
+    .sort((a, z) => a.d - z.d)
+    .slice(0, max)
+    .map((x) => x.c);
+}
+
+export interface RefTable {
+  database: string;
+  table: string;
+  columns: string[];
+}
+
+/** Referenced tables that resolve to a real, session-visible table — matched by
+ *  qualified (`db.table`) or bare table name, case-insensitively, quoting
+ *  stripped. Anything unmatched (aliases, CTEs, functions) is silently dropped. */
+export function matchReferencedTables(
+  refs: string[],
+  tables: RefTable[],
+): { table: string; columns: string[] }[] {
+  const norm = (s: string) => s.replace(/["'`\s]/g, "").toLowerCase();
+  const qualified = new Set(refs.map(norm));
+  const bare = new Set(
+    refs.map((r) => {
+      const n = norm(r);
+      return n.includes(".") ? n.split(".").pop()! : n;
+    }),
+  );
+  return tables
+    .filter((t) => {
+      const q = `${t.database}.${t.table}`.toLowerCase();
+      return qualified.has(q) || bare.has(t.table.toLowerCase());
+    })
+    .map((t) => ({ table: `${t.database}.${t.table}`, columns: t.columns }));
+}
+
+/** Render the schema block appended to an unknown-column error: the referenced
+ *  tables' columns + a cross-table "did you mean". null when there's nothing to
+ *  add (no matched tables). */
+export function renderColumnHint(
+  bad: string | null,
+  matched: { table: string; columns: string[] }[],
+): string | null {
+  if (!matched.length) return null;
+  const lines = ["Columns of the tables you referenced:"];
+  for (const t of matched) {
+    const cols = t.columns;
+    const shown = cols.length > 60 ? cols.slice(0, 60).join(", ") + `, …(+${cols.length - 60})` : cols.join(", ");
+    lines.push(`  ${t.table}: ${shown}`);
+  }
+  if (bad) {
+    const all = [...new Set(matched.flatMap((t) => t.columns))];
+    const near = nearestColumns(bad, all);
+    lines.push(
+      near.length
+        ? `No column \`${bad}\` — did you mean ${near.map((c) => `\`${c}\``).join(" / ")}?`
+        : `No column \`${bad}\` in those tables.`,
+    );
+  }
+  return lines.join("\n");
+}

--- a/plugin/gateway/lib/store.ts
+++ b/plugin/gateway/lib/store.ts
@@ -911,6 +911,19 @@ export class KnowledgeStore {
       .all(limit) as unknown as AuditRow[];
   }
 
+  /** The full audit history for one tool, oldest-first — the chronological
+   *  order the friction miner (friction-cli.ts) needs to spot a per-user
+   *  fail→retry→success sequence. `id` is the append order (ts can tie at
+   *  ISO-second granularity), so ordering by it keeps same-second retries in
+   *  the order they actually happened. */
+  auditForTool(tool: string): AuditRow[] {
+    return this.db
+      .query(
+        "SELECT ts, user, tool, payload FROM audit WHERE tool = ? ORDER BY id ASC",
+      )
+      .all(tool) as unknown as AuditRow[];
+  }
+
   /* -------------------------------- accounts ---------------------------- */
 
   /** Create a local account (Phase 5.1). pwhash must already be argon2id.

--- a/plugin/skills/eval/SKILL.md
+++ b/plugin/skills/eval/SKILL.md
@@ -79,6 +79,16 @@ Reproduces what `find_context` would surface for each trap and checks whether th
 
 Scorecard: per trap, ungrounded ✓/✗ and grounded ✓/✗; the **answer-lift = grounded − ungrounded** correct rate. That single number is the closest thing to "is Setoku worth it" — a trap the agent gets right *only* when grounded is Setoku earning its keep. A trap it gets right *both* ways means the curated fact added nothing (drop it or harden the trap); wrong *both* ways means the fact is missing or unreachable (see the deterministic punch-list).
 
+## Tool friction (does the query surface itself get in the way?)
+
+The evals above score the *answer*. This one scores the **tool ergonomics** — where agents get stuck driving `run_query`. It's deterministic and model-free (I8): it mines the box's audit log for the fail→retry→success pattern, clusters failures by cause (`table_unavailable`, `syntax`, `unknown_column`, …), and reports the **in-session recovery rate** per cause.
+
+```bash
+bun run eval:friction --db <knowledge.db> [--window <min>] [--json] [--no-sql]
+```
+
+A cause with a **low recovery rate** is where agents stay blocked — the priority for a better error hint (`plugin/gateway/lib/queryhint.ts`, which already appends a "→ next step" to live `run_query` failures), a schema rename, or a new curated metric. The **"intents that keep failing"** section lists the `purpose` strings on repeated failed queries — a question agents can't reliably turn into SQL is often a metric worth curating. This is behavioral (grounded in what agents actually did), not self-report, so it doesn't depend on the model introspecting. SQL snippets can contain customer values; pass `--no-sql` before sharing a report off the box.
+
 ## Compaction (the companion pass — issue #10)
 
 Compaction ("REM sleep") — merging duplicate facts, resolving contradictions, tightening verbose docs — is judgment work, so it runs **in a curator session** via [`/setoku:compact-knowledge`](../compact-knowledge/SKILL.md), not as a server-side job (I8). The `/admin/knowledge` health bar surfaces the deterministic signals (contradictions / duplicates / verbose / stale counts) as a cheap map; the skill does the actual semantic cleanup and commits it through the curator membrane (I9). The metrics above are how you check that a compaction pass actually improved the store.

--- a/test/friction.test.ts
+++ b/test/friction.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// The friction miner: cluster run_query failures by cause and detect per-session
+// fail→retry→success recovery from the audit log. Deterministic, model-free.
+import { describe, it, expect } from "bun:test";
+import type { AuditRow } from "../plugin/gateway/lib/store";
+import {
+  mineFriction,
+  parseRunQueryEvents,
+  renderFriction,
+} from "../plugin/gateway/lib/friction";
+
+// Build an audit row the way store.audit() would (payload is a JSON string).
+function row(
+  ts: string,
+  user: string,
+  payload: Record<string, unknown>,
+  tool = "run_query",
+): AuditRow {
+  return { ts, user, tool, payload: JSON.stringify(payload) };
+}
+
+const T = (min: number) =>
+  new Date(Date.UTC(2026, 6, 16, 12, min, 0)).toISOString();
+
+describe("parseRunQueryEvents", () => {
+  it("skips non-run_query rows and unparseable payloads", () => {
+    const rows: AuditRow[] = [
+      row(T(0), "a", { ok: true, sql: "SELECT 1" }),
+      row(T(1), "a", {}, "find_context"),
+      { ts: T(2), user: "a", tool: "run_query", payload: "{not json" },
+    ];
+    const ev = parseRunQueryEvents(rows);
+    expect(ev.length).toBe(1);
+    expect(ev[0].ok).toBe(true);
+  });
+});
+
+describe("mineFriction", () => {
+  it("counts failures and computes the failure rate", () => {
+    const rows: AuditRow[] = [
+      row(T(0), "a", { ok: true, sql: "SELECT 1" }),
+      row(T(1), "a", { ok: false, error: "Code: 60. Table x doesn't exist", sql: "SELECT * FROM x" }),
+    ];
+    const r = mineFriction(rows);
+    expect(r.totalCalls).toBe(2);
+    expect(r.totalFailures).toBe(1);
+    expect(r.failureRate).toBeCloseTo(0.5);
+    expect(r.buckets[0].code).toBe("table_unavailable");
+  });
+
+  it("marks a failure recovered when the same user succeeds within the window", () => {
+    const rows: AuditRow[] = [
+      row(T(0), "a", { ok: false, error: "Code: 60. doesn't exist", sql: "SELECT * FROM biz.foo" }),
+      row(T(2), "a", { ok: true, sql: "SELECT * FROM biz.foos" }),
+    ];
+    const r = mineFriction(rows, { windowMinutes: 15 });
+    expect(r.recoveredFailures).toBe(1);
+    expect(r.recoveryRate).toBeCloseTo(1);
+    expect(r.buckets[0].recovered).toBe(1);
+    expect(r.buckets[0].stuck).toBe(0);
+  });
+
+  it("does NOT count recovery across a session gap larger than the window", () => {
+    const rows: AuditRow[] = [
+      row(T(0), "a", { ok: false, error: "Code: 60. doesn't exist", sql: "SELECT * FROM x" }),
+      row(T(30), "a", { ok: true, sql: "SELECT 1" }), // 30m later = new session
+    ];
+    const r = mineFriction(rows, { windowMinutes: 15 });
+    expect(r.recoveredFailures).toBe(0);
+    expect(r.buckets[0].stuck).toBe(1);
+  });
+
+  it("does not pair a success from a DIFFERENT user as recovery", () => {
+    const rows: AuditRow[] = [
+      row(T(0), "a", { ok: false, error: "Code: 62. Syntax error", sql: "SELECT" }),
+      row(T(1), "b", { ok: true, sql: "SELECT 1" }),
+    ];
+    const r = mineFriction(rows);
+    expect(r.recoveredFailures).toBe(0);
+    expect(r.users).toBe(2);
+  });
+
+  it("sorts buckets by most-stuck first", () => {
+    const rows: AuditRow[] = [
+      // syntax: 2 fails, both stuck (no later success)
+      row(T(0), "a", { ok: false, error: "Code: 62. Syntax error", sql: "SELECT" }),
+      row(T(1), "a", { ok: false, error: "Code: 62. Syntax error", sql: "SELECT" }),
+      // table: 1 fail, recovered
+      row(T(2), "b", { ok: false, error: "Code: 60. doesn't exist", sql: "SELECT * FROM x" }),
+      row(T(3), "b", { ok: true, sql: "SELECT * FROM biz.x" }),
+    ];
+    const r = mineFriction(rows);
+    expect(r.buckets[0].code).toBe("syntax");
+    expect(r.buckets[0].stuck).toBe(2);
+  });
+
+  it("surfaces repeated failing intents as candidate missing metrics", () => {
+    const rows: AuditRow[] = [
+      row(T(0), "a", { ok: false, error: "e", sql: "s", purpose: "monthly churn rate" }),
+      row(T(1), "a", { ok: false, error: "e", sql: "s", purpose: "Monthly Churn Rate" }),
+      row(T(2), "a", { ok: false, error: "e", sql: "s", purpose: "one-off" }),
+    ];
+    const r = mineFriction(rows);
+    expect(r.topFailingIntents[0].count).toBe(2); // case-insensitive grouping
+    expect(r.topFailingIntents[0].purpose.toLowerCase()).toBe("monthly churn rate");
+  });
+});
+
+describe("renderFriction", () => {
+  it("renders an empty-store message when there are no failures", () => {
+    const r = mineFriction([row(T(0), "a", { ok: true, sql: "SELECT 1" })]);
+    expect(renderFriction(r)).toMatch(/No run_query failures/);
+  });
+
+  it("redacts SQL when showSql is false", () => {
+    const rows: AuditRow[] = [
+      row(T(0), "a", { ok: false, error: "Code: 60. x", sql: "SELECT email FROM biz.users WHERE id=42" }),
+    ];
+    const md = renderFriction(mineFriction(rows), { showSql: false });
+    expect(md).not.toMatch(/email FROM biz.users/);
+    const withSql = renderFriction(mineFriction(rows), { showSql: true });
+    expect(withSql).toMatch(/email FROM biz.users/);
+  });
+});

--- a/test/mirror.test.ts
+++ b/test/mirror.test.ts
@@ -2,12 +2,47 @@
 // Pure helpers of the gateway's mirror view (lib/mirror) — the lake-reading
 // side is exercised end-to-end in ingest/pg-mirror/mirror.test.ts.
 import { describe, it, expect } from "bun:test";
-import { mirrorAsOf, referencedBizTables, type MirroredTable } from "../plugin/gateway/lib/mirror";
+import {
+  mirrorAsOf,
+  referencedBizTables,
+  mirrorNameOf,
+  queryableTableName,
+  type MirroredTable,
+} from "../plugin/gateway/lib/mirror";
 
 const TABLES: MirroredTable[] = [
   { target: "orders", source: "public.orders", asOf: "2026-07-03T10:00:00.000Z" },
   { target: "ticketing_seat_txn", source: "ticketing.seat_txn", asOf: "2026-07-03T09:00:00.000Z" },
 ];
+
+describe("mirrorNameOf", () => {
+  it("strips the pg schema, lowercasing for case-insensitive matching by default", () => {
+    expect(mirrorNameOf("public.JobPost")).toBe("jobpost");
+    expect(mirrorNameOf("ticketing.seat_txn")).toBe("ticketing_seat_txn");
+    expect(mirrorNameOf("orders")).toBe("orders");
+  });
+  it("preserves case for a display name (ClickHouse table names are case-sensitive)", () => {
+    expect(mirrorNameOf("public.JobPost", true)).toBe("JobPost");
+    expect(mirrorNameOf("Ticketing.Seat_Txn", true)).toBe("Ticketing_Seat_Txn");
+  });
+});
+
+describe("queryableTableName", () => {
+  it("maps a pg-qualified provenance name to its case-preserved biz.* mirror", () => {
+    expect(queryableTableName("public.JobPost")).toBe("biz.JobPost");
+    expect(queryableTableName("public.Company")).toBe("biz.Company");
+    expect(queryableTableName("ticketing.seat_txn")).toBe("biz.ticketing_seat_txn");
+  });
+  it("passes bare lake/unqualified names through untouched", () => {
+    expect(queryableTableName("mercury_transactions")).toBe("mercury_transactions");
+    expect(queryableTableName("slack_messages")).toBe("slack_messages");
+  });
+  it("leaves already-ClickHouse-qualified names alone (lake db / mirror)", () => {
+    // a lake table documented as setoku.X must NOT become biz.setoku_X
+    expect(queryableTableName("setoku.github_issues")).toBe("setoku.github_issues");
+    expect(queryableTableName("biz.orders")).toBe("biz.orders");
+  });
+});
 
 describe("mirrorAsOf", () => {
   it("is the OLDEST fresh copy — an app is only as current as its stalest input", () => {

--- a/test/queryhint.test.ts
+++ b/test/queryhint.test.ts
@@ -143,12 +143,19 @@ describe("schema-aware unknown-column helpers", () => {
     expect(extractTableRefs("SELECT * FROM (SELECT 1) t")).toEqual([]);
   });
 
-  it("extracts the unknown identifier from ClickHouse and Postgres phrasings", () => {
+  it("extracts the unknown identifier across ClickHouse and Postgres phrasings", () => {
+    // the "or function" variant AND the plain "expression identifier" variant
+    // (modern analyzer) — the plain one used to return the literal "identifier"
     expect(extractUnknownColumn("Code: 47. Unknown expression or function identifier `timestamp` in scope")).toBe("timestamp");
+    expect(extractUnknownColumn("Code: 47. Unknown expression identifier `revenue` in scope SELECT")).toBe("revenue");
+    // the single-quoted "cannot be resolved" form used to return null
+    expect(extractUnknownColumn("Code: 47. Identifier 'u.linkedinUrl' cannot be resolved from table with name u")).toBe("linkedinUrl");
     expect(extractUnknownColumn("Unknown identifier: custmer_id")).toBe("custmer_id");
     expect(extractUnknownColumn('column "salaryMin" does not exist')).toBe("salaryMin");
     // strips a table-alias prefix down to the bare column
     expect(extractUnknownColumn("Unknown identifier `u.resumeUrl`")).toBe("resumeUrl");
+    // never returns the literal word "identifier"
+    expect(extractUnknownColumn("Code: 47. Unknown expression identifier `x` in scope")).not.toBe("identifier");
     expect(extractUnknownColumn("something else entirely")).toBeNull();
   });
 
@@ -166,6 +173,20 @@ describe("schema-aware unknown-column helpers", () => {
     ];
     const m = matchReferencedTables(['biz.JobPost', '"logs_vercel"', "jp"], schema);
     expect(m.map((t) => t.table).sort()).toEqual(["biz.JobPost", "setoku.logs_vercel"]);
+  });
+
+  it("a QUALIFIED ref never drags in a same-named table from another db", () => {
+    const schema = [
+      { database: "biz", table: "events", columns: ["id"] },
+      { database: "setoku", table: "events", columns: ["ts"] },
+    ];
+    // biz.events must match ONLY biz.events, not setoku.events
+    expect(matchReferencedTables(["biz.events"], schema).map((t) => t.table)).toEqual(["biz.events"]);
+    // a bare ref legitimately can't disambiguate — matches both
+    expect(matchReferencedTables(["events"], schema).map((t) => t.table).sort()).toEqual([
+      "biz.events",
+      "setoku.events",
+    ]);
   });
 
   it("renders the columns block and a did-you-mean; null when no tables matched", () => {

--- a/test/queryhint.test.ts
+++ b/test/queryhint.test.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Query-error classification + the live "→ next step" hint appended to
+// run_query failures. The membrane invariant is the load-bearing test: a denied
+// table and a nonexistent one MUST classify + hint identically (I2/I9).
+import { describe, it, expect } from "bun:test";
+import {
+  classifyQueryError,
+  queryErrorHint,
+  extractTableRefs,
+  extractUnknownColumn,
+  nearestColumns,
+  matchReferencedTables,
+  renderColumnHint,
+} from "../plugin/gateway/lib/queryhint";
+
+describe("classifyQueryError", () => {
+  it("buckets the common ClickHouse failure codes", () => {
+    expect(classifyQueryError("Code: 60. DB::Exception: Table biz.foo doesn't exist")).toBe(
+      "table_unavailable",
+    );
+    expect(classifyQueryError("Code: 47. DB::Exception: Unknown identifier: revene")).toBe(
+      "unknown_column",
+    );
+    expect(classifyQueryError("Code: 46. DB::Exception: Unknown function date_trunc")).toBe(
+      "unknown_function",
+    );
+    expect(classifyQueryError("Code: 62. DB::Exception: Syntax error near '::'")).toBe("syntax");
+    expect(classifyQueryError("Code: 159. DB::Exception: Timeout exceeded")).toBe("timeout");
+    expect(classifyQueryError("Code: 241. DB::Exception: Memory limit exceeded")).toBe("memory");
+    expect(classifyQueryError("Code: 53. DB::Exception: Type mismatch")).toBe("type_mismatch");
+  });
+
+  it("buckets our own gate + retirement messages (not 'other')", () => {
+    expect(
+      classifyQueryError('Only read statements are allowed (got "UPDATE"). The connection is READ ONLY;'),
+    ).toBe("read_only");
+    expect(classifyQueryError("Multiple statements (semicolons) are not supported")).toBe(
+      "multi_statement",
+    );
+    expect(
+      classifyQueryError("The direct business-Postgres path is retired — business tables are read via the biz.* ClickHouse mirror"),
+    ).toBe("pg_retired");
+  });
+
+  it("classifies Postgres-phrased and ClickHouse-worded unknown tables", () => {
+    // legacy/retired-path audit rows carry Postgres wording (no Code: N)
+    expect(classifyQueryError('relation "Company" does not exist')).toBe("table_unavailable");
+    expect(
+      classifyQueryError("DB::Exception: Unknown table expression identifier 'User' in scope SELECT"),
+    ).toBe("table_unavailable");
+  });
+
+  it("buckets the curator-session lake-denied rejection distinctly", () => {
+    expect(
+      classifyQueryError(
+        "This is a curator session — reading the lake (clickhouse dialect) is disabled here",
+      ),
+    ).toBe("curator_lake_denied");
+  });
+
+  it("classifies Postgres-phrased timeouts and column errors (legacy rows)", () => {
+    expect(classifyQueryError("canceling statement due to statement timeout")).toBe("timeout");
+    expect(classifyQueryError('column "salaryMin" does not exist')).toBe("unknown_column");
+  });
+
+  it("buckets historical audit sentinels", () => {
+    expect(classifyQueryError("mirror-required")).toBe("mirror_required");
+    expect(classifyQueryError("pg-retired")).toBe("pg_retired");
+  });
+
+  it("classifies the ClickHouse correlated-subquery limitation", () => {
+    expect(
+      classifyQueryError("Code: 1. Resolved identifier 'u.id' in parent scope to expression"),
+    ).toBe("correlated_subquery");
+  });
+
+  it("falls back to 'other' for unrecognized errors", () => {
+    expect(classifyQueryError("Code: 999. Some brand new failure")).toBe("other");
+    expect(classifyQueryError("")).toBe("other");
+  });
+
+  // MEMBRANE (I2/I9): access-denied must be indistinguishable from not-found.
+  it("collapses ACCESS_DENIED and UNKNOWN_TABLE to one code", () => {
+    const denied = classifyQueryError("Code: 497. DB::Exception: ... ACCESS_DENIED: not enough privileges");
+    const missing = classifyQueryError("Code: 60. DB::Exception: Table biz.secret doesn't exist");
+    expect(denied).toBe("table_unavailable");
+    expect(missing).toBe("table_unavailable");
+    expect(denied).toBe(missing);
+  });
+});
+
+describe("queryErrorHint", () => {
+  it("returns a discovery-pointing hint for cryptic engine errors", () => {
+    const h = queryErrorHint("Code: 60. Table biz.foo doesn't exist");
+    expect(h?.code).toBe("table_unavailable");
+    expect(h?.hint).toMatch(/get_schema|SHOW TABLES/);
+  });
+
+  it("gives the SAME hint for a denied table as a missing one (membrane)", () => {
+    const denied = queryErrorHint("Code: 497. ACCESS_DENIED: not enough privileges");
+    const missing = queryErrorHint("Code: 60. Table biz.secret doesn't exist");
+    expect(denied?.hint).toBe(missing?.hint);
+  });
+
+  it("sharpens the syntax hint when a Postgres :: cast is present", () => {
+    const generic = queryErrorHint("Code: 62. Syntax error", "SELECT count(*) FROM biz.t");
+    const cast = queryErrorHint("Code: 62. Syntax error", "SELECT id::text FROM biz.t");
+    expect(generic?.hint).toMatch(/ClickHouse SQL/);
+    expect(cast?.hint).toMatch(/Postgres `::` cast/);
+    expect(cast?.hint).not.toBe(generic?.hint);
+  });
+
+  it("returns null for messages that are already self-explanatory", () => {
+    expect(queryErrorHint("The connection is READ ONLY; writes are rejected.")).toBeNull();
+    expect(queryErrorHint("Multiple statements (semicolons) are not supported")).toBeNull();
+    expect(queryErrorHint("The direct business-Postgres path is retired")).toBeNull();
+  });
+
+  it("returns null for unrecognized errors (no misleading hint)", () => {
+    expect(queryErrorHint("Code: 999. brand new failure")).toBeNull();
+  });
+
+  it("sharpens type_mismatch for the Nullable-in-array case", () => {
+    const nested = queryErrorHint(
+      "Code: 43. Nested type Array(String) cannot be inside Nullable type",
+    );
+    expect(nested?.code).toBe("type_mismatch");
+    expect(nested?.hint).toMatch(/assumeNotNull|coalesce/);
+    // a plain type mismatch keeps the generic cast hint
+    expect(queryErrorHint("Code: 53. Type mismatch")?.hint).toMatch(/cast explicitly/i);
+  });
+});
+
+describe("schema-aware unknown-column helpers", () => {
+  it("extracts table refs from FROM / JOIN (bare, qualified, quoted, aliased)", () => {
+    const refs = extractTableRefs(
+      'SELECT * FROM biz.JobPost jp JOIN setoku.logs_vercel v ON 1 JOIN "Company" WHERE x',
+    );
+    expect(refs).toContain("biz.JobPost");
+    expect(refs).toContain("setoku.logs_vercel");
+    expect(refs).toContain('"Company"');
+    // does not grab the alias or a subquery paren
+    expect(extractTableRefs("SELECT * FROM (SELECT 1) t")).toEqual([]);
+  });
+
+  it("extracts the unknown identifier from ClickHouse and Postgres phrasings", () => {
+    expect(extractUnknownColumn("Code: 47. Unknown expression or function identifier `timestamp` in scope")).toBe("timestamp");
+    expect(extractUnknownColumn("Unknown identifier: custmer_id")).toBe("custmer_id");
+    expect(extractUnknownColumn('column "salaryMin" does not exist')).toBe("salaryMin");
+    // strips a table-alias prefix down to the bare column
+    expect(extractUnknownColumn("Unknown identifier `u.resumeUrl`")).toBe("resumeUrl");
+    expect(extractUnknownColumn("something else entirely")).toBeNull();
+  });
+
+  it("suggests the nearest column, case-insensitively, within an edit budget", () => {
+    expect(nearestColumns("timestamp", ["ts", "level", "message"])).toEqual([]); // too far
+    expect(nearestColumns("custmer_id", ["customer_id", "company_id"])).toEqual(["customer_id"]);
+    // ClickHouse is case-sensitive: salaryMin → salarymin is distance 0 here
+    expect(nearestColumns("salaryMin", ["salarymin", "salarymax"])[0]).toBe("salarymin");
+  });
+
+  it("matches referenced tables by qualified or bare name, quoting-insensitive", () => {
+    const schema = [
+      { database: "biz", table: "JobPost", columns: ["id", "title"] },
+      { database: "setoku", table: "logs_vercel", columns: ["ts", "message"] },
+    ];
+    const m = matchReferencedTables(['biz.JobPost', '"logs_vercel"', "jp"], schema);
+    expect(m.map((t) => t.table).sort()).toEqual(["biz.JobPost", "setoku.logs_vercel"]);
+  });
+
+  it("renders the columns block and a did-you-mean; null when no tables matched", () => {
+    const out = renderColumnHint("custmer_id", [
+      { table: "biz.orders", columns: ["id", "customer_id", "total"] },
+    ]);
+    expect(out).toMatch(/biz\.orders: id, customer_id, total/);
+    expect(out).toMatch(/did you mean `customer_id`/);
+    expect(renderColumnHint("x", [])).toBeNull();
+  });
+});


### PR DESCRIPTION
Agents that mis-drive `run_query` used to get the bare ClickHouse message and re-guess, burning turns. This makes `run_query` self-correcting about schema, aligns the context layer's table names with the query layer, and adds a behavioral way to find where agents get stuck. All generic across deploys — they read each box's own live schema / audit log, no per-tenant config. (Prompted by the HN "designing APIs for agents" thread, item 48894874.)

## #1 — Actionable errors (`lib/queryhint.ts`)
Classify the failure and append a `→ next step` pointing at a discovery tool. **Membrane-safe (I2/I9):** `ACCESS_DENIED` and `UNKNOWN_TABLE` collapse to one code + one hint, so a denied table is never confirmed to exist. Buckets cover the causes seen in production: `unknown_column`, `type_mismatch`, `syntax`/Postgres-isms, `timeout`, `correlated_subquery`, the `curator_lake_denied` membrane, and the `mirror_required`/`pg_retired` audit sentinels.

## #1b — Schema-aware unknown-column help
On an unknown column, surface the referenced tables' **real columns** + a Levenshtein "did you mean". Reads a new `scopedSchema()` helper **extracted from `get_schema`** (same roles + denied-family belt filter), so the augment can reveal nothing `get_schema` wouldn't. `type_mismatch` "cannot be inside Nullable" gets the `assumeNotNull`/`coalesce` idiom.

## #2 — Friction miner (`lib/friction.ts`, `friction-cli.ts`, `bun run eval:friction`)
Mine the audit log for the fail→retry→success pattern, cluster by the same classifier, report per-cause **in-session recovery rate**. A low-recovery cause is where agents stay stuck.

The property that matters here is that it's **grounded in behavior, not self-report**: it reads what agents actually did (tried X, failed, tried Y, worked) instead of asking a model "what confused you?", which the HN thread argues is unreliable introspection. It's also model-free/deterministic — not a correctness constraint for a report you run on demand, but what lets the same script run unattended in CI or on the box (the `eval:*` family it joins) and keeps the *clustering* cheap. The *analysis* of the clusters is expected to be model-read (done for hedgy — see below). Adds `store.auditForTool()`.

## #3 — Align context-layer table names with the query layer (`lib/mirror.ts`)
`find_context` / `list_entities` displayed entity docs' `meta.table` verbatim — `JobPost (public.JobPost)` — while `run_query`/`get_schema` want `biz.JobPost`. That was the last place we handed agents a Postgres-flavored name after the pg-read-path retirement (#87). New `queryableTableName()` maps a pg-qualified provenance name to its **case-preserved** `biz.*` mirror (ClickHouse names are case-sensitive); names already ClickHouse-qualified (`setoku.github_issues` lake table, `biz.orders`) and bare names pass through untouched. `meta.table` keeps its pg provenance in the store (generate/curate cross-reference the app codebase); only the display is bridged. `mirrorNameOf()` moved out of the `buildServer` closure into `lib/mirror.ts` (with a `preserveCase` flag) so it's unit-testable.

## Validation
- 39 new/updated tests (queryhint, friction, mirror); full suite green; typecheck clean.
- Model-read analysis of the miner against hedgy (1175 calls / 103 failures): the pg/ClickHouse-idiom failures are ~all **pre-#87** (jsonb 12→1, `::` 10→1, "relation does not exist" 8→0, `timestamp` 5→0, Nullable 8→0 across the 7/14 boundary). Post-retirement the only recurring live pattern is correlated subqueries (now hinted); the rest is column-name unfamiliarity (#1b handles) plus a real grants gap on `setoku.logs_vercel` (config, not code).
- Deployed to hedgy; hints, augment, and the biz.* names are live (confirmed via MCP `list_entities` — no `public.` names remain).

## Follow-ups
- Cause-branched auto-remediation (#94): alias-column for Setoku-owned lake tables, drafted gotcha for tenant tables. That path *does* touch the box, so I8 is load-bearing there — any model phrasing runs in a curator session, not server-side.
- Check/confirm the `setoku_ro` grants for `setoku.logs_vercel` (the one stuck current failure).

https://claude.ai/code/session_01VSuT53sMy2YUQmz3HUuXeK