### PR TITLE
Site: agent discovery surface, generated llms.txt, and /docs (was /developers)

### DIFF
--- a/deploy/caddy.d/setoku-com.caddy
+++ b/deploy/caddy.d/setoku-com.caddy
@@ -25,17 +25,83 @@ setoku.com {
 	encode gzip
 	root * /etc/caddy/conf.d/site
 
-	# Agents fetch these cross-origin (an OpenAPI spec is useless if the fetch is
-	# blocked by CORS). Everything under these paths is public documentation for
-	# an open-source project, so `*` costs nothing.
-	header /openapi.json Access-Control-Allow-Origin *
-	header /llms.txt Access-Control-Allow-Origin *
-	header /api/* Access-Control-Allow-Origin *
+	# Agents fetch this site cross-origin (an OpenAPI spec is useless if the fetch
+	# is blocked by CORS). One unmatched rule rather than a list of paths: every
+	# document here is public documentation for an open-source project, so `*`
+	# costs nothing — and the per-path version left each newly published file
+	# uncovered until someone remembered to extend it, which is how /sitemap.xml
+	# (the file that ENUMERATES the discovery documents) ended up with no CORS
+	# header at all.
+	header Access-Control-Allow-Origin *
 
-	# /developers without the trailing slash, rewritten rather than redirected so
+	# The markdown twins (/index.md, /docs.md). Go's mime table has no entry
+	# for .md, so without this the file_server sniffs and serves them as
+	# text/plain — and a client deciding whether it got markdown looks at the
+	# content type, not the extension.
+	@md path *.md
+	header @md Content-Type "text/markdown; charset=utf-8"
+
+	# /docs without the trailing slash, rewritten rather than redirected so
 	# the canonical URL in the page's <link rel=canonical> is the one that serves.
-	@developers path /developers
-	rewrite @developers /developers/index.html
+	@docs path /docs
+	rewrite @docs /docs/index.html
+
+	# ?mode=agent — hand an agent the markdown twin of the page it asked for,
+	# instead of a page of marketing HTML it has to strip tags out of. Scoped to
+	# the two pages that HAVE a twin: `/openapi.json?mode=agent` must keep
+	# answering with JSON, so this cannot be a site-wide rule.
+	#
+	# The Content-Type is set INSIDE the handle, not by the @md matcher above:
+	# `header` runs before `rewrite` in Caddy's directive order, so at that point
+	# the path is still `/` and a path matcher on *.md would miss.
+	@agent_home expression {query.mode} == "agent" && path("/", "/index.html")
+	handle @agent_home {
+		header Content-Type "text/markdown; charset=utf-8"
+		rewrite * /index.md
+		file_server
+	}
+	# `/docs/index.html` is in the list because the @docs rewrite above has already
+	# fired by the time this matcher is evaluated (`rewrite` sorts before
+	# `handle`), so the path is no longer the one the client asked for.
+	@agent_docs expression {query.mode} == "agent" && path("/docs", "/docs/", "/docs/index.html")
+	handle @agent_docs {
+		header Content-Type "text/markdown; charset=utf-8"
+		rewrite * /docs.md
+		file_server
+	}
+
+	# Errors are JSON unless a browser asked for HTML. Nothing here is an API in
+	# the write sense, but agents probe this host with fetch(), and an HTML error
+	# page is unparseable to them: they get a 404 they cannot distinguish from a
+	# malformed document. Codes and hints, not prose.
+	handle_errors {
+		@browser header_regexp Accept text/html
+		handle @browser {
+			rewrite * /404.html
+			file_server
+		}
+		# The bodies interpolate no request data. {path} would read better, but it
+		# is not JSON-escaped by Caddy, so a request for /%22 would emit a body
+		# that no longer parses — an unparseable error is the exact thing this
+		# block exists to stop.
+		#
+		# Two bodies rather than one templated by `map`: map's outputs come back
+		# empty inside handle_errors (verified against caddy:2), and a JSON error
+		# whose `code` field is silently blank is worse than a duplicated string.
+		@notfound expression {err.status_code} == 404
+		handle @notfound {
+			header Content-Type "application/json; charset=utf-8"
+			header Access-Control-Allow-Origin *
+			respond `{"ok":false,"error":{"code":"not_found","status":404,"message":"No document at that path on setoku.com.","hint":"setoku.com serves the documentation, the OpenAPI spec, and the discovery files. The Setoku API itself runs on your own box, not here: see https://setoku.com/docs. Everything this site publishes is listed at https://setoku.com/api/index.json.","docs":"https://setoku.com/docs","index":"https://setoku.com/api/index.json"}}
+` 404
+		}
+		handle {
+			header Content-Type "application/json; charset=utf-8"
+			header Access-Control-Allow-Origin *
+			respond `{"ok":false,"error":{"code":"request_failed","status":{err.status_code},"message":"That request failed on setoku.com.","hint":"Retry; if it persists, this is a bug in the site, not in your client. Report it at https://github.com/Hedgy-Labs/setoku/issues or mail hello@setoku.com.","docs":"https://setoku.com/docs","index":"https://setoku.com/api/index.json"}}
+` {err.status_code}
+		}
+	}
 
 	# NOTE: deliberately NO `try_files {path} {path}/ /index.html` here.
 	# That SPA-style fallback answered *every* unknown path with 200 + the

--- a/scripts/build-site-api.ts
+++ b/scripts/build-site-api.ts
@@ -9,6 +9,12 @@
 //   site/api/index.json      catalog root: what Setoku is, how to install it
 //   site/api/tools.json      the MCP tool surface, with the role each tool needs
 //   site/api/connectors.json the sources that land in the lake
+//   site/.well-known/mcp.json                    where the MCP server is, how to auth
+//   site/.well-known/agent-card.json             A2A-style card: who we are, what we do
+//   site/.well-known/agent-skills/index.json     the shipped skills, name + description
+//   site/index.md            markdown twin of the homepage (agents fetch this)
+//   site/docs.md             markdown twin of /docs (the API reference)
+//   site/llms.txt            the prose entry point, sharing one when-to-use source
 //
 // These are DERIVED (version from the plugin manifest, tools + their capability
 // gating from gateway/app.ts, connectors from ingest/schemas) so they cannot
@@ -19,7 +25,12 @@
 // Usage:  bun run build:site
 import { mkdirSync } from "node:fs";
 
-import { DEMO_MCP_URL } from "../demo/connector";
+import {
+  DEMO_BASE_URL,
+  DEMO_MCP_URL,
+  DEMO_PUBLIC_APPS,
+  demoAppUrl,
+} from "../demo/connector";
 
 const ROOT = new URL("..", import.meta.url).pathname;
 const SITE = "https://setoku.com";
@@ -101,7 +112,7 @@ async function tools(): Promise<
  * an entry with no matching schema is dropped, and a schema matching no entry is
  * a hard error. Without that second direction this was a hardcoded array wearing
  * a derivation costume: adding ingest/schemas/090_stripe_charges.sql would have
- * changed nothing, and /developers tells agents this file "tracks the release".
+ * changed nothing, and /docs tells agents this file "tracks the release".
  */
 const CONNECTOR_CATALOG: { id: string; name: string; data: string; match: RegExp }[] = [
   { id: "postgres", name: "PostgreSQL", data: "your app database, mirrored read-only into biz.*", match: /pg_mirror/ },
@@ -139,6 +150,36 @@ async function connectors(): Promise<{ id: string; name: string; data: string }[
   );
 }
 
+/**
+ * The shipped skills, read out of each `plugin/skills/<name>/SKILL.md`.
+ *
+ * These are what an agent can actually be asked to do with Setoku, so they are
+ * what the discovery files publish as "capabilities". Derived rather than
+ * restated: adding a skill directory publishes it, and a skill whose frontmatter
+ * lost its description is a hard error rather than a blank entry on a public URL.
+ */
+async function skills(): Promise<{ id: string; name: string; description: string }[]> {
+  const glob = new Bun.Glob("*/SKILL.md");
+  const found: { id: string; name: string; description: string }[] = [];
+  for await (const f of glob.scan({ cwd: ROOT + "plugin/skills" })) {
+    const dir = f.split("/")[0];
+    const src = await read(`plugin/skills/${f}`);
+    const fm = src.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? "";
+    const name = fm.match(/^name:\s*(.+)$/m)?.[1]?.trim();
+    const description = fm.match(/^description:\s*(.+)$/m)?.[1]?.trim();
+    if (!name || !description) {
+      throw new Error(
+        `build-site-api: plugin/skills/${dir}/SKILL.md has no ${name ? "description" : "name"} in ` +
+          `its frontmatter. The skill index at ${SITE}/.well-known/agent-skills/index.json is ` +
+          `derived from it, and an entry with a missing name or description is worse than no ` +
+          `entry — agents parse that file to decide whether to reach for us.`,
+      );
+    }
+    found.push({ id: `setoku:${name}`, name, description });
+  }
+  return found.sort((a, b) => a.name.localeCompare(b.name));
+}
+
 /* --------------------------------- OpenAPI -------------------------------- */
 
 /**
@@ -165,9 +206,9 @@ function openapi(toolNames: string[]) {
         `${toolNames.length} tools (see https://setoku.com/api/tools.json). The REST endpoints ` +
         "below are the credential-free surface: box health, and published apps.",
       license: { name: "Apache-2.0", identifier: "Apache-2.0" },
-      contact: { name: "Setoku", url: `${SITE}/developers`, email: "hello@setoku.com" },
+      contact: { name: "Setoku", url: `${SITE}/docs`, email: "hello@setoku.com" },
     },
-    externalDocs: { description: "Setoku developer documentation", url: `${SITE}/developers` },
+    externalDocs: { description: "Setoku API reference", url: `${SITE}/docs` },
     servers: [
       {
         url: "https://{host}",
@@ -193,7 +234,7 @@ function openapi(toolNames: string[]) {
             "field. The token identifies one person and is revocable from the box's web console. " +
             "Treat the whole URL as a credential, like a database connection string.\n\n" +
             "OAuth 2.0 is scoped but deliberately not shipped; see " +
-            "https://setoku.com/developers#auth.",
+            "https://setoku.com/docs#auth.",
         },
       },
       schemas: {
@@ -436,6 +477,537 @@ function openapi(toolNames: string[]) {
   };
 }
 
+/* ----------------------------- agent discovery ---------------------------- */
+
+type Tool = { name: string; title: string; role: string; readOnly: boolean };
+type Skill = { id: string; name: string; description: string };
+type Connector = { id: string; name: string; data: string };
+
+/**
+ * WHEN TO USE SETOKU — the single most useful paragraph on this whole site for a
+ * machine reader, and the one thing marketing copy never says out loud. Every
+ * discovery file (llms.txt, the agent card, the skill index, index.md) states
+ * the same three lists, so an agent gets the same answer wherever it looks.
+ *
+ * Kept honest in both directions: what Setoku is *wrong* for is published next
+ * to what it is right for, because an agent that reaches for us on a question we
+ * cannot answer wastes a turn and then distrusts the next answer too.
+ */
+const WHEN_TO_USE = {
+  summary:
+    "Reach for Setoku when the answer lives in a specific company's own data and depends on " +
+    "that company's definitions.",
+  use_when: [
+    "A question is about one company's own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.",
+    "You need the company's definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.",
+    "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.",
+    "Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.",
+    "You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner's own box.",
+  ],
+  do_not_use_when: [
+    "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
+    "You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
+    "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
+    "You want a model to run server-side. Setoku runs no inference; your own agent does the thinking.",
+  ],
+  how_to_call: [
+    "Connect to the box's MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person's bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.",
+    "Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.",
+    "Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.",
+    "Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself.",
+  ],
+} as const;
+
+/** Where the MCP server actually is. Advertised at the conventional well-known
+ *  path so an agent can find the endpoint without reading an OpenAPI document. */
+function mcpManifest(toolList: Tool[]) {
+  return {
+    // No `$schema`: it used to point at this very URL, so anything that
+    // dereferenced it to validate got the instance back instead of a schema.
+    // There is no published schema this document conforms to, and naming one we
+    // do not follow would be the same lie in the other direction.
+    name: "setoku",
+    title: "Setoku",
+    description:
+      "Self-hosted MCP knowledge server: a read-only, audited view of one company's data plus " +
+      "the curated context needed to use it correctly.",
+    version: VERSION,
+    license: "Apache-2.0",
+    repository: { url: REPO, source: "github" },
+    documentation: `${SITE}/docs`,
+    when_to_use: WHEN_TO_USE,
+    // `remotes` follows the MCP registry's server.json shape. There is no
+    // setoku.com MCP server to list here: the product is single-tenant, so the
+    // endpoint an agent connects to is the operator's own box. The demo box is a
+    // real, reachable instance of exactly that.
+    remotes: [
+      {
+        type: "streamable-http",
+        url: "https://{host}/mcp",
+        description:
+          "Your own Setoku box. `host` is the hostname you deployed to; there is no hosted service.",
+        headers: [
+          {
+            name: "Authorization",
+            description: "Bearer <your connector token>, issued and revoked from the box's console.",
+            is_required: true,
+            is_secret: true,
+          },
+        ],
+      },
+      {
+        type: "streamable-http",
+        url: DEMO_MCP_URL,
+        description:
+          "Public demo box (synthetic pro-sports-club dataset). The token is public on purpose, " +
+          "read-only, and carries the analyst role. Callable right now, no signup.",
+      },
+    ],
+    auth: { type: "bearer", oauth2: false, accepted_in: ["authorization-header", "url-path"] },
+    tools: toolList,
+    tool_catalog: `${SITE}/api/tools.json`,
+    openapi: `${SITE}/openapi.json`,
+    note: "Generated by scripts/build-site-api.ts from the Setoku source tree — do not edit by hand.",
+  };
+}
+
+/**
+ * An A2A-style agent card. Honest about the transport: the URL below speaks MCP
+ * over Streamable HTTP, not the A2A task protocol — we publish the card because
+ * it is where agents look for "who is this and what can it do", and a card that
+ * quietly implied an A2A task endpoint we never built would be the same kind of
+ * lie the OpenAPI spec is tested against (see "does not claim OAuth support we
+ * have not built" in test/site-api.test.ts).
+ */
+function agentCard(skillList: Skill[], toolList: Tool[]) {
+  return {
+    protocolVersion: "0.3.0",
+    name: "Setoku",
+    description:
+      "Setoku makes an AI agent fluent in one company's data. It serves the company's curated " +
+      "context (metric definitions, gotchas, which table to trust) and a governed read-only " +
+      "query path into their warehouse, so an agent can answer business questions correctly and " +
+      "publish live views of the result. Self-hosted and single-tenant: the agent you are " +
+      "talking to runs on the operator's own box.",
+    version: VERSION,
+    provider: { organization: "Hedgy Labs", url: SITE },
+    documentationUrl: `${SITE}/docs`,
+    iconUrl: `${SITE}/assets/setoku-mark.svg`,
+    // The endpoint is MCP, so `url` is a real, callable address — but it must not
+    // be labelled with an A2A transport. `preferredTransport: "JSONRPC"` would
+    // send an A2A client into a `message/send` against a server that answers
+    // method-not-found, and it would blame us for being broken rather than for
+    // speaking a different protocol; the prose note below is not something any
+    // client parses. A transport value outside the A2A enum makes a conforming
+    // client skip the card, which is the correct outcome: we do not implement
+    // A2A, and being skipped beats being miscalled.
+    url: DEMO_MCP_URL,
+    preferredTransport: "MCP-STREAMABLE-HTTP",
+    additionalInterfaces: [
+      { transport: "MCP-STREAMABLE-HTTP", url: DEMO_MCP_URL },
+      { transport: "MCP-STREAMABLE-HTTP", url: "https://{host}/mcp" },
+    ],
+    transportNote:
+      "This card describes an MCP server, not an A2A agent. `url` speaks JSON-RPC 2.0 over MCP " +
+      "Streamable HTTP (protocol revision 2025-06-18) and implements no A2A method: initialize " +
+      "an MCP session against it rather than sending A2A tasks. The URL shown is the public demo " +
+      "box — for a real deployment, substitute your own host.",
+    capabilities: { streaming: true, pushNotifications: false, stateTransitionHistory: false },
+    defaultInputModes: ["application/json", "text/plain"],
+    defaultOutputModes: ["application/json", "text/plain", "text/html"],
+    securitySchemes: {
+      bearerToken: {
+        type: "http",
+        scheme: "bearer",
+        description:
+          "Per-person connector token, revocable from the box's console. The public demo token " +
+          "above is read-only and intentionally published.",
+      },
+    },
+    security: [{ bearerToken: [] }],
+    whenToUse: WHEN_TO_USE,
+    skills: [
+      ...skillList.map((s) => ({
+        id: s.id,
+        name: s.name,
+        description: s.description,
+        tags: ["setoku", "mcp", "company-data", s.name],
+        examples: [`/setoku:${s.name}`],
+      })),
+      {
+        id: "setoku:answer",
+        name: "answer",
+        description:
+          "Answer a question about the operator's own business data: retrieve the curated " +
+          "context for it (find_context), read the schema, then run a governed read-only query.",
+        tags: ["setoku", "mcp", "analytics", "sql", "company-data"],
+        examples: [
+          "What did we bill last month, using our definition of billed revenue?",
+          "Which accounts churned in Q2, excluding the test tenant?",
+        ],
+      },
+      {
+        id: "setoku:publish-app",
+        name: "publish-app",
+        description:
+          "Build a small live app or dashboard over that data and publish it to a link the " +
+          "whole team can open, refreshing against real data.",
+        tags: ["setoku", "mcp", "dashboard", "app", "sharing"],
+        examples: ["Turn that into a dashboard the sales team can watch."],
+      },
+    ],
+    tools: toolList.map((t) => ({ name: t.name, description: t.title, role: t.role })),
+    note: "Generated by scripts/build-site-api.ts from the Setoku source tree — do not edit by hand.",
+  };
+}
+
+/** The Agent Skills index: the workflows Setoku ships, each with a name and a
+ *  description, at the path agents probe for them. */
+function agentSkillsIndex(skillList: Skill[]) {
+  return {
+    name: "Setoku",
+    description:
+      "Skills for connecting an AI agent to one company's data and keeping the knowledge behind " +
+      "it correct. They ship in the Setoku Claude Code plugin and run against a Setoku box.",
+    version: VERSION,
+    license: "Apache-2.0",
+    homepage: SITE,
+    documentation: `${SITE}/docs`,
+    when_to_use: WHEN_TO_USE,
+    install: ["/plugin marketplace add Hedgy-Labs/setoku", "/plugin install setoku@setoku"],
+    skills: skillList.map((s) => ({
+      name: s.name,
+      id: s.id,
+      description: s.description,
+      command: `/setoku:${s.name}`,
+      source: `${REPO}/blob/main/plugin/skills/${s.name}/SKILL.md`,
+    })),
+    note: "Generated by scripts/build-site-api.ts from the Setoku source tree — do not edit by hand.",
+  };
+}
+
+/* ------------------------------ markdown twins ---------------------------- */
+
+/**
+ * A shared string, on its way into markdown prose. Two jobs:
+ *
+ * 1. Curly apostrophes. Site copy uses ’ (see CLAUDE.md) but the JSON artifacts
+ *    have always used the ASCII one, and these pages reuse the very same
+ *    strings — so the conversion happens here rather than at the source.
+ * 2. Escaping `<`. A bare `<their-box>` or `<source>` is a valid raw-HTML tag in
+ *    CommonMark: every renderer SWALLOWS it, which silently deleted the host and
+ *    token out of the one instruction the page most needs to get right
+ *    (`https://<their-box>/mcp/<token>` rendered as `https:///mcp/`). Skill
+ *    descriptions come from SKILL.md frontmatter, so escaping is the only fix
+ *    that covers text this file does not own.
+ *
+ * Backtick spans are left alone in both cases: inside a code span `<` is already
+ * literal, and the shell quoting in the code samples (`-d '{"jsonrpc":…}'`) must
+ * survive untouched.
+ */
+const prose = (s: string): string =>
+  s
+    .split("`")
+    .map((seg, i) =>
+      i % 2 === 1 ? seg : seg.replace(/(\w)'(\w)/g, "$1’$2").replace(/</g, "\\<"),
+    )
+    .join("`");
+
+const bullets = (xs: readonly string[]) => xs.map((x) => `- ${prose(x)}`).join("\n");
+const steps = (xs: readonly string[]) => xs.map((x, i) => `${i + 1}. ${prose(x)}`).join("\n");
+
+/**
+ * `/index.md` — the homepage, as one canonical markdown document.
+ *
+ * Not a scrape of index.html: it is generated from the same derived facts the
+ * JSON artifacts are (version, tools, connectors, demo connector), so the two
+ * can disagree in tone but never in fact.
+ */
+function indexMarkdown(toolList: Tool[], connectorList: Connector[], skillList: Skill[]) {
+  return `# Setoku
+
+> Make any AI fluent in your company data.
+
+Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives an AI agent a read-only, audited view of a company’s data plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
+
+Version ${VERSION} · Apache-2.0 · <${REPO}>
+
+This is the markdown twin of <${SITE}/>. The API reference is <${SITE}/docs> (markdown: <${SITE}/docs.md>).
+
+## When to use Setoku
+
+${prose(WHEN_TO_USE.summary)}
+
+Use it when:
+
+${bullets(WHEN_TO_USE.use_when)}
+
+Do not use it when:
+
+${bullets(WHEN_TO_USE.do_not_use_when)}
+
+## How an agent calls it
+
+${steps(WHEN_TO_USE.how_to_call)}
+
+## Try it without installing anything
+
+The demo box is wired to a synthetic pro-sports-club dataset (ticketing, sponsorship, concessions, payroll, broadcast rights) for a fictional club, the Bonita Bulldogs. Add this as a custom MCP connector:
+
+    ${DEMO_MCP_URL}
+
+The token is public on purpose: read-only, analyst role, synthetic data.
+
+${DEMO_PUBLIC_APPS.map((a) => `- [${a.title}](${demoAppUrl(a.id)}) — ${a.blurb}, published by an agent and running on live demo data.`).join("\n")}
+- [Demo box health](${DEMO_BASE_URL}/healthz) — a credential-free REST endpoint, if you want to see the shape of the API before you connect.
+
+## Install
+
+Claude Code plugin, from your project directory:
+
+    /plugin marketplace add Hedgy-Labs/setoku
+    /plugin install setoku@setoku
+    /setoku:onboard
+
+Server, by hand, on a fresh Ubuntu VPS (about $5–12/month):
+
+    git clone ${REPO} /opt/setoku
+    cd /opt/setoku
+    SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh
+
+## The tool surface
+
+${toolList.length} MCP tools. Which ones a session sees depends on its token’s role — that split is the security model, not a convenience.
+
+| Tool | What it does | Role |
+| --- | --- | --- |
+${toolList.map((t) => `| \`${t.name}\` | ${prose(t.title)} | ${t.role} |`).join("\n")}
+
+## Skills
+
+${skillList.map((s) => `- \`/setoku:${s.name}\` — ${prose(s.description)}`).join("\n")}
+
+## Connectors
+
+${connectorList.map((c) => `- **${c.name}** — ${c.data}`).join("\n")}
+
+No connector for yours? \`/setoku:connect\` gives a coding agent the patterns to wire one up.
+
+## Security model
+
+- **Two identities, one membrane.** An analyst token may query the lake but holds no tool that commits knowledge. A curator token may commit knowledge but cannot read the lake. They never coexist on one session, so a prompt-injected session cannot weaponize the write path.
+- **Accepting knowledge is a human click** on the box’s admin page, outside the agent loop. No MCP tool creates users, grants access, or commits knowledge on its own.
+- **Reads are governed by database roles**, not by parsing SQL in our code. The engine enforces it.
+- **The credential never reaches the model.** Config names an environment variable; the gateway resolves it.
+- **No model runs on the server**, so there is no inference cost and no AI API key on the box.
+
+## Machine-readable index
+
+- [OpenAPI 3.1](${SITE}/openapi.json) — the gateway HTTP API
+- [MCP manifest](${SITE}/.well-known/mcp.json) — endpoint, transport, auth
+- [Agent card](${SITE}/.well-known/agent-card.json) — who we are, what we do
+- [Agent skills index](${SITE}/.well-known/agent-skills/index.json)
+- [Catalog root](${SITE}/api/index.json) · [tools](${SITE}/api/tools.json) · [connectors](${SITE}/api/connectors.json)
+- [llms.txt](${SITE}/llms.txt)
+
+Contact: hello@setoku.com · Issues: <${REPO}/issues>
+`;
+}
+
+/**
+ * `/llms.txt` — the prose entry point, generated for the same reason the rest of
+ * this file is.
+ *
+ * It used to be hand-written, with the when-to-use guidance retyped by hand from
+ * `WHEN_TO_USE` and pinned by a single sentence fragment in the tests. That is
+ * the drift shape this whole script exists to prevent: edit the constant, run
+ * the build, and llms.txt would keep publishing the old rule while every test
+ * stayed green — so the file an agent reads FIRST would be the one document
+ * disagreeing with the rest.
+ */
+function llmsTxt(skillList: Skill[]) {
+  return `# Setoku
+
+> Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives any AI agent a read-only, audited view of your company’s data plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
+
+Setoku is single-tenant on purpose. There is no hosted Setoku service and no multi-tenant API: you run it on a box you own (one small VPS), and your data and your context stay there. That is the point of the product, not a gap in it. So the API described below is the API that *your* deployment exposes, not one hosted at setoku.com.
+
+The primary interface is MCP over Streamable HTTP at \`/mcp\` on your box. Any MCP client can use it: Claude, Claude Code, Codex, or your own. Authentication is a per-person bearer token, revocable from the box’s web console. No AI model runs on the server, so there is no inference cost and no AI API key.
+
+Two identities share one server and never overlap. An **analyst** token may query the data lake but holds no tool that commits knowledge. A **curator** token may commit knowledge but cannot read the lake. Accepting proposed knowledge is a human click on the admin page, outside the agent loop, so a prompt-injected session cannot rewrite what Setoku knows.
+
+## When to use Setoku
+
+${prose(WHEN_TO_USE.summary)}
+
+Use it when:
+
+${bullets(WHEN_TO_USE.use_when)}
+
+Do not use it when:
+
+${bullets(WHEN_TO_USE.do_not_use_when)}
+
+How an agent should call it:
+
+${steps(WHEN_TO_USE.how_to_call)}
+
+The same guidance, machine-readable, is in [/.well-known/mcp.json](${SITE}/.well-known/mcp.json), [/.well-known/agent-card.json](${SITE}/.well-known/agent-card.json), and [/.well-known/agent-skills/index.json](${SITE}/.well-known/agent-skills/index.json).
+
+## Setoku developer resources
+
+- [Setoku API reference](${SITE}/docs): the HTTP API, authentication, the MCP tool surface, quickstart, and the security model. Markdown twin: [/docs.md](${SITE}/docs.md).
+- [Setoku homepage in markdown](${SITE}/index.md): the whole product page as one canonical markdown document, no HTML to parse. Both content pages — this one and /docs — also answer \`?mode=agent\` with their markdown twin; the JSON documents below answer as themselves.
+- [Setoku MCP manifest](${SITE}/.well-known/mcp.json): where the MCP server is, which transport it speaks, and how to authenticate.
+- [Setoku agent card](${SITE}/.well-known/agent-card.json): what Setoku is for, its skills, and the endpoint to call.
+- [Setoku agent skills index](${SITE}/.well-known/agent-skills/index.json): the shipped skills, each with a name and a description.
+- [Setoku OpenAPI specification](${SITE}/openapi.json): OpenAPI 3.1 for the Setoku gateway HTTP API, covering the MCP endpoint, health, published apps, and the installer. Mirrored at [/api/openapi.json](${SITE}/api/openapi.json).
+- [Setoku catalog API](${SITE}/api/index.json): machine-readable product metadata — version, install commands, every document this site publishes, and how to reach the MCP endpoint.
+- [Setoku MCP tool catalog](${SITE}/api/tools.json): every MCP tool, with the role each one requires.
+- [Setoku connector catalog](${SITE}/api/connectors.json): the data sources Setoku ingests.
+- [Setoku source repository](${REPO}): Apache-2.0, the full server, skills, and deploy scripts.
+
+## Try Setoku without installing it
+
+- [Setoku public demo](${SITE}/#demo): a live box wired to a synthetic pro-sports-club dataset (ticketing, sponsorship, concessions, payroll, broadcast rights). Add \`${DEMO_MCP_URL}\` as a custom MCP connector. The token is public on purpose and read-only.
+${DEMO_PUBLIC_APPS.map((a) => `- [Setoku demo app: ${prose(a.title)}](${demoAppUrl(a.id)}): ${prose(a.blurb)}, built and published by an agent on live demo data.`).join("\n")}
+- [Setoku demo box health](${DEMO_BASE_URL}/healthz): a real, credential-free REST endpoint you can call right now to see the shape of the API.
+
+## Install Setoku
+
+- [Setoku quickstart](${SITE}/#quickstart): add the Claude Code plugin (\`/plugin marketplace add Hedgy-Labs/setoku\`), then run \`/setoku:onboard\` from your project directory.
+- [Setoku manual server setup](${SITE}/docs#install): clone the repo onto a fresh Ubuntu VPS and run \`deploy/bootstrap.sh\`.
+
+## Setoku skills
+
+${skillList.map((s) => `- \`/setoku:${s.name}\`: ${prose(s.description)}`).join("\n")}
+
+## Optional
+
+- [Setoku architecture](${SITE}/#architecture): how the gateway, the ClickHouse lake, and the knowledge store fit together on one box.
+- [Setoku security model](${SITE}/#security): what the token is, why reads are governed by database roles rather than by parsing SQL, and why writes pass through a person.
+- [Setoku issue tracker](${REPO}/issues): bugs and feature requests.
+- Contact: hello@setoku.com
+`;
+}
+
+/** `/docs.md` — the API reference, as markdown. Same derivation. */
+function docsMarkdown(toolList: Tool[], spec: ReturnType<typeof openapi>) {
+  const byRole = (role: string) => toolList.filter((t) => t.role === role);
+  const paths = Object.entries(spec.paths).flatMap(([p, ops]) =>
+    Object.entries(ops as Record<string, { summary?: string; security?: unknown[] }>).map(
+      ([method, op]) => ({
+        route: `${method.toUpperCase()} ${p}`,
+        summary: op.summary ?? "",
+        auth: op.security && (op.security as unknown[]).length === 0 ? "none" : "bearer",
+      }),
+    ),
+  );
+  return `# Setoku API reference
+
+The HTTP API, authentication, and the MCP tool surface for Setoku ${VERSION}. This is the markdown twin of <${SITE}/docs>.
+
+Setoku is single-tenant and self-hosted: **there is no setoku.com API**. Everything below describes the API *your own box* exposes once you deploy it, and the public demo box (\`${DEMO_BASE_URL}\`) is a real instance of it.
+
+## When to reach for Setoku
+
+${prose(WHEN_TO_USE.summary)}
+
+${bullets(WHEN_TO_USE.use_when)}
+
+Not a fit when:
+
+${bullets(WHEN_TO_USE.do_not_use_when)}
+
+## MCP endpoint
+
+Transport: **Streamable HTTP**, at \`POST /mcp\`. Protocol revision 2025-06-18. Any MCP client works: Claude, Claude Code, Codex, or your own.
+
+    curl -sS -X POST https://<your-box>/mcp \\
+      -H "Authorization: Bearer <token>" \\
+      -H "Content-Type: application/json" \\
+      -H "Accept: application/json, text/event-stream" \\
+      -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+
+Callable right now against the demo box:
+
+    ${DEMO_MCP_URL}
+
+## Authentication
+
+- A per-person **bearer token**, sent as \`Authorization: Bearer <token>\` — or as a path segment (\`/mcp/<token>\`) for connector dialogs with nowhere to put a header. Treat the whole URL as a credential.
+- Tokens are issued and revoked from the box’s web console. Every call is attributed to one person in the audit log.
+- **OAuth 2.0 is not shipped.** It is scoped; it does not exist yet. Do not build against it.
+- A missing, unknown, or revoked token is a \`401\`, before any tool runs. See [Errors](#errors) for the shapes.
+
+## Tool surface
+
+${steps(WHEN_TO_USE.how_to_call)}
+
+**Every session** — the analyst surface. Reads data and curated context, and may only *propose* knowledge changes:
+
+${byRole("analyst").map((t) => `- \`${t.name}\`${t.readOnly ? "" : " (writes)"} — ${prose(t.title)}`).join("\n")}
+
+**Curator sessions only.** Commits curated knowledge:
+
+${byRole("curator").map((t) => `- \`${t.name}\` — ${prose(t.title)}`).join("\n")}
+
+**Janitor sessions only.** Drafts and auto-rejects pending corrections, commits nothing:
+
+${byRole("janitor").map((t) => `- \`${t.name}\` — ${prose(t.title)}`).join("\n")}
+
+A session has exactly one role, and the two role-scoped groups are *registered* only for that role: a session without it does not get a refusal, the tool is simply absent from its \`tools/list\`.
+
+The analyst tools are registered on every session, including a curator one — the membrane’s other half is enforced at call time instead. A curator session can commit knowledge but cannot read the data lake: \`run_query\` refuses lake queries and \`list_sources\` tells you to switch connectors. So the session that can rewrite what Setoku knows is never the session that has read untrusted bulk text (I2).
+
+## REST surface
+
+Credential-free unless marked. Full spec: <${SITE}/openapi.json>.
+
+| Endpoint | What it returns | Auth |
+| --- | --- | --- |
+${paths.map((p) => `| \`${p.route}\` | ${prose(p.summary)} | ${p.auth} |`).join("\n")}
+
+## Errors
+
+Three different surfaces, three shapes. Branch on the HTTP status; do not expect one envelope everywhere.
+
+**The box’s REST endpoints** answer with \`ok: false\` and a human-readable string. There is no error code to switch on — the status line is the machine-readable part:
+
+    { "ok": false, "error": "app not found or archived" }
+
+**MCP tools** return their failure as the tool result, per the MCP specification, not as an HTTP error: the call is \`200\` and the content carries the message. \`run_query\` failures are written to be actionable — they name the table or column that did not resolve and what to call instead. A missing, unknown, or revoked token is the exception: that is a plain \`401\` before any tool runs.
+
+**setoku.com itself** (this site, not your box) answers non-HTML requests with a structured document, so an agent probing the docs surface gets something it can parse:
+
+    {
+      "ok": false,
+      "error": {
+        "code": "not_found",
+        "status": 404,
+        "message": "No document at that path on setoku.com.",
+        "hint": "…",
+        "docs": "https://setoku.com/docs",
+        "index": "https://setoku.com/api/index.json"
+      }
+    }
+
+## Install a box
+
+    git clone ${REPO} /opt/setoku
+    cd /opt/setoku
+    SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh
+
+One small VPS. Docker Compose brings up the gateway, Caddy (HTTPS), and a local ClickHouse lake. No model runs on the server.
+
+## More
+
+- [OpenAPI 3.1](${SITE}/openapi.json) · [MCP manifest](${SITE}/.well-known/mcp.json) · [agent card](${SITE}/.well-known/agent-card.json) · [skills index](${SITE}/.well-known/agent-skills/index.json)
+- [Tool catalog](${SITE}/api/tools.json) · [connector catalog](${SITE}/api/connectors.json) · [catalog root](${SITE}/api/index.json)
+- [Source](${REPO}) · [issues](${REPO}/issues) · hello@setoku.com
+`;
+}
+
 /* --------------------------------- emit ----------------------------------- */
 
 /**
@@ -450,13 +1022,13 @@ function openapi(toolNames: string[]) {
 export async function buildArtifacts(): Promise<[string, unknown][]> {
 const toolList = await tools();
 const connectorList = await connectors();
+const skillList = await skills();
 const spec = openapi(toolList.map((t) => t.name));
 
 const NOTE =
   "Generated by scripts/build-site-api.ts from the Setoku source tree — do not edit by hand.";
 
 const index = {
-  $schema: `${SITE}/api/index.json`,
   name: "Setoku",
   tagline: "Make any AI fluent in your company data.",
   description: manifest.description,
@@ -466,15 +1038,28 @@ const index = {
   hosted_service: false,
   links: {
     homepage: `${SITE}/`,
-    developers: `${SITE}/developers`,
+    homepage_markdown: `${SITE}/index.md`,
+    docs: `${SITE}/docs`,
+    docs_markdown: `${SITE}/docs.md`,
     openapi: `${SITE}/openapi.json`,
     llms_txt: `${SITE}/llms.txt`,
     tools: `${SITE}/api/tools.json`,
     connectors: `${SITE}/api/connectors.json`,
+    mcp_manifest: `${SITE}/.well-known/mcp.json`,
+    agent_card: `${SITE}/.well-known/agent-card.json`,
+    agent_skills: `${SITE}/.well-known/agent-skills/index.json`,
     repository: REPO,
     issues: `${REPO}/issues`,
     contact: "mailto:hello@setoku.com",
   },
+  /**
+   * Every document setoku.com serves. The site's 404 body and its 404 page both
+   * tell readers this file is the complete index, so it is filled in below from
+   * the artifact list itself rather than typed out — the five discovery
+   * documents were added to the build without reaching this object, which left
+   * an agent following that hint concluding we publish no MCP manifest at all.
+   */
+  publishes: [] as string[],
   mcp: {
     transport: "streamable-http",
     path: "/mcp",
@@ -485,7 +1070,7 @@ const index = {
       oauth2: false,
       note:
         "Per-person, revocable connector tokens. OAuth 2.0 is scoped but not shipped; " +
-        `see ${SITE}/developers#auth.`,
+        `see ${SITE}/docs#auth.`,
     },
     public_demo: {
       url: DEMO_MCP_URL,
@@ -513,7 +1098,6 @@ const index = {
 const out: [string, unknown][] = [
   ["site/openapi.json", spec],
   ["site/api/openapi.json", spec],
-  ["site/api/index.json", index],
   [
     "site/api/tools.json",
     {
@@ -544,17 +1128,39 @@ const out: [string, unknown][] = [
       note: NOTE,
     },
   ],
+  // Agent discovery. Conventional paths first, because that is where an agent
+  // probes before it ever reads a page.
+  ["site/.well-known/mcp.json", mcpManifest(toolList)],
+  ["site/.well-known/agent-card.json", agentCard(skillList, toolList)],
+  ["site/.well-known/agent-skills/index.json", agentSkillsIndex(skillList)],
+  // Markdown twins: one canonical URL per page that is text, not HTML.
+  ["site/index.md", indexMarkdown(toolList, connectorList, skillList)],
+  ["site/docs.md", docsMarkdown(toolList, spec)],
+  ["site/llms.txt", llmsTxt(skillList)],
 ];
+
+// The documents this generator does not own. site/404.html is deliberately not
+// listed: it is what you get instead of a document, not one.
+const HAND_WRITTEN = [`${SITE}/`, `${SITE}/docs`, `${SITE}/robots.txt`, `${SITE}/sitemap.xml`];
+const CATALOG = "site/api/index.json";
+index.publishes = [
+  ...HAND_WRITTEN,
+  ...[...out.map(([p]) => p), CATALOG].map((p) => SITE + p.slice("site".length)),
+].sort();
+out.push([CATALOG, index]);
+
   return out;
 }
 
 /** Exactly how an artifact is serialized on disk — shared so the drift test
- *  compares bytes rather than re-guessing the formatting. */
-export const serialize = (body: unknown): string => JSON.stringify(body, null, 2) + "\n";
+ *  compares bytes rather than re-guessing the formatting. Markdown artifacts are
+ *  already text and are written through unchanged. */
+export const serialize = (body: unknown): string =>
+  typeof body === "string" ? body : JSON.stringify(body, null, 2) + "\n";
 
 if (import.meta.main) {
   const out = await buildArtifacts();
-  mkdirSync(ROOT + "site/api", { recursive: true });
+  for (const [p] of out) mkdirSync(ROOT + p.replace(/\/[^/]+$/, ""), { recursive: true });
   for (const [p, body] of out) {
     await Bun.write(ROOT + p, serialize(body));
     console.log(`  ${p}`);

--- a/scripts/deploy-site.sh
+++ b/scripts/deploy-site.sh
@@ -33,7 +33,7 @@ echo "→ rebuild site API artifacts"
 bun scripts/build-site-api.ts
 
 # Whole directory, so new documents (llms.txt, robots.txt, sitemap.xml,
-# openapi.json, api/, developers/) ship without editing this list every time.
+# openapi.json, api/, docs/) ship without editing this list every time.
 echo "→ rsync site/ to ${SSH}:${SITE_DIR}"
 rsync -az --delete --exclude='.DS_Store' site/ "${SSH}:${SITE_DIR}/"
 
@@ -49,12 +49,39 @@ curl -s --max-time 12 "https://${DOMAIN}/" | grep -o '<title>[^<]*</title>' \
 echo "→ verify the agent-facing surface …"
 surface_bad=0
 for p in /llms.txt /robots.txt /sitemap.xml /openapi.json /api/index.json \
-         /api/tools.json /api/connectors.json /developers /nonsense-404-probe; do
+         /api/tools.json /api/connectors.json /docs \
+         /.well-known/mcp.json /.well-known/agent-card.json \
+         /.well-known/agent-skills/index.json /nonsense-404-probe; do
   read -r code type < <(curl -s -o /dev/null --max-time 12 \
     -w '%{http_code} %{content_type}\n' "https://${DOMAIN}${p}")
   want=200; [ "$p" = /nonsense-404-probe ] && want=404
   mark=" "; if [ "$code" != "$want" ]; then mark="!"; surface_bad=$((surface_bad + 1)); fi
-  printf '   %s %-24s %s  %s\n' "$mark" "$p" "$code" "$type"
+  printf '   %s %-38s %s  %s\n' "$mark" "$p" "$code" "$type"
+done
+
+# The parts of the surface that depend on the CADDY BLOCK, not just on a file
+# being rsynced: markdown content type, ?mode=agent, and JSON errors. These are
+# the ones that silently regress, because the file is right there on disk and
+# only the header is wrong — and a client deciding whether we serve markdown
+# looks at the header. A mismatch here means the box is running an older
+# deploy/caddy.d/setoku-com.caddy: run `bun run deploy` to install and reload it.
+for probe in "/index.md|200|text/markdown|" "/docs.md|200|text/markdown|" \
+             "/?mode=agent|200|text/markdown|" "/docs?mode=agent|200|text/markdown|" \
+             "/api/nonsense-404-probe.json|404|application/json|" \
+             "/nonsense-404-probe|404|text/html|text/html"; do
+  # The last field is an Accept header. Plain curl sends `*/*`, which always
+  # lands in the JSON branch of handle_errors — so without it, the branded HTML
+  # 404 was never exercised and a missing 404.html shipped green.
+  IFS='|' read -r p want_code want_type accept <<<"$probe"
+  read -r code type < <(curl -s -o /dev/null --max-time 12 \
+    ${accept:+-H "Accept: ${accept}"} \
+    -w '%{http_code} %{content_type}\n' "https://${DOMAIN}${p}")
+  mark=" "
+  case "$code:$type" in
+    "$want_code":"$want_type"*) ;;
+    *) mark="!"; surface_bad=$((surface_bad + 1)) ;;
+  esac
+  printf '   %s %-38s %s  %s\n' "$mark" "$p" "$code" "$type"
 done
 if [ "$surface_bad" -ne 0 ]; then
   echo

--- a/site/.well-known/agent-card.json
+++ b/site/.well-known/agent-card.json
@@ -1,0 +1,288 @@
+{
+  "protocolVersion": "0.3.0",
+  "name": "Setoku",
+  "description": "Setoku makes an AI agent fluent in one company's data. It serves the company's curated context (metric definitions, gotchas, which table to trust) and a governed read-only query path into their warehouse, so an agent can answer business questions correctly and publish live views of the result. Self-hosted and single-tenant: the agent you are talking to runs on the operator's own box.",
+  "version": "0.21.0",
+  "provider": {
+    "organization": "Hedgy Labs",
+    "url": "https://setoku.com"
+  },
+  "documentationUrl": "https://setoku.com/docs",
+  "iconUrl": "https://setoku.com/assets/setoku-mark.svg",
+  "url": "https://demo.setoku.com/mcp/85315b4240ff6ded111072f950ac6f14167d920fdb765144",
+  "preferredTransport": "MCP-STREAMABLE-HTTP",
+  "additionalInterfaces": [
+    {
+      "transport": "MCP-STREAMABLE-HTTP",
+      "url": "https://demo.setoku.com/mcp/85315b4240ff6ded111072f950ac6f14167d920fdb765144"
+    },
+    {
+      "transport": "MCP-STREAMABLE-HTTP",
+      "url": "https://{host}/mcp"
+    }
+  ],
+  "transportNote": "This card describes an MCP server, not an A2A agent. `url` speaks JSON-RPC 2.0 over MCP Streamable HTTP (protocol revision 2025-06-18) and implements no A2A method: initialize an MCP session against it rather than sending A2A tasks. The URL shown is the public demo box — for a real deployment, substitute your own host.",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes": [
+    "application/json",
+    "text/plain"
+  ],
+  "defaultOutputModes": [
+    "application/json",
+    "text/plain",
+    "text/html"
+  ],
+  "securitySchemes": {
+    "bearerToken": {
+      "type": "http",
+      "scheme": "bearer",
+      "description": "Per-person connector token, revocable from the box's console. The public demo token above is read-only and intentionally published."
+    }
+  },
+  "security": [
+    {
+      "bearerToken": []
+    }
+  ],
+  "whenToUse": {
+    "summary": "Reach for Setoku when the answer lives in a specific company's own data and depends on that company's definitions.",
+    "use_when": [
+      "A question is about one company's own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.",
+      "You need the company's definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.",
+      "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.",
+      "Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.",
+      "You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner's own box."
+    ],
+    "do_not_use_when": [
+      "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
+      "You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
+      "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
+      "You want a model to run server-side. Setoku runs no inference; your own agent does the thinking."
+    ],
+    "how_to_call": [
+      "Connect to the box's MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person's bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.",
+      "Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.",
+      "Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.",
+      "Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself."
+    ]
+  },
+  "skills": [
+    {
+      "id": "setoku:compact-knowledge",
+      "name": "compact-knowledge",
+      "description": "Periodically tidy the Setoku knowledge store in a curator session — merge duplicate facts, resolve contradictions, tighten verbose docs, and flag stale knowledge. Use when the user asks to compact / clean up / dedupe / tidy knowledge, or when /admin/knowledge shows merge / contradiction / verbose flags.",
+      "tags": [
+        "setoku",
+        "mcp",
+        "company-data",
+        "compact-knowledge"
+      ],
+      "examples": [
+        "/setoku:compact-knowledge"
+      ]
+    },
+    {
+      "id": "setoku:connect",
+      "name": "connect",
+      "description": "Connect a data source to Setoku end-to-end — ensure a box exists, wire the source up (read-only), verify the agent actually understands the data, and write what it learns back as knowledge. Use when the user says \"connect <source>\", \"hook up <source>\", \"add a data source\", \"set up Setoku\", or \"/setoku:connect\".",
+      "tags": [
+        "setoku",
+        "mcp",
+        "company-data",
+        "connect"
+      ],
+      "examples": [
+        "/setoku:connect"
+      ]
+    },
+    {
+      "id": "setoku:curate",
+      "name": "curate",
+      "description": "Review pending Setoku knowledge candidates and promote, edit, or reject them — conversationally, no git or dev skills required. Use when the user asks to curate/review setoku knowledge, or when list_entities reports pending corrections.",
+      "tags": [
+        "setoku",
+        "mcp",
+        "company-data",
+        "curate"
+      ],
+      "examples": [
+        "/setoku:curate"
+      ]
+    },
+    {
+      "id": "setoku:eval",
+      "name": "eval",
+      "description": "Run the Setoku golden-question eval for this repository and report a scorecard. Use when the user asks to eval/test setoku answer quality, or after significant context-artifact changes.",
+      "tags": [
+        "setoku",
+        "mcp",
+        "company-data",
+        "eval"
+      ],
+      "examples": [
+        "/setoku:eval"
+      ]
+    },
+    {
+      "id": "setoku:generate",
+      "name": "generate",
+      "description": "Generate or refresh Setoku's business-context knowledge by reading this repository's code — ORM schemas, business logic, migrations, existing docs — and saving it to the knowledge store (commits directly on a curator connector, or proposes for human approval on the everyday analyst connector — no SSH needed). Use when the user asks to generate/update/refresh business context, when setoku tools report an empty knowledge store, or when schema drift is detected.",
+      "tags": [
+        "setoku",
+        "mcp",
+        "company-data",
+        "generate"
+      ],
+      "examples": [
+        "/setoku:generate"
+      ]
+    },
+    {
+      "id": "setoku:onboard",
+      "name": "onboard",
+      "description": "First-run setup for Setoku in a repo — connect the business database, generate context from the code, and answer a first question end-to-end. Use when the user says \"set up setoku\" or \"onboard\", or when setoku tools report missing config. (Thin wrapper over /setoku:connect.)",
+      "tags": [
+        "setoku",
+        "mcp",
+        "company-data",
+        "onboard"
+      ],
+      "examples": [
+        "/setoku:onboard"
+      ]
+    },
+    {
+      "id": "setoku:answer",
+      "name": "answer",
+      "description": "Answer a question about the operator's own business data: retrieve the curated context for it (find_context), read the schema, then run a governed read-only query.",
+      "tags": [
+        "setoku",
+        "mcp",
+        "analytics",
+        "sql",
+        "company-data"
+      ],
+      "examples": [
+        "What did we bill last month, using our definition of billed revenue?",
+        "Which accounts churned in Q2, excluding the test tenant?"
+      ]
+    },
+    {
+      "id": "setoku:publish-app",
+      "name": "publish-app",
+      "description": "Build a small live app or dashboard over that data and publish it to a link the whole team can open, refreshing against real data.",
+      "tags": [
+        "setoku",
+        "mcp",
+        "dashboard",
+        "app",
+        "sharing"
+      ],
+      "examples": [
+        "Turn that into a dashboard the sales team can watch."
+      ]
+    }
+  ],
+  "tools": [
+    {
+      "name": "find_context",
+      "description": "Find business context (verified + unverified)",
+      "role": "analyst"
+    },
+    {
+      "name": "list_entities",
+      "description": "List documented business entities",
+      "role": "analyst"
+    },
+    {
+      "name": "describe_entity",
+      "description": "Full context doc for one entity",
+      "role": "analyst"
+    },
+    {
+      "name": "get_metric",
+      "description": "Canonical metric definition",
+      "role": "analyst"
+    },
+    {
+      "name": "report_correction",
+      "description": "Record a context correction / clarification",
+      "role": "analyst"
+    },
+    {
+      "name": "list_corrections",
+      "description": "List pending knowledge corrections",
+      "role": "analyst"
+    },
+    {
+      "name": "resolve_correction",
+      "description": "Resolve a pending correction (curator)",
+      "role": "curator"
+    },
+    {
+      "name": "upsert_context",
+      "description": "Create or update a knowledge doc (generate/curate workflows)",
+      "role": "curator"
+    },
+    {
+      "name": "draft_correction",
+      "description": "Attach a drafted doc-edit to a pending correction (auto-draft)",
+      "role": "janitor"
+    },
+    {
+      "name": "reject_correction",
+      "description": "Auto-reject a pending correction (janitor, reject-only)",
+      "role": "janitor"
+    },
+    {
+      "name": "list_sources",
+      "description": "List connected data sources (capabilities)",
+      "role": "analyst"
+    },
+    {
+      "name": "get_schema",
+      "description": "Queryable schema (biz.* mirror + lake, permission-scoped)",
+      "role": "analyst"
+    },
+    {
+      "name": "run_query",
+      "description": "Run a read-only SQL query (capped + audited)",
+      "role": "analyst"
+    },
+    {
+      "name": "app_guide",
+      "description": "How to build a Setoku app (read before publish_app / update_app)",
+      "role": "analyst"
+    },
+    {
+      "name": "publish_app",
+      "description": "Publish a live app to the box (team-shareable URL)",
+      "role": "analyst"
+    },
+    {
+      "name": "update_app",
+      "description": "Edit an app you published (in place, same link)",
+      "role": "analyst"
+    },
+    {
+      "name": "list_apps",
+      "description": "List apps published to the box",
+      "role": "analyst"
+    },
+    {
+      "name": "get_app",
+      "description": "Inspect an app — its full template + panels (how it's built)",
+      "role": "analyst"
+    },
+    {
+      "name": "unpublish_app",
+      "description": "Archive a published app",
+      "role": "analyst"
+    }
+  ],
+  "note": "Generated by scripts/build-site-api.ts from the Setoku source tree — do not edit by hand."
+}

--- a/site/.well-known/agent-skills/index.json
+++ b/site/.well-known/agent-skills/index.json
@@ -1,0 +1,79 @@
+{
+  "name": "Setoku",
+  "description": "Skills for connecting an AI agent to one company's data and keeping the knowledge behind it correct. They ship in the Setoku Claude Code plugin and run against a Setoku box.",
+  "version": "0.21.0",
+  "license": "Apache-2.0",
+  "homepage": "https://setoku.com",
+  "documentation": "https://setoku.com/docs",
+  "when_to_use": {
+    "summary": "Reach for Setoku when the answer lives in a specific company's own data and depends on that company's definitions.",
+    "use_when": [
+      "A question is about one company's own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.",
+      "You need the company's definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.",
+      "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.",
+      "Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.",
+      "You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner's own box."
+    ],
+    "do_not_use_when": [
+      "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
+      "You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
+      "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
+      "You want a model to run server-side. Setoku runs no inference; your own agent does the thinking."
+    ],
+    "how_to_call": [
+      "Connect to the box's MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person's bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.",
+      "Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.",
+      "Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.",
+      "Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself."
+    ]
+  },
+  "install": [
+    "/plugin marketplace add Hedgy-Labs/setoku",
+    "/plugin install setoku@setoku"
+  ],
+  "skills": [
+    {
+      "name": "compact-knowledge",
+      "id": "setoku:compact-knowledge",
+      "description": "Periodically tidy the Setoku knowledge store in a curator session — merge duplicate facts, resolve contradictions, tighten verbose docs, and flag stale knowledge. Use when the user asks to compact / clean up / dedupe / tidy knowledge, or when /admin/knowledge shows merge / contradiction / verbose flags.",
+      "command": "/setoku:compact-knowledge",
+      "source": "https://github.com/Hedgy-Labs/setoku/blob/main/plugin/skills/compact-knowledge/SKILL.md"
+    },
+    {
+      "name": "connect",
+      "id": "setoku:connect",
+      "description": "Connect a data source to Setoku end-to-end — ensure a box exists, wire the source up (read-only), verify the agent actually understands the data, and write what it learns back as knowledge. Use when the user says \"connect <source>\", \"hook up <source>\", \"add a data source\", \"set up Setoku\", or \"/setoku:connect\".",
+      "command": "/setoku:connect",
+      "source": "https://github.com/Hedgy-Labs/setoku/blob/main/plugin/skills/connect/SKILL.md"
+    },
+    {
+      "name": "curate",
+      "id": "setoku:curate",
+      "description": "Review pending Setoku knowledge candidates and promote, edit, or reject them — conversationally, no git or dev skills required. Use when the user asks to curate/review setoku knowledge, or when list_entities reports pending corrections.",
+      "command": "/setoku:curate",
+      "source": "https://github.com/Hedgy-Labs/setoku/blob/main/plugin/skills/curate/SKILL.md"
+    },
+    {
+      "name": "eval",
+      "id": "setoku:eval",
+      "description": "Run the Setoku golden-question eval for this repository and report a scorecard. Use when the user asks to eval/test setoku answer quality, or after significant context-artifact changes.",
+      "command": "/setoku:eval",
+      "source": "https://github.com/Hedgy-Labs/setoku/blob/main/plugin/skills/eval/SKILL.md"
+    },
+    {
+      "name": "generate",
+      "id": "setoku:generate",
+      "description": "Generate or refresh Setoku's business-context knowledge by reading this repository's code — ORM schemas, business logic, migrations, existing docs — and saving it to the knowledge store (commits directly on a curator connector, or proposes for human approval on the everyday analyst connector — no SSH needed). Use when the user asks to generate/update/refresh business context, when setoku tools report an empty knowledge store, or when schema drift is detected.",
+      "command": "/setoku:generate",
+      "source": "https://github.com/Hedgy-Labs/setoku/blob/main/plugin/skills/generate/SKILL.md"
+    },
+    {
+      "name": "onboard",
+      "id": "setoku:onboard",
+      "description": "First-run setup for Setoku in a repo — connect the business database, generate context from the code, and answer a first question end-to-end. Use when the user says \"set up setoku\" or \"onboard\", or when setoku tools report missing config. (Thin wrapper over /setoku:connect.)",
+      "command": "/setoku:onboard",
+      "source": "https://github.com/Hedgy-Labs/setoku/blob/main/plugin/skills/onboard/SKILL.md"
+    }
+  ],
+  "note": "Generated by scripts/build-site-api.ts from the Setoku source tree — do not edit by hand."
+}

--- a/site/.well-known/mcp.json
+++ b/site/.well-known/mcp.json
@@ -1,0 +1,181 @@
+{
+  "name": "setoku",
+  "title": "Setoku",
+  "description": "Self-hosted MCP knowledge server: a read-only, audited view of one company's data plus the curated context needed to use it correctly.",
+  "version": "0.21.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/Hedgy-Labs/setoku",
+    "source": "github"
+  },
+  "documentation": "https://setoku.com/docs",
+  "when_to_use": {
+    "summary": "Reach for Setoku when the answer lives in a specific company's own data and depends on that company's definitions.",
+    "use_when": [
+      "A question is about one company's own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.",
+      "You need the company's definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.",
+      "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.",
+      "Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.",
+      "You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner's own box."
+    ],
+    "do_not_use_when": [
+      "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
+      "You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
+      "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
+      "You want a model to run server-side. Setoku runs no inference; your own agent does the thinking."
+    ],
+    "how_to_call": [
+      "Connect to the box's MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person's bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.",
+      "Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.",
+      "Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.",
+      "Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself."
+    ]
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://{host}/mcp",
+      "description": "Your own Setoku box. `host` is the hostname you deployed to; there is no hosted service.",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer <your connector token>, issued and revoked from the box's console.",
+          "is_required": true,
+          "is_secret": true
+        }
+      ]
+    },
+    {
+      "type": "streamable-http",
+      "url": "https://demo.setoku.com/mcp/85315b4240ff6ded111072f950ac6f14167d920fdb765144",
+      "description": "Public demo box (synthetic pro-sports-club dataset). The token is public on purpose, read-only, and carries the analyst role. Callable right now, no signup."
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "oauth2": false,
+    "accepted_in": [
+      "authorization-header",
+      "url-path"
+    ]
+  },
+  "tools": [
+    {
+      "name": "find_context",
+      "title": "Find business context (verified + unverified)",
+      "role": "analyst",
+      "readOnly": true
+    },
+    {
+      "name": "list_entities",
+      "title": "List documented business entities",
+      "role": "analyst",
+      "readOnly": true
+    },
+    {
+      "name": "describe_entity",
+      "title": "Full context doc for one entity",
+      "role": "analyst",
+      "readOnly": true
+    },
+    {
+      "name": "get_metric",
+      "title": "Canonical metric definition",
+      "role": "analyst",
+      "readOnly": true
+    },
+    {
+      "name": "report_correction",
+      "title": "Record a context correction / clarification",
+      "role": "analyst",
+      "readOnly": false
+    },
+    {
+      "name": "list_corrections",
+      "title": "List pending knowledge corrections",
+      "role": "analyst",
+      "readOnly": true
+    },
+    {
+      "name": "resolve_correction",
+      "title": "Resolve a pending correction (curator)",
+      "role": "curator",
+      "readOnly": false
+    },
+    {
+      "name": "upsert_context",
+      "title": "Create or update a knowledge doc (generate/curate workflows)",
+      "role": "curator",
+      "readOnly": false
+    },
+    {
+      "name": "draft_correction",
+      "title": "Attach a drafted doc-edit to a pending correction (auto-draft)",
+      "role": "janitor",
+      "readOnly": false
+    },
+    {
+      "name": "reject_correction",
+      "title": "Auto-reject a pending correction (janitor, reject-only)",
+      "role": "janitor",
+      "readOnly": false
+    },
+    {
+      "name": "list_sources",
+      "title": "List connected data sources (capabilities)",
+      "role": "analyst",
+      "readOnly": true
+    },
+    {
+      "name": "get_schema",
+      "title": "Queryable schema (biz.* mirror + lake, permission-scoped)",
+      "role": "analyst",
+      "readOnly": true
+    },
+    {
+      "name": "run_query",
+      "title": "Run a read-only SQL query (capped + audited)",
+      "role": "analyst",
+      "readOnly": true
+    },
+    {
+      "name": "app_guide",
+      "title": "How to build a Setoku app (read before publish_app / update_app)",
+      "role": "analyst",
+      "readOnly": true
+    },
+    {
+      "name": "publish_app",
+      "title": "Publish a live app to the box (team-shareable URL)",
+      "role": "analyst",
+      "readOnly": false
+    },
+    {
+      "name": "update_app",
+      "title": "Edit an app you published (in place, same link)",
+      "role": "analyst",
+      "readOnly": false
+    },
+    {
+      "name": "list_apps",
+      "title": "List apps published to the box",
+      "role": "analyst",
+      "readOnly": true
+    },
+    {
+      "name": "get_app",
+      "title": "Inspect an app — its full template + panels (how it's built)",
+      "role": "analyst",
+      "readOnly": true
+    },
+    {
+      "name": "unpublish_app",
+      "title": "Archive a published app",
+      "role": "analyst",
+      "readOnly": false
+    }
+  ],
+  "tool_catalog": "https://setoku.com/api/tools.json",
+  "openapi": "https://setoku.com/openapi.json",
+  "note": "Generated by scripts/build-site-api.ts from the Setoku source tree — do not edit by hand."
+}

