### PR TITLE
embeddings: batch 8, not 64 — cap the onnxruntime arena's RSS ratchet

### DIFF
--- a/plugin/gateway/lib/embeddings.ts
+++ b/plugin/gateway/lib/embeddings.ts
@@ -35,6 +35,17 @@ export function embeddingsEnabled(): boolean {
   return process.env.SETOKU_EMBEDDINGS !== "0";
 }
 
+/**
+ * Docs per onnxruntime inference call. Deliberately small: the runtime's arena
+ * allocator grows to a batch's peak working set and never gives it back, so the
+ * batch size sets the gateway's steady-state RSS floor for the life of the
+ * process. Measured on a 500-doc embed (1200-char docs): batch 64 ratchets RSS
+ * to ~1.7GB and holds it; batch 8 peaks at ~420MB. The cost is ~14% wall-clock
+ * on a full rebuild, which nobody waits on — the index build is background and
+ * vectors persist, so restarts only re-embed changed docs.
+ */
+const EMBED_BATCH_SIZE = 8;
+
 let cached: Promise<Embedder | null> | null = null;
 
 /** The process-wide embedder, or null if disabled/unavailable. Memoized. */
@@ -63,7 +74,7 @@ async function init(): Promise<Embedder | null> {
       dim,
       async embedDocs(texts) {
         const out: number[][] = [];
-        for await (const batch of model.embed(texts, 64))
+        for await (const batch of model.embed(texts, EMBED_BATCH_SIZE))
           for (const v of batch) out.push(Array.from(v as ArrayLike<number>));
         return out;
       },


### PR DESCRIPTION
Fixes the gateway's ~1–2GB idle RSS (#107).

## What was happening

`bun gateway/http.ts` held ~2GB RSS on hedgy and ~1GB on campsh even when idle — private dirty anonymous memory, so real heap, not file mappings or the SQLite page cache. The demo instance sat at the same ~2GB as the busy prod instance, so it was never traffic-driven.

The BGE-small model itself is only ~300MB loaded. The rest is onnxruntime's arena allocator: it grows to the peak working set of an embedding batch and never returns it. That makes the doc-embedding batch size the process's steady-state RSS floor for its whole life, and explains why RSS tracked box size (arena/thread-pool sizing scales with core count) rather than load.

Measured on a standalone bun script (init model → embed 500 docs of ~1200 chars → repeat):

| stage | batch 64 (before) | batch 8 (after) |
|---|---|---|
| model load + warmup | 379 MB | 388 MB |
| after embedding 500 docs | **1,670 MB** | **418 MB** |
| second pass (1000 total) | 1,815 MB | 392 MB |

The second pass barely moves either way — it's a ratchet to peak batch size, not a leak.

## The change

`EMBED_BATCH_SIZE = 8` in `plugin/gateway/lib/embeddings.ts`, named and commented so the next person doesn't "optimize" it back up. This is the only bulk-embed call site in the process; `queryEmbed` (warmup and the query path) is single-input, so 8 is now the process-wide ceiling on arena growth.

## Trade-off

~14% slower end-to-end on a 1,000-doc embed run (84s vs 74s, including model load). Not user-facing: the index build is background and non-blocking by design, and vectors persist, so restarts re-embed only changed docs. In exchange, steady-state gateway RSS drops from ~1.9GB to ~450MB, which is what matters on the smaller deployment targets.

## Verification

- `bun run typecheck` clean; `bun test` — 578 pass, 21 skip, 0 fail.
- Confirmed the symptom is still live before changing anything: hedgy's two gateway processes were at 2.05GB and 2.04GB RSS. `64` had been in place since #32 and was never a prior fix.
- Memory numbers above are from the issue's repro, not re-measured here.

Takes effect on a box only after a deploy plus gateway restart — the arena floor is set for the life of the process.

Closes #107