--- a/site/404.html
+++ b/site/404.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setoku · no such page</title>
+    <meta name="robots" content="noindex" />
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/assets/manpage.css" />
+  </head>
+  <body>
+    <!-- The HTML half of the 404. Anything that did not ask for text/html gets
+         a JSON error instead, with a code and a hint: see the handle_errors
+         block in deploy/caddy.d/setoku-com.caddy. -->
+    <div class="runline top">
+      <span><a href="/">SETOKU</a></span>
+      <span class="mid">Not Found</span>
+      <span>404</span>
+    </div>
+
+    <main id="top">
+      <section>
+        <h2 class="man">NAME</h2>
+        <div class="body">
+          <h1 class="nameline">
+            <b>404</b> &mdash; there’s no Setoku page at that address
+          </h1>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="man">DESCRIPTION</h2>
+        <div class="body">
+          <p>
+            setoku.com is a handful of static documents: the product page, the
+            developer manual, and the machine-readable files agents fetch. It has
+            no client-side router, so an unknown path is simply missing rather
+            than something that will resolve in a moment.
+          </p>
+          <p class="dim">
+            Looking for the API? It isn’t here. Setoku is self-hosted and
+            single-tenant, so the API runs on your own box, not on this domain.
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="man">SEE ALSO</h2>
+        <div class="body">
+          <ul class="man">
+            <li><a href="/">setoku.com</a> — what Setoku is, and a live demo</li>
+            <li>
+              <a href="/docs">setoku.com/docs</a> — API reference and
+              the MCP tool surface
+            </li>
+            <li>
+              <a href="/api/index.json">/api/index.json</a> — everything this
+              site publishes, in one JSON document
+            </li>
+            <li>
+              <a href="mailto:hello@setoku.com">hello@setoku.com</a> — if
+              something here should have existed
+            </li>
+          </ul>
+        </div>
+      </section>
+    </main>
+
+    <div class="runline bot">
+      <span>Hedgy Labs</span>
+      <span class="mid">2026</span>
+      <span><a href="/">SETOKU</a></span>
+    </div>
+  </body>
+</html>

--- a/site/api/index.json
+++ b/site/api/index.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://setoku.com/api/index.json",
   "name": "Setoku",
   "tagline": "Make any AI fluent in your company data.",
   "description": "Governed agentic BI on your Claude subscription. Setoku gives Claude a verified business-context layer (derived from your codebase) plus read-only, audited access to your database — so it answers business questions accurately instead of guessing from column names.",
@@ -9,15 +8,37 @@
   "hosted_service": false,
   "links": {
     "homepage": "https://setoku.com/",
-    "developers": "https://setoku.com/developers",
+    "homepage_markdown": "https://setoku.com/index.md",
+    "docs": "https://setoku.com/docs",
+    "docs_markdown": "https://setoku.com/docs.md",
     "openapi": "https://setoku.com/openapi.json",
     "llms_txt": "https://setoku.com/llms.txt",
     "tools": "https://setoku.com/api/tools.json",
     "connectors": "https://setoku.com/api/connectors.json",
+    "mcp_manifest": "https://setoku.com/.well-known/mcp.json",
+    "agent_card": "https://setoku.com/.well-known/agent-card.json",
+    "agent_skills": "https://setoku.com/.well-known/agent-skills/index.json",
     "repository": "https://github.com/Hedgy-Labs/setoku",
     "issues": "https://github.com/Hedgy-Labs/setoku/issues",
     "contact": "mailto:hello@setoku.com"
   },
+  "publishes": [
+    "https://setoku.com/",
+    "https://setoku.com/.well-known/agent-card.json",
+    "https://setoku.com/.well-known/agent-skills/index.json",
+    "https://setoku.com/.well-known/mcp.json",
+    "https://setoku.com/api/connectors.json",
+    "https://setoku.com/api/index.json",
+    "https://setoku.com/api/openapi.json",
+    "https://setoku.com/api/tools.json",
+    "https://setoku.com/docs",
+    "https://setoku.com/docs.md",
+    "https://setoku.com/index.md",
+    "https://setoku.com/llms.txt",
+    "https://setoku.com/openapi.json",
+    "https://setoku.com/robots.txt",
+    "https://setoku.com/sitemap.xml"
+  ],
   "mcp": {
     "transport": "streamable-http",
     "path": "/mcp",
@@ -29,7 +50,7 @@
         "url-path"
       ],
       "oauth2": false,
-      "note": "Per-person, revocable connector tokens. OAuth 2.0 is scoped but not shipped; see https://setoku.com/developers#auth."
+      "note": "Per-person, revocable connector tokens. OAuth 2.0 is scoped but not shipped; see https://setoku.com/docs#auth."
     },
     "public_demo": {
       "url": "https://demo.setoku.com/mcp/85315b4240ff6ded111072f950ac6f14167d920fdb765144",

--- a/site/api/openapi.json
+++ b/site/api/openapi.json
@@ -11,13 +11,13 @@
     },
     "contact": {
       "name": "Setoku",
-      "url": "https://setoku.com/developers",
+      "url": "https://setoku.com/docs",
       "email": "hello@setoku.com"
     }
   },
   "externalDocs": {
-    "description": "Setoku developer documentation",
-    "url": "https://setoku.com/developers"
+    "description": "Setoku API reference",
+    "url": "https://setoku.com/docs"
   },
   "servers": [
     {
@@ -58,7 +58,7 @@
       "bearerToken": {
         "type": "http",
         "scheme": "bearer",
-        "description": "A per-person connector token. Send it as `Authorization: Bearer <token>`, or as a path segment (`/mcp/<token>`) for MCP clients whose connector dialog has no header field. The token identifies one person and is revocable from the box's web console. Treat the whole URL as a credential, like a database connection string.\n\nOAuth 2.0 is scoped but deliberately not shipped; see https://setoku.com/developers#auth."
+        "description": "A per-person connector token. Send it as `Authorization: Bearer <token>`, or as a path segment (`/mcp/<token>`) for MCP clients whose connector dialog has no header field. The token identifies one person and is revocable from the box's web console. Treat the whole URL as a credential, like a database connection string.\n\nOAuth 2.0 is scoped but deliberately not shipped; see https://setoku.com/docs#auth."
       }
     },
     "schemas": {

--- a/site/docs.md
+++ b/site/docs.md
@@ -1,0 +1,136 @@
+# Setoku API reference
+
+The HTTP API, authentication, and the MCP tool surface for Setoku 0.21.0. This is the markdown twin of <https://setoku.com/docs>.
+
+Setoku is single-tenant and self-hosted: **there is no setoku.com API**. Everything below describes the API *your own box* exposes once you deploy it, and the public demo box (`https://demo.setoku.com`) is a real instance of it.
+
+## When to reach for Setoku
+
+Reach for Setoku when the answer lives in a specific company’s own data and depends on that company’s definitions.
+
+- A question is about one company’s own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.
+- You need the company’s definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.
+- A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.
+- Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.
+- You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner’s own box.
+
+Not a fit when:
+
+- The question is general knowledge, or about public data — Setoku only knows the data its operator connected.
+- You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
+- You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator’s own box.
+- You want a model to run server-side. Setoku runs no inference; your own agent does the thinking.
+
+## MCP endpoint
+
+Transport: **Streamable HTTP**, at `POST /mcp`. Protocol revision 2025-06-18. Any MCP client works: Claude, Claude Code, Codex, or your own.
+
+    curl -sS -X POST https://<your-box>/mcp \
+      -H "Authorization: Bearer <token>" \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/json, text/event-stream" \
+      -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+
+Callable right now against the demo box:
+
+    https://demo.setoku.com/mcp/85315b4240ff6ded111072f950ac6f14167d920fdb765144
+
+## Authentication
+
+- A per-person **bearer token**, sent as `Authorization: Bearer <token>` — or as a path segment (`/mcp/<token>`) for connector dialogs with nowhere to put a header. Treat the whole URL as a credential.
+- Tokens are issued and revoked from the box’s web console. Every call is attributed to one person in the audit log.
+- **OAuth 2.0 is not shipped.** It is scoped; it does not exist yet. Do not build against it.
+- A missing, unknown, or revoked token is a `401`, before any tool runs. See [Errors](#errors) for the shapes.
+
+## Tool surface
+
+1. Connect to the box’s MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person’s bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.
+2. Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.
+3. Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.
+4. Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself.
+
+**Every session** — the analyst surface. Reads data and curated context, and may only *propose* knowledge changes:
+
+- `find_context` — Find business context (verified + unverified)
+- `list_entities` — List documented business entities
+- `describe_entity` — Full context doc for one entity
+- `get_metric` — Canonical metric definition
+- `report_correction` (writes) — Record a context correction / clarification
+- `list_corrections` — List pending knowledge corrections
+- `list_sources` — List connected data sources (capabilities)
+- `get_schema` — Queryable schema (biz.* mirror + lake, permission-scoped)
+- `run_query` — Run a read-only SQL query (capped + audited)
+- `app_guide` — How to build a Setoku app (read before publish_app / update_app)
+- `publish_app` (writes) — Publish a live app to the box (team-shareable URL)
+- `update_app` (writes) — Edit an app you published (in place, same link)
+- `list_apps` — List apps published to the box
+- `get_app` — Inspect an app — its full template + panels (how it’s built)
+- `unpublish_app` (writes) — Archive a published app
+
+**Curator sessions only.** Commits curated knowledge:
+
+- `resolve_correction` — Resolve a pending correction (curator)
+- `upsert_context` — Create or update a knowledge doc (generate/curate workflows)
+
+**Janitor sessions only.** Drafts and auto-rejects pending corrections, commits nothing:
+
+- `draft_correction` — Attach a drafted doc-edit to a pending correction (auto-draft)
+- `reject_correction` — Auto-reject a pending correction (janitor, reject-only)
+
+A session has exactly one role, and the two role-scoped groups are *registered* only for that role: a session without it does not get a refusal, the tool is simply absent from its `tools/list`.
+
+The analyst tools are registered on every session, including a curator one — the membrane’s other half is enforced at call time instead. A curator session can commit knowledge but cannot read the data lake: `run_query` refuses lake queries and `list_sources` tells you to switch connectors. So the session that can rewrite what Setoku knows is never the session that has read untrusted bulk text (I2).
+
+## REST surface
+
+Credential-free unless marked. Full spec: <https://setoku.com/openapi.json>.
+
+| Endpoint | What it returns | Auth |
+| --- | --- | --- |
+| `POST /mcp` | Model Context Protocol endpoint (Streamable HTTP) | bearer |
+| `POST /mcp/{token}` | MCP endpoint with the token in the path | bearer |
+| `GET /healthz` | Aggregate health | none |
+| `GET /health` | Liveness probe | none |
+| `GET /p/{id}` | A published app | none |
+| `GET /p/{id}/data` | Freshness metadata for a published app | none |
+| `GET /p/{id}/state` | Read an app’s sandboxed state | none |
+| `POST /p/{id}/state` | Write an app’s sandboxed state | none |
+| `GET /i/{token}` | One-line installer script | none |
+
+## Errors
+
+Three different surfaces, three shapes. Branch on the HTTP status; do not expect one envelope everywhere.
+
+**The box’s REST endpoints** answer with `ok: false` and a human-readable string. There is no error code to switch on — the status line is the machine-readable part:
+
+    { "ok": false, "error": "app not found or archived" }
+
+**MCP tools** return their failure as the tool result, per the MCP specification, not as an HTTP error: the call is `200` and the content carries the message. `run_query` failures are written to be actionable — they name the table or column that did not resolve and what to call instead. A missing, unknown, or revoked token is the exception: that is a plain `401` before any tool runs.
+
+**setoku.com itself** (this site, not your box) answers non-HTML requests with a structured document, so an agent probing the docs surface gets something it can parse:
+
+    {
+      "ok": false,
+      "error": {
+        "code": "not_found",
+        "status": 404,
+        "message": "No document at that path on setoku.com.",
+        "hint": "…",
+        "docs": "https://setoku.com/docs",
+        "index": "https://setoku.com/api/index.json"
+      }
+    }
+
+## Install a box
+
+    git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+    cd /opt/setoku
+    SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh
+
+One small VPS. Docker Compose brings up the gateway, Caddy (HTTPS), and a local ClickHouse lake. No model runs on the server.
+
+## More
+
+- [OpenAPI 3.1](https://setoku.com/openapi.json) · [MCP manifest](https://setoku.com/.well-known/mcp.json) · [agent card](https://setoku.com/.well-known/agent-card.json) · [skills index](https://setoku.com/.well-known/agent-skills/index.json)
+- [Tool catalog](https://setoku.com/api/tools.json) · [connector catalog](https://setoku.com/api/connectors.json) · [catalog root](https://setoku.com/api/index.json)
+- [Source](https://github.com/Hedgy-Labs/setoku) · [issues](https://github.com/Hedgy-Labs/setoku/issues) · hello@setoku.com

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -3,20 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Setoku developer documentation · MCP server, API reference, OpenAPI spec</title>
+    <title>Setoku API reference · MCP server, HTTP API, OpenAPI spec</title>
     <meta
       name="description"
       content="Developer documentation for Setoku, the open-source self-hosted MCP knowledge server: the MCP tool surface, HTTP API reference, OpenAPI spec, authentication, and quickstart."
     />
-    <link rel="canonical" href="https://setoku.com/developers" />
+    <link rel="canonical" href="https://setoku.com/docs" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Setoku" />
-    <meta property="og:title" content="Setoku developer documentation" />
+    <meta property="og:title" content="Setoku API reference" />
     <meta
       property="og:description"
       content="The MCP tool surface, HTTP API reference, OpenAPI spec, authentication, and quickstart for Setoku, the open-source self-hosted MCP knowledge server."
     />
-    <meta property="og:url" content="https://setoku.com/developers" />
+    <meta property="og:url" content="https://setoku.com/docs" />
     <meta property="og:image" content="https://setoku.com/assets/og.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
@@ -40,6 +40,12 @@
       href="https://setoku.com/llms.txt"
       title="Setoku llms.txt"
     />
+    <link
+      rel="alternate"
+      type="text/markdown"
+      href="https://setoku.com/docs.md"
+      title="Setoku API reference in markdown"
+    />
     <!-- Same @ids as the homepage graph, so this page's entities link to those
          rather than declaring a second, competing copy of the product. -->
     <script type="application/ld+json">
@@ -48,10 +54,10 @@
         "@graph": [
           {
             "@type": "TechArticle",
-            "@id": "https://setoku.com/developers#doc",
-            "url": "https://setoku.com/developers",
-            "name": "Setoku developer documentation",
-            "headline": "Setoku developer documentation: MCP server, API reference, OpenAPI spec",
+            "@id": "https://setoku.com/docs#doc",
+            "url": "https://setoku.com/docs",
+            "name": "Setoku API reference",
+            "headline": "Setoku API reference: MCP tool surface, HTTP API, OpenAPI spec",
             "description": "The MCP tool surface, HTTP API reference, OpenAPI specification, authentication model, and quickstart for Setoku, the open-source self-hosted MCP knowledge server.",
             "proficiencyLevel": "Beginner",
             "inLanguage": "en",
@@ -64,7 +70,7 @@
                 "@id": "https://setoku.com/#api",
                 "name": "Setoku Gateway API",
                 "description": "The HTTP surface every self-hosted Setoku box exposes: the MCP endpoint, health, published apps, and the installer.",
-                "documentation": "https://setoku.com/developers#api",
+                "documentation": "https://setoku.com/docs#api",
                 "termsOfService": "https://github.com/Hedgy-Labs/setoku/blob/main/LICENSE",
                 "provider": { "@id": "https://setoku.com/#org" }
               }
@@ -93,7 +99,7 @@
   <body>
     <div class="runline top">
       <span><a href="/">SETOKU</a></span>
-      <span class="mid">Developer Manual</span>
+      <span class="mid">API Reference</span>
       <span
         ><a
           href="https://github.com/Hedgy-Labs/setoku"
@@ -110,8 +116,7 @@
         <div class="body">
           <!-- the page's h1 — see the note on the homepage's NAME line -->
           <h1 class="nameline">
-            <b>setoku-developers</b> &mdash; build against Setoku, the
-            self-hosted MCP knowledge server
+            <b>setoku-api</b> &mdash; the Setoku HTTP and MCP API reference
           </h1>
         </div>
       </section>
@@ -122,9 +127,9 @@
           <p>
             Setoku is an open-source MCP server you run on your own box. It
             gives an AI agent a read-only, audited path into your data plus the
-            curated context to use it correctly. This page is the developer
-            reference: the API, the tools, the auth model, and how to get a box
-            of your own.
+            curated context to use it correctly. This page is the reference:
+            the API, the MCP tools, the auth model, and how to get a box of your
+            own. The homepage is the tour.
           </p>
 <pre class="block"><span class="c"># the whole API surface, from a real running box</span>
 curl https://demo.setoku.com/healthz

--- a/site/index.html
+++ b/site/index.html
@@ -46,6 +46,12 @@
       href="https://setoku.com/llms.txt"
       title="Setoku llms.txt"
     />
+    <link
+      rel="alternate"
+      type="text/markdown"
+      href="https://setoku.com/index.md"
+      title="Setoku homepage in markdown"
+    />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -74,7 +80,7 @@
               "@type": "ContactPoint",
               "contactType": "technical support",
               "email": "hello@setoku.com",
-              "url": "https://setoku.com/developers",
+              "url": "https://setoku.com/docs",
               "availableLanguage": "English"
             }
           },
@@ -91,8 +97,8 @@
             "license": "https://www.apache.org/licenses/LICENSE-2.0",
             "downloadUrl": "https://github.com/Hedgy-Labs/setoku",
             "codeRepository": "https://github.com/Hedgy-Labs/setoku",
-            "softwareHelp": "https://setoku.com/developers",
-            "installUrl": "https://setoku.com/developers#install",
+            "softwareHelp": "https://setoku.com/docs",
+            "installUrl": "https://setoku.com/docs#install",
             "programmingLanguage": "TypeScript",
             "isAccessibleForFree": true,
             "offers": {
@@ -114,10 +120,10 @@
           },
           {
             "@type": "TechArticle",
-            "@id": "https://setoku.com/developers#doc",
-            "url": "https://setoku.com/developers",
-            "name": "Setoku developer documentation",
-            "headline": "Setoku developer documentation: MCP server, API reference, OpenAPI spec",
+            "@id": "https://setoku.com/docs#doc",
+            "url": "https://setoku.com/docs",
+            "name": "Setoku API reference",
+            "headline": "Setoku API reference: MCP tool surface, HTTP API, OpenAPI spec",
             "description": "The MCP tool surface, HTTP API reference, OpenAPI specification, authentication model, and quickstart for Setoku.",
             "about": { "@id": "https://setoku.com/#software" },
             "isPartOf": { "@id": "https://setoku.com/#website" },
@@ -151,7 +157,9 @@
       >
       <span class="mid">User Manual</span>
       <span
-        ><a href="/developers">DEVELOPERS</a> ·
+        ><!-- "API", not "DEVELOPERS": this whole page is for developers, so that
+             label said nothing. The linked page is the API reference. -->
+        <a href="/docs">API</a> ·
         <a
           href="https://github.com/Hedgy-Labs/setoku"
           target="_blank"
@@ -671,7 +679,7 @@ SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</pre>
             </li>
             <li><a href="#demo">DEMO</a> — try it on real-ish data</li>
             <li>
-              <a href="/developers">setoku.com/developers</a> — API reference,
+              <a href="/docs">setoku.com/docs</a> — API reference,
               the MCP tool surface, and the
               <a href="/openapi.json">OpenAPI spec</a>
             </li>

--- a/site/index.md
+++ b/site/index.md
@@ -1,0 +1,128 @@
+# Setoku
+
+> Make any AI fluent in your company data.
+
+Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives an AI agent a read-only, audited view of a company’s data plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
+
+Version 0.21.0 · Apache-2.0 · <https://github.com/Hedgy-Labs/setoku>
+
+This is the markdown twin of <https://setoku.com/>. The API reference is <https://setoku.com/docs> (markdown: <https://setoku.com/docs.md>).
+
+## When to use Setoku
+
+Reach for Setoku when the answer lives in a specific company’s own data and depends on that company’s definitions.
+
+Use it when:
+
+- A question is about one company’s own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.
+- You need the company’s definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.
+- A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.
+- Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.
+- You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner’s own box.
+
+Do not use it when:
+
+- The question is general knowledge, or about public data — Setoku only knows the data its operator connected.
+- You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
+- You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator’s own box.
+- You want a model to run server-side. Setoku runs no inference; your own agent does the thinking.
+
+## How an agent calls it
+
+1. Connect to the box’s MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person’s bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.
+2. Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.
+3. Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.
+4. Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself.
+
+## Try it without installing anything
+
+The demo box is wired to a synthetic pro-sports-club dataset (ticketing, sponsorship, concessions, payroll, broadcast rights) for a fictional club, the Bonita Bulldogs. Add this as a custom MCP connector:
+
+    https://demo.setoku.com/mcp/85315b4240ff6ded111072f950ac6f14167d920fdb765144
+
+The token is public on purpose: read-only, analyst role, synthetic data.
+
+- [Sponsorship pricing table](https://demo.setoku.com/p/7e38381ced6517329947b14d) — inventory and rates for sponsorship placements, published by an agent and running on live demo data.
+- [Bulldogs attendance forecast](https://demo.setoku.com/p/a7a1240ae0bc202c5eefa1cc) — projected gate for upcoming home games, published by an agent and running on live demo data.
+- [Demo box health](https://demo.setoku.com/healthz) — a credential-free REST endpoint, if you want to see the shape of the API before you connect.
+
+## Install
+
+Claude Code plugin, from your project directory:
+
+    /plugin marketplace add Hedgy-Labs/setoku
+    /plugin install setoku@setoku
+    /setoku:onboard
+
+Server, by hand, on a fresh Ubuntu VPS (about $5–12/month):
+
+    git clone https://github.com/Hedgy-Labs/setoku /opt/setoku
+    cd /opt/setoku
+    SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh
+
+## The tool surface
+
+19 MCP tools. Which ones a session sees depends on its token’s role — that split is the security model, not a convenience.
+
+| Tool | What it does | Role |
+| --- | --- | --- |
+| `find_context` | Find business context (verified + unverified) | analyst |
+| `list_entities` | List documented business entities | analyst |
+| `describe_entity` | Full context doc for one entity | analyst |
+| `get_metric` | Canonical metric definition | analyst |
+| `report_correction` | Record a context correction / clarification | analyst |
+| `list_corrections` | List pending knowledge corrections | analyst |
+| `resolve_correction` | Resolve a pending correction (curator) | curator |
+| `upsert_context` | Create or update a knowledge doc (generate/curate workflows) | curator |
+| `draft_correction` | Attach a drafted doc-edit to a pending correction (auto-draft) | janitor |
+| `reject_correction` | Auto-reject a pending correction (janitor, reject-only) | janitor |
+| `list_sources` | List connected data sources (capabilities) | analyst |
+| `get_schema` | Queryable schema (biz.* mirror + lake, permission-scoped) | analyst |
+| `run_query` | Run a read-only SQL query (capped + audited) | analyst |
+| `app_guide` | How to build a Setoku app (read before publish_app / update_app) | analyst |
+| `publish_app` | Publish a live app to the box (team-shareable URL) | analyst |
+| `update_app` | Edit an app you published (in place, same link) | analyst |
+| `list_apps` | List apps published to the box | analyst |
+| `get_app` | Inspect an app — its full template + panels (how it’s built) | analyst |
+| `unpublish_app` | Archive a published app | analyst |
+
+## Skills
+
+- `/setoku:compact-knowledge` — Periodically tidy the Setoku knowledge store in a curator session — merge duplicate facts, resolve contradictions, tighten verbose docs, and flag stale knowledge. Use when the user asks to compact / clean up / dedupe / tidy knowledge, or when /admin/knowledge shows merge / contradiction / verbose flags.
+- `/setoku:connect` — Connect a data source to Setoku end-to-end — ensure a box exists, wire the source up (read-only), verify the agent actually understands the data, and write what it learns back as knowledge. Use when the user says "connect \<source>", "hook up \<source>", "add a data source", "set up Setoku", or "/setoku:connect".
+- `/setoku:curate` — Review pending Setoku knowledge candidates and promote, edit, or reject them — conversationally, no git or dev skills required. Use when the user asks to curate/review setoku knowledge, or when list_entities reports pending corrections.
+- `/setoku:eval` — Run the Setoku golden-question eval for this repository and report a scorecard. Use when the user asks to eval/test setoku answer quality, or after significant context-artifact changes.
+- `/setoku:generate` — Generate or refresh Setoku’s business-context knowledge by reading this repository’s code — ORM schemas, business logic, migrations, existing docs — and saving it to the knowledge store (commits directly on a curator connector, or proposes for human approval on the everyday analyst connector — no SSH needed). Use when the user asks to generate/update/refresh business context, when setoku tools report an empty knowledge store, or when schema drift is detected.
+- `/setoku:onboard` — First-run setup for Setoku in a repo — connect the business database, generate context from the code, and answer a first question end-to-end. Use when the user says "set up setoku" or "onboard", or when setoku tools report missing config. (Thin wrapper over /setoku:connect.)
+
+## Connectors
+
+- **PostgreSQL** — your app database, mirrored read-only into biz.*
+- **GitHub** — issues, pull requests, commits, comments
+- **Vercel** — deploys and logs
+- **Render** — deploys and logs
+- **Slack** — messages
+- **Mercury** — accounts and transactions
+- **Monarch** — accounts, transactions, net worth, budgets, holdings
+- **Gmail** — messages, per-mailbox OAuth
+
+No connector for yours? `/setoku:connect` gives a coding agent the patterns to wire one up.
+
+## Security model
+
+- **Two identities, one membrane.** An analyst token may query the lake but holds no tool that commits knowledge. A curator token may commit knowledge but cannot read the lake. They never coexist on one session, so a prompt-injected session cannot weaponize the write path.
+- **Accepting knowledge is a human click** on the box’s admin page, outside the agent loop. No MCP tool creates users, grants access, or commits knowledge on its own.
+- **Reads are governed by database roles**, not by parsing SQL in our code. The engine enforces it.
+- **The credential never reaches the model.** Config names an environment variable; the gateway resolves it.
+- **No model runs on the server**, so there is no inference cost and no AI API key on the box.
+
+## Machine-readable index
+
+- [OpenAPI 3.1](https://setoku.com/openapi.json) — the gateway HTTP API
+- [MCP manifest](https://setoku.com/.well-known/mcp.json) — endpoint, transport, auth
+- [Agent card](https://setoku.com/.well-known/agent-card.json) — who we are, what we do
+- [Agent skills index](https://setoku.com/.well-known/agent-skills/index.json)
+- [Catalog root](https://setoku.com/api/index.json) · [tools](https://setoku.com/api/tools.json) · [connectors](https://setoku.com/api/connectors.json)
+- [llms.txt](https://setoku.com/llms.txt)
+
+Contact: hello@setoku.com · Issues: <https://github.com/Hedgy-Labs/setoku/issues>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -8,11 +8,43 @@ The primary interface is MCP over Streamable HTTP at `/mcp` on your box. Any MCP
 
 Two identities share one server and never overlap. An **analyst** token may query the data lake but holds no tool that commits knowledge. A **curator** token may commit knowledge but cannot read the lake. Accepting proposed knowledge is a human click on the admin page, outside the agent loop, so a prompt-injected session cannot rewrite what Setoku knows.
 
+## When to use Setoku
+
+Reach for Setoku when the answer lives in a specific company’s own data and depends on that company’s definitions.
+
+Use it when:
+
+- A question is about one company’s own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.
+- You need the company’s definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.
+- A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.
+- Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.
+- You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner’s own box.
+
+Do not use it when:
+
+- The question is general knowledge, or about public data — Setoku only knows the data its operator connected.
+- You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
+- You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator’s own box.
+- You want a model to run server-side. Setoku runs no inference; your own agent does the thinking.
+
+How an agent should call it:
+
+1. Connect to the box’s MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person’s bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.
+2. Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.
+3. Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.
+4. Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself.
+
+The same guidance, machine-readable, is in [/.well-known/mcp.json](https://setoku.com/.well-known/mcp.json), [/.well-known/agent-card.json](https://setoku.com/.well-known/agent-card.json), and [/.well-known/agent-skills/index.json](https://setoku.com/.well-known/agent-skills/index.json).
+
 ## Setoku developer resources
 
-- [Setoku developer portal](https://setoku.com/developers): API reference, authentication, the MCP tool surface, quickstart, and the security model.
+- [Setoku API reference](https://setoku.com/docs): the HTTP API, authentication, the MCP tool surface, quickstart, and the security model. Markdown twin: [/docs.md](https://setoku.com/docs.md).
+- [Setoku homepage in markdown](https://setoku.com/index.md): the whole product page as one canonical markdown document, no HTML to parse. Both content pages — this one and /docs — also answer `?mode=agent` with their markdown twin; the JSON documents below answer as themselves.
+- [Setoku MCP manifest](https://setoku.com/.well-known/mcp.json): where the MCP server is, which transport it speaks, and how to authenticate.
+- [Setoku agent card](https://setoku.com/.well-known/agent-card.json): what Setoku is for, its skills, and the endpoint to call.
+- [Setoku agent skills index](https://setoku.com/.well-known/agent-skills/index.json): the shipped skills, each with a name and a description.
 - [Setoku OpenAPI specification](https://setoku.com/openapi.json): OpenAPI 3.1 for the Setoku gateway HTTP API, covering the MCP endpoint, health, published apps, and the installer. Mirrored at [/api/openapi.json](https://setoku.com/api/openapi.json).
-- [Setoku catalog API](https://setoku.com/api/index.json): machine-readable product metadata — version, install commands, links, and how to reach the MCP endpoint.
+- [Setoku catalog API](https://setoku.com/api/index.json): machine-readable product metadata — version, install commands, every document this site publishes, and how to reach the MCP endpoint.
 - [Setoku MCP tool catalog](https://setoku.com/api/tools.json): every MCP tool, with the role each one requires.
 - [Setoku connector catalog](https://setoku.com/api/connectors.json): the data sources Setoku ingests.
 - [Setoku source repository](https://github.com/Hedgy-Labs/setoku): Apache-2.0, the full server, skills, and deploy scripts.
@@ -20,14 +52,23 @@ Two identities share one server and never overlap. An **analyst** token may quer
 ## Try Setoku without installing it
 
 - [Setoku public demo](https://setoku.com/#demo): a live box wired to a synthetic pro-sports-club dataset (ticketing, sponsorship, concessions, payroll, broadcast rights). Add `https://demo.setoku.com/mcp/85315b4240ff6ded111072f950ac6f14167d920fdb765144` as a custom MCP connector. The token is public on purpose and read-only.
-- [Setoku demo app: sponsorship pricing](https://demo.setoku.com/p/7e38381ced6517329947b14d): an app an agent built and published, running on live demo data.
-- [Setoku demo app: Bulldogs attendance forecast](https://demo.setoku.com/p/a7a1240ae0bc202c5eefa1cc): the same, projecting gate for upcoming home games.
+- [Setoku demo app: Sponsorship pricing table](https://demo.setoku.com/p/7e38381ced6517329947b14d): inventory and rates for sponsorship placements, built and published by an agent on live demo data.
+- [Setoku demo app: Bulldogs attendance forecast](https://demo.setoku.com/p/a7a1240ae0bc202c5eefa1cc): projected gate for upcoming home games, built and published by an agent on live demo data.
 - [Setoku demo box health](https://demo.setoku.com/healthz): a real, credential-free REST endpoint you can call right now to see the shape of the API.
 
 ## Install Setoku
 
 - [Setoku quickstart](https://setoku.com/#quickstart): add the Claude Code plugin (`/plugin marketplace add Hedgy-Labs/setoku`), then run `/setoku:onboard` from your project directory.
-- [Setoku manual server setup](https://setoku.com/developers#install): clone the repo onto a fresh Ubuntu VPS and run `deploy/bootstrap.sh`.
+- [Setoku manual server setup](https://setoku.com/docs#install): clone the repo onto a fresh Ubuntu VPS and run `deploy/bootstrap.sh`.
+
+## Setoku skills
+
+- `/setoku:compact-knowledge`: Periodically tidy the Setoku knowledge store in a curator session — merge duplicate facts, resolve contradictions, tighten verbose docs, and flag stale knowledge. Use when the user asks to compact / clean up / dedupe / tidy knowledge, or when /admin/knowledge shows merge / contradiction / verbose flags.
+- `/setoku:connect`: Connect a data source to Setoku end-to-end — ensure a box exists, wire the source up (read-only), verify the agent actually understands the data, and write what it learns back as knowledge. Use when the user says "connect \<source>", "hook up \<source>", "add a data source", "set up Setoku", or "/setoku:connect".
+- `/setoku:curate`: Review pending Setoku knowledge candidates and promote, edit, or reject them — conversationally, no git or dev skills required. Use when the user asks to curate/review setoku knowledge, or when list_entities reports pending corrections.
+- `/setoku:eval`: Run the Setoku golden-question eval for this repository and report a scorecard. Use when the user asks to eval/test setoku answer quality, or after significant context-artifact changes.
+- `/setoku:generate`: Generate or refresh Setoku’s business-context knowledge by reading this repository’s code — ORM schemas, business logic, migrations, existing docs — and saving it to the knowledge store (commits directly on a curator connector, or proposes for human approval on the everyday analyst connector — no SSH needed). Use when the user asks to generate/update/refresh business context, when setoku tools report an empty knowledge store, or when schema drift is detected.
+- `/setoku:onboard`: First-run setup for Setoku in a repo — connect the business database, generate context from the code, and answer a first question end-to-end. Use when the user says "set up setoku" or "onboard", or when setoku tools report missing config. (Thin wrapper over /setoku:connect.)
 
 ## Optional
 

--- a/site/openapi.json
+++ b/site/openapi.json
@@ -11,13 +11,13 @@
     },
     "contact": {
       "name": "Setoku",
-      "url": "https://setoku.com/developers",
+      "url": "https://setoku.com/docs",
       "email": "hello@setoku.com"
     }
   },
   "externalDocs": {
-    "description": "Setoku developer documentation",
-    "url": "https://setoku.com/developers"
+    "description": "Setoku API reference",
+    "url": "https://setoku.com/docs"
   },
   "servers": [
     {
@@ -58,7 +58,7 @@
       "bearerToken": {
         "type": "http",
         "scheme": "bearer",
-        "description": "A per-person connector token. Send it as `Authorization: Bearer <token>`, or as a path segment (`/mcp/<token>`) for MCP clients whose connector dialog has no header field. The token identifies one person and is revocable from the box's web console. Treat the whole URL as a credential, like a database connection string.\n\nOAuth 2.0 is scoped but deliberately not shipped; see https://setoku.com/developers#auth."
+        "description": "A per-person connector token. Send it as `Authorization: Bearer <token>`, or as a path segment (`/mcp/<token>`) for MCP clients whose connector dialog has no header field. The token identifies one person and is revocable from the box's web console. Treat the whole URL as a credential, like a database connection string.\n\nOAuth 2.0 is scoped but deliberately not shipped; see https://setoku.com/docs#auth."
       }
     },
     "schemas": {

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -8,5 +8,10 @@ Sitemap: https://setoku.com/sitemap.xml
 
 # Machine-readable entry points, for agents that would rather fetch than scrape:
 #   https://setoku.com/llms.txt          product + developer resources, in prose
+#   https://setoku.com/index.md          the homepage as markdown (/docs.md too)
+#   https://setoku.com/?mode=agent       the same twin, for clients that pass a flag
 #   https://setoku.com/openapi.json      OpenAPI 3.1 for the Setoku gateway API
 #   https://setoku.com/api/index.json    catalog root
+#   https://setoku.com/.well-known/mcp.json                 the MCP endpoint + auth
+#   https://setoku.com/.well-known/agent-card.json          what Setoku is for
+#   https://setoku.com/.well-known/agent-skills/index.json  the shipped skills

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -6,9 +6,34 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://setoku.com/developers</loc>
+    <loc>https://setoku.com/docs</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://setoku.com/index.md</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://setoku.com/docs.md</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://setoku.com/.well-known/mcp.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://setoku.com/.well-known/agent-card.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://setoku.com/.well-known/agent-skills/index.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://setoku.com/openapi.json</loc>

--- a/test/demo-connector.test.ts
+++ b/test/demo-connector.test.ts
@@ -27,7 +27,7 @@ const PROSE = [
   "README.md",
   "demo/README.md",
   "site/index.html",
-  "site/developers/index.html",
+  "site/docs/index.html",
   "site/llms.txt",
   "site/api/index.json",
 ];

--- a/test/site-api.test.ts
+++ b/test/site-api.test.ts
@@ -175,7 +175,7 @@ describe("the OpenAPI spec is well formed", () => {
 });
 
 describe("discovery files point at documents that exist", () => {
-  /** https://setoku.com/x -> site/x, with /developers served as a directory. */
+  /** https://setoku.com/x -> site/x, with /docs served as a directory. */
   const localPath = (url: string): string | null => {
     const m = url.match(/^https:\/\/setoku\.com(\/[^#?]*)/);
     if (!m) return null;
@@ -190,7 +190,7 @@ describe("discovery files point at documents that exist", () => {
     for (const [, url] of txt.matchAll(/\((https:\/\/setoku\.com[^)]*)\)/g)) {
       const p = localPath(url);
       if (!p) continue;
-      // /developers is served by a rewrite to its index.html
+      // /docs is served by a rewrite to its index.html
       const candidates = [p, `${p}/index.html`];
       if (!candidates.some((c) => existsSync(ROOT + c))) missing.push(url);
     }
@@ -218,14 +218,14 @@ describe("discovery files point at documents that exist", () => {
   });
 
   test("both pages share one stylesheet, so they cannot drift apart", async () => {
-    for (const p of ["site/index.html", "site/developers/index.html"]) {
+    for (const p of ["site/index.html", "site/docs/index.html"]) {
       expect(await readText(p)).toContain('href="/assets/manpage.css"');
     }
     expect(existsSync(ROOT + "site/assets/manpage.css")).toBe(true);
   });
 
-  test("the developer portal is reachable from the homepage", async () => {
-    expect(await readText("site/index.html")).toContain('href="/developers"');
+  test("the API reference is reachable from the homepage", async () => {
+    expect(await readText("site/index.html")).toContain('href="/docs"');
   });
 });
 
@@ -250,7 +250,7 @@ describe("hand-written pages agree with the generated catalog", () => {
     return names;
   }
 
-  test("/developers names only tools that actually exist", async () => {
+  test("/docs names only tools that actually exist", async () => {
     // The portal's tool list is prose — it can't import tools.json. So assert the
     // one direction that matters for a reader: every name it advertises is real.
     // It previously listed 17 of 19 and omitted the janitor role entirely, three
@@ -258,15 +258,15 @@ describe("hand-written pages agree with the generated catalog", () => {
     const published = new Set<string>(
       (await readJson("site/api/tools.json")).tools.map((t: { name: string }) => t.name),
     );
-    const bogus = [...(await proseToolNames("site/developers/index.html"))].filter(
+    const bogus = [...(await proseToolNames("site/docs/index.html"))].filter(
       (n) => !published.has(n),
     );
     expect(bogus).toEqual([]);
   });
 
-  test("/developers accounts for every tool and role", async () => {
+  test("/docs accounts for every tool and role", async () => {
     const catalog = await readJson("site/api/tools.json");
-    const html = await readText("site/developers/index.html");
+    const html = await readText("site/docs/index.html");
     const missing = catalog.tools
       .map((t: { name: string }) => t.name)
       .filter((n: string) => !html.includes(n));
@@ -289,8 +289,203 @@ describe("hand-written pages agree with the generated catalog", () => {
   });
 });
 
+describe("the agent-facing surface an agent probes for", () => {
+  // Everything in this block is a document agents fetch by CONVENTION rather
+  // than by following a link: the well-known paths, the markdown twins, and the
+  // ?mode=agent view. Nothing on the site links to most of them, so a rename or
+  // a Caddy edit can quietly unpublish one without a single broken link.
+  const CADDY = "deploy/caddy.d/setoku-com.caddy";
+
+  test("the well-known discovery files exist and are self-describing", async () => {
+    const card = await readJson("site/.well-known/agent-card.json");
+    expect(card.name).toBe("Setoku");
+    expect(card.description).toContain("Setoku");
+    expect(card.skills.length).toBeGreaterThan(2);
+    for (const s of card.skills) {
+      expect(s.name).toBeString();
+      expect(s.description.length).toBeGreaterThan(20);
+    }
+
+    const skills = await readJson("site/.well-known/agent-skills/index.json");
+    expect(skills.skills.length).toBeGreaterThan(2);
+    for (const s of skills.skills) {
+      expect(s.name).toBeString();
+      expect(s.description.length).toBeGreaterThan(20);
+    }
+
+    const mcp = await readJson("site/.well-known/mcp.json");
+    expect(mcp.remotes.some((r: { type: string }) => r.type === "streamable-http")).toBe(true);
+    expect(mcp.auth.oauth2).toBe(false);
+  });
+
+  test("the skill index publishes exactly the skills we ship", async () => {
+    const glob = new Bun.Glob("*/SKILL.md");
+    const dirs: string[] = [];
+    for await (const f of glob.scan({ cwd: ROOT + "plugin/skills" })) dirs.push(f.split("/")[0]);
+    const published = (await readJson("site/.well-known/agent-skills/index.json")).skills.map(
+      (s: { name: string }) => s.name,
+    );
+    expect(published.sort()).toEqual(dirs.sort());
+  });
+
+  test("every discovery file says WHEN to use Setoku, not just what it is", async () => {
+    // The one thing marketing copy never states outright, and the thing an agent
+    // most needs in order to decide whether to reach for us at all.
+    for (const p of [
+      "site/.well-known/agent-card.json",
+      "site/.well-known/mcp.json",
+      "site/.well-known/agent-skills/index.json",
+    ]) {
+      const doc = await readJson(p);
+      const when = doc.whenToUse ?? doc.when_to_use;
+      expect({ file: p, hasGuidance: !!when }).toEqual({ file: p, hasGuidance: true });
+      expect(when.use_when.length).toBeGreaterThan(2);
+      expect(when.do_not_use_when.length).toBeGreaterThan(2);
+      expect(when.how_to_call.join(" ")).toContain("find_context");
+    }
+    // The prose pages state the same rule in the same words, so an agent that
+    // reads llms.txt and an agent that reads the markdown twin get one answer.
+    for (const p of ["site/llms.txt", "site/index.md", "site/docs.md"]) {
+      expect(await readText(p)).toContain("Reach for Setoku when the answer lives in");
+    }
+  });
+
+  test("the markdown twins are markdown, and lead with a heading", async () => {
+    for (const p of ["site/index.md", "site/docs.md"]) {
+      const body = await readText(p);
+      expect({ page: p, first: body.split("\n")[0] }).toEqual({
+        page: p,
+        first: p.endsWith("index.md") ? "# Setoku" : "# Setoku API reference",
+      });
+      expect(body).not.toContain("<html");
+      // Straight apostrophes are a site-copy smell (CLAUDE.md), and these pages
+      // are generated, so a regression here is a generator bug, not a typo.
+      expect(body).not.toMatch(/[A-Za-z]'[A-Za-z]/);
+    }
+  });
+
+  test("angle-bracket placeholders survive being rendered", async () => {
+    // `<their-box>` outside a code span is a raw-HTML tag in CommonMark, and
+    // every renderer swallows it: `https://<their-box>/mcp/<token>` displayed as
+    // `https:///mcp/`, silently deleting the host and the token out of the one
+    // instruction these pages most need to get right. Either escape it or put it
+    // in backticks — this checks the rendered result rather than the technique.
+    for (const p of ["site/index.md", "site/docs.md", "site/llms.txt"]) {
+      const swallowed: string[] = [];
+      // strip fenced/indented code and code spans: inside them `<` is literal
+      const text = (await readText(p))
+        .split("\n")
+        .filter((l) => !l.startsWith("    "))
+        .join("\n")
+        .replace(/`[^`]*`/g, "");
+      // `\<` is a CommonMark backslash escape and renders as a literal `<`.
+      for (const [, m] of text.matchAll(/(?:^|[^\\])(<[A-Za-z][A-Za-z0-9-]*>)/g)) {
+        swallowed.push(m);
+      }
+      expect({ page: p, swallowed }).toEqual({ page: p, swallowed: [] });
+    }
+  });
+
+  test("the box's error shape is documented as the spec declares it", async () => {
+    // /docs.md used to promise a structured {code, message, hint} envelope
+    // from every endpoint. The gateway returns {ok:false, error:"<string>"} —
+    // which is what the openapi.json emitted by this same generator says — so
+    // the published docs contradicted the published spec in one build, and an
+    // integrator branching on `error.code` matched nothing forever.
+    const spec = await readJson("site/openapi.json");
+    expect(spec.components.schemas.Error.properties.error.type).toBe("string");
+    const md = await readText("site/docs.md");
+    expect(md).toContain('{ "ok": false, "error": "app not found or archived" }');
+  });
+
+  test("/docs.md describes the membrane the way app.ts implements it", async () => {
+    // Only the curator/janitor tools are registration-gated; the analyst surface
+    // is registered on EVERY session and the lake block is a call-time refusal.
+    // Publishing "the tools of the others are never registered" made a false
+    // statement about I2 on a public URL — the exact thing tools() throws to
+    // prevent — and told a curator session that find_context was unavailable.
+    const md = await readText("site/docs.md");
+    expect(md).toContain("registered on every session");
+    expect(md).toContain("refuses lake queries");
+    expect(md).not.toContain("The tools of the others are not merely refused");
+  });
+
+  test("both HTML pages advertise their markdown twin", async () => {
+    for (const [html, md] of [
+      ["site/index.html", "https://setoku.com/index.md"],
+      ["site/docs/index.html", "https://setoku.com/docs.md"],
+    ]) {
+      const head = await readText(html);
+      expect(head).toContain('type="text/markdown"');
+      expect(head).toContain(md);
+    }
+  });
+
+  test("Caddy actually serves that surface (the files alone are not enough)", async () => {
+    // These behaviours were verified against caddy:2 locally; this pins the
+    // directives so an edit to the vhost cannot silently drop one. Without the
+    // Content-Type line, .md files go out as text/plain and a client checking
+    // the header concludes we do not serve markdown at all.
+    const conf = await readText(CADDY);
+    expect(conf).toContain('header @md Content-Type "text/markdown; charset=utf-8"');
+    expect(conf).toContain('{query.mode} == "agent"');
+    expect(conf).toContain("rewrite * /index.md");
+    expect(conf).toContain("rewrite * /docs.md");
+    expect(conf).toContain("handle_errors");
+    expect(conf).toContain('"code":"not_found"');
+    // Unmatched, so a newly published document is covered the day it lands. The
+    // per-path list this replaced had already missed /sitemap.xml — the file
+    // that enumerates the discovery documents for a browser-based agent.
+    expect(conf).toMatch(/^\theader Access-Control-Allow-Origin \*$/m);
+    // The HTML branch of the 404 has to have something to serve.
+    expect(conf).toContain("rewrite * /404.html");
+    expect(existsSync(ROOT + "site/404.html")).toBe(true);
+  });
+
+  test("api/index.json really does list everything the site publishes", async () => {
+    // Both 404 surfaces (the JSON body in the vhost and site/404.html) send
+    // readers to this file as the complete index, so "complete" has to be true:
+    // the five discovery documents were added to the build without reaching it,
+    // and an agent following that hint concluded we ship no MCP manifest at all.
+    const published: string[] = (await readJson("site/api/index.json")).publishes;
+    const artifacts = (await buildArtifacts()).map(
+      ([p]) => `https://setoku.com${p.slice("site".length)}`,
+    );
+    const missing = artifacts.filter((u) => !published.includes(u));
+    expect({ missing, hint: "add it to `publishes` in scripts/build-site-api.ts" }).toEqual({
+      missing: [],
+      hint: "add it to `publishes` in scripts/build-site-api.ts",
+    });
+    // …and the other direction: nothing listed that we do not actually serve.
+    const phantom = published.filter((u) => {
+      const p = u.replace("https://setoku.com", "site");
+      return !existsSync(ROOT + (p === "site/" ? "site/index.html" : p)) &&
+        !existsSync(ROOT + `${p}/index.html`);
+    });
+    expect(phantom).toEqual([]);
+  });
+
+  test("the JSON error body in the Caddy config is valid JSON with a code and a hint", async () => {
+    const conf = await readText(CADDY);
+    const bodies = [...conf.matchAll(/respond `([\s\S]*?)`\s/g)].map((m) => m[1]);
+    expect(bodies.length).toBeGreaterThan(1);
+    for (const raw of bodies) {
+      // {err.status_code} is a Caddy placeholder; substitute a number so the
+      // rest can be parsed. A body that only *looks* like JSON is the exact
+      // failure this catches — agents cannot parse an HTML error page, and they
+      // cannot parse a malformed one either.
+      const doc = JSON.parse(raw.replace(/\{err\.status_code\}/g, "500"));
+      expect(doc.ok).toBe(false);
+      expect(doc.error.code).toBeString();
+      expect(doc.error.message).toBeString();
+      expect(doc.error.hint.length).toBeGreaterThan(20);
+      expect(doc.error.docs).toStartWith("https://setoku.com");
+    }
+  });
+});
+
 describe("pages carry the structure crawlers and screen readers need", () => {
-  const PAGES = ["site/index.html", "site/developers/index.html"];
+  const PAGES = ["site/index.html", "site/docs/index.html"];
 
   test("each page has exactly one h1", async () => {
     for (const p of PAGES) {
@@ -338,7 +533,7 @@ describe("pages carry the structure crawlers and screen readers need", () => {
       );
     };
     const home = await idsFor("site/index.html");
-    const devs = await idsFor("site/developers/index.html");
+    const devs = await idsFor("site/docs/index.html");
     for (const shared of ["https://setoku.com/#software", "https://setoku.com/#org"]) {
       expect(home.has(shared)).toBe(true);
       expect(devs.has(shared)).toBe(true);


### PR DESCRIPTION
Second pass on the [orank](https://ora.ai) agent-readiness gaps, plus every finding from the code review of the first pass (#105).

## The surface an agent probes for

All generated by `scripts/build-site-api.ts`, so it cannot drift from the product:

| URL | What it is |
| --- | --- |
| `/.well-known/mcp.json` | endpoint, transport, auth, tool list |
| `/.well-known/agent-card.json` | who we are, what we do, our skills |
| `/.well-known/agent-skills/index.json` | the shipped skills, read from their `SKILL.md` |
| `/index.md`, `/docs.md` | markdown twins of the two content pages |
| `?mode=agent` | the same twin, for clients that pass a flag |

Every one of them carries the same `WHEN_TO_USE` block — what Setoku is right for, what it is wrong for, and how to call it (`find_context` first). That was the largest single gap in the scan, and the one thing marketing copy never says out loud. `llms.txt` is now **generated** from that same constant instead of retyping it, so the file an agent reads first cannot disagree with the rest.

Errors are JSON unless a browser asked for HTML: agents probe this host with `fetch()`, and an HTML error page is unparseable to them. Bodies carry a code, a message and a hint; `site/404.html` is the human half.

## From the review of the first pass

- `/docs.md` described a de-registration model the gateway does not implement. Only the curator/janitor tools are registration-gated; the analyst surface is registered on every session and the lake block is a call-time refusal. A false statement of I2 on a public URL is exactly what `tools()` throws to prevent.
- The same page documented an `{error: {code, hint}}` envelope no box returns. It now documents the three real shapes, pinned against `openapi.json`.
- `<their-box>` and `<token>` are raw-HTML tags in CommonMark: the rendered twins showed `https:///mcp/`, silently deleting the host and the token.
- The agent card advertised A2A's `JSONRPC` transport at an MCP endpoint. An A2A client would have sent `message/send` and blamed us for answering method-not-found. Better to be skipped than miscalled.
- `api/index.json` is advertised by both 404 surfaces as the complete index of the site, so it now carries a `publishes` list derived from the artifact list itself.
- CORS is one unmatched rule; the per-path list had already missed `/sitemap.xml`, the file that enumerates the discovery documents.

## /developers → /docs

The page calls itself the API reference now, rather than "developer documentation" — the homepage is for developers too, so that label named nothing. No redirect: the old path was live for minutes.

## Verification

Against `caddy:2` in a container, on the real tree: markdown content types, both `?mode=agent` forms, the JSON 404, the branded HTML 404, and CORS across every content type. `deploy:site` now probes all of it, including the HTML 404 branch that plain curl never reaches (it always lands in the JSON branch).

`bun test` 550 pass / 0 fail, `tsc --noEmit` clean.

https://claude.ai/code/session_013R7Bqocyqqv2HcDRqrMhdk