### PR TITLE
Small-box hardening: bootstrap swap + RAM-derived ClickHouse preset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,10 @@ SETOKU_DATABASE_URL=
 #SETOKU_HEALTHZ_PING=vector=http://vector:8686/health
 
 # ── clickhouse sizing ───────────────────────────────────────────────────────
-# small = 4–8 GB boxes (Hetzner CX32) · roomy = 24 GB prototype (Oracle A1)
+# tiny = under ~3.3 GB · small = 4–8 GB (Hetzner CX32) · roomy = 12 GB and up
+# deploy/bootstrap.sh picks this from the box's RAM; set it by hand only if you
+# skipped bootstrap or want to override. `bash deploy/ch-preset.sh` prints the
+# preset this box would get.
 SETOKU_CH_PRESET=small
 
 # ── backups (I4 — bucket on a DIFFERENT provider than the box) ──────────────

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -14,8 +14,11 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 source deploy/dc.sh # docker compose v2/v1 shim
+source deploy/ch-preset.sh # ch_preset_for_ram_mb: sizing from RAM, not guesswork
 
 log() { echo "[bootstrap] $*"; }
+
+RAM_MB="$(ch_host_ram_mb)"
 
 # 1. Docker -----------------------------------------------------------------
 if ! command -v docker >/dev/null; then
@@ -25,7 +28,39 @@ if ! command -v docker >/dev/null; then
   log "Docker installed. If the next step can't reach the daemon, log out/in once (group change) and re-run."
 fi
 
-# 2. Firewall (defense in depth; only Caddy's 80/443 + SSH) -----------------
+# 2. Swap (a cushion, not headroom) -----------------------------------------
+# A small box runs with no slack at exactly one moment: a rebuild on the box,
+# where an image build has to fit alongside the whole running stack. 2 GB of
+# swap turns that spike from an OOM kill into a slow minute. Boxes with real
+# headroom (≥ 8 GB) don't need it and don't get it.
+FSTYPE="$(findmnt -no FSTYPE / 2>/dev/null || echo unknown)"
+DISK_FREE_GB="$(df -BG --output=avail / 2>/dev/null | tail -n1 | tr -dc '0-9')"
+if [ -n "$(swapon --show 2>/dev/null)" ]; then
+  : # already has swap (a provider-supplied partition counts) — leave it alone
+elif [ "${RAM_MB:-0}" -ge 8000 ]; then
+  : # enough headroom that the build spike fits in RAM
+elif [ "$FSTYPE" != "ext4" ] && [ "$FSTYPE" != "xfs" ]; then
+  log "no swap, but / is $FSTYPE — swapfiles need filesystem-specific setup there; skipping"
+elif [ "${DISK_FREE_GB:-0}" -lt 8 ]; then
+  log "no swap, but only ${DISK_FREE_GB}G free on / — skipping (a swapfile needs room to spare)"
+else
+  log "no swap on a ${RAM_MB} MB box → creating a 2G /swapfile…"
+  # dd, not fallocate: swapon rejects a file with unwritten extents on ext4.
+  sudo dd if=/dev/zero of=/swapfile bs=1M count=2048 status=none
+  sudo chmod 600 /swapfile
+  sudo mkswap /swapfile >/dev/null
+  sudo swapon /swapfile
+  grep -q '^/swapfile ' /etc/fstab || echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab >/dev/null
+fi
+# Emergency cushion, not a routine paging target: the default swappiness of 60
+# pages out ClickHouse's and the gateway's anon pages just to grow page cache,
+# which is the wrong trade when the gateway is answering a tool call.
+if [ "$(cat /proc/sys/vm/swappiness 2>/dev/null || echo 10)" != "10" ]; then
+  echo 'vm.swappiness=10' | sudo tee /etc/sysctl.d/99-setoku-swap.conf >/dev/null
+  sudo sysctl -q -p /etc/sysctl.d/99-setoku-swap.conf
+fi
+
+# 3. Firewall (defense in depth; only Caddy's 80/443 + SSH) -----------------
 if command -v ufw >/dev/null; then
   log "firewall: allowing 22/80/443…"
   sudo ufw allow 22/tcp >/dev/null
@@ -35,8 +70,10 @@ if command -v ufw >/dev/null; then
   sudo ufw --force enable >/dev/null
 fi
 
-# 3. .env (generated once; secrets randomized) ------------------------------
+# 4. .env (generated once; secrets randomized) ------------------------------
 if [ ! -f .env ]; then
+  CH_PRESET="$(ch_preset_for_ram_mb "$RAM_MB")"
+  log "clickhouse preset: $CH_PRESET (${RAM_MB} MB box)"
   DOMAIN="${1:-}"
   if [ -z "$DOMAIN" ]; then
     IP="$(curl -fsS4 https://ifconfig.me 2>/dev/null || hostname -I | awk '{print $1}')"
@@ -46,7 +83,7 @@ if [ ! -f .env ]; then
   gen() { openssl rand -hex 24; }
   umask 077
   # No SETOKU_TOKENS here: agent connectors are provisioned in the gateway's DB
-  # (step 5 creates the operator's), so they're rotatable/revocable at runtime.
+  # (step 6 creates the operator's), so they're rotatable/revocable at runtime.
   cat > .env <<EOF
 SETOKU_DOMAIN=$DOMAIN
 COMPOSE_PROFILES=lake,ingest
@@ -55,7 +92,7 @@ POSTGRES_PASSWORD=$(gen)
 CLICKHOUSE_USER=setoku
 CLICKHOUSE_PASSWORD=$(gen)
 CLICKHOUSE_RO_PASSWORD=$(gen)
-SETOKU_CH_PRESET=small
+SETOKU_CH_PRESET=$CH_PRESET
 SETOKU_HEALTHZ_PING=vector=http://vector:8686/health
 EOF
   # Second isolated stack on the same box (testing): persist the stack name and
@@ -72,10 +109,19 @@ EOF
   log "wrote .env (add SETOKU_DATABASE_URL if you want run_query against a business DB)"
 else
   log ".env exists — keeping it"
+  # Never silently reconfigure a box that's already running. Do say something if
+  # its RAM no longer matches the preset it was bootstrapped with (resized VPS,
+  # or a .env copied over from a bigger box).
+  WANT_PRESET="$(ch_preset_for_ram_mb "$RAM_MB")"
+  HAVE_PRESET="$(sed -n 's/^SETOKU_CH_PRESET=//p' .env | head -n1)"
+  if [ -n "$HAVE_PRESET" ] && [ "$HAVE_PRESET" != "$WANT_PRESET" ]; then
+    log "note: a ${RAM_MB} MB box would pick '$WANT_PRESET', .env says '$HAVE_PRESET'"
+    log "      (to switch: edit .env, then 'docker compose up -d --force-recreate clickhouse')"
+  fi
 fi
 set -a; source .env; set +a
 
-# 4. Bring up the stack -----------------------------------------------------
+# 5. Bring up the stack -----------------------------------------------------
 # Prefer the prebuilt gateway image (published by CI) — the box PULLS instead of
 # running bun install + baking the embed model on a small VPS. Fall back to an
 # on-box build only if the image can't be pulled (private/unpublished tag, air-gap).
@@ -89,7 +135,7 @@ else
 fi
 log "stack healthy."
 
-# 5. The operator: ONE person = your /admin login AND your agent connector ---
+# 6. The operator: ONE person = your /admin login AND your agent connector ---
 # (same identity for both — users and connectors are 1:1)
 ADMIN_LOGIN_MSG=""
 MCP_TOKEN=""
@@ -124,7 +170,7 @@ else
   fi
 fi
 
-# 6. Report -----------------------------------------------------------------
+# 7. Report -----------------------------------------------------------------
 # Legacy fallback: an old .env may still carry env-pinned SETOKU_TOKENS.
 [ -z "$MCP_TOKEN" ] && MCP_TOKEN="$(printf '%s' "${SETOKU_TOKENS:-}" | cut -d= -f1)"
 # Give this box a distinct connector name so a second box (a demo, another

--- a/deploy/ch-preset.sh
+++ b/deploy/ch-preset.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pick the ClickHouse memory/concurrency preset for this box's RAM.
+#
+#   source deploy/ch-preset.sh && ch_preset_for_ram_mb 3000   # → tiny
+#   bash deploy/ch-preset.sh 3000                             # → tiny
+#   bash deploy/ch-preset.sh                                  # → this box
+#
+# Thresholds are MemTotal MiB as `free -m` reports it, which runs a few percent
+# under the advertised size (a "4 GB" VPS reports ~3800). They come from
+# measured high-water marks on the running boxes, not from the sticker size:
+#
+#   - the gateway holds ~570 MB and does NOT shrink on a smaller box (that's
+#     the onnxruntime embedding arena), vector peaks ~350 MB, and caddy +
+#     postgres + the pollers add ~300 MB. That ~1.2 GB is the floor ClickHouse
+#     has to fit around, before the host's own ~300 MB.
+#   - a 4 GB box carrying exactly that load has run for weeks on `small` with
+#     zero OOM kills, so 4 GB stays on `small`. `tiny` is for the 3 GB class and
+#     below, where small's 0.7×RAM would hand ClickHouse memory the rest of the
+#     stack has already committed.
+#
+# Unknown/unparseable RAM falls back to `small`, which was the fixed default
+# before this file existed: a bad reading should never silently downgrade a box.
+
+ch_preset_for_ram_mb() {
+  local mb="${1:-}"
+  case "$mb" in
+    '' | *[!0-9]*) echo small; return 0 ;;
+  esac
+  if [ "$mb" -lt 3300 ]; then
+    echo tiny
+  elif [ "$mb" -lt 12000 ]; then
+    echo small
+  else
+    echo roomy
+  fi
+}
+
+ch_host_ram_mb() { free -m 2>/dev/null | awk '/^Mem:/{print $2}'; }
+
+# Executed directly (not sourced): print the preset for the given size, or this box's.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  ch_preset_for_ram_mb "${1:-$(ch_host_ram_mb)}"
+fi

--- a/deploy/clickhouse/tiny.xml
+++ b/deploy/clickhouse/tiny.xml
@@ -1,0 +1,31 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Setoku ClickHouse preset: TINY (boxes under ~3.3 GB reported RAM).
+     `small` is tuned for 4-8 GB and hands ClickHouse 0.7×RAM. Below ~3.3 GB
+     that ratio claims memory the rest of the stack has already committed: the
+     gateway alone holds ~570 MB (the embedding runtime, not elastic), vector
+     peaks ~350 MB, and caddy + postgres + the pollers add ~300 MB.
+
+     So: halve the memory ceiling and the merge concurrency, and keep exactly
+     `small`'s knob set rather than inventing new ones.
+
+     Status, honestly: derived from measured peaks on the 4 GB box, NOT yet
+     soaked on a real 3 GB box the way `small` was (AC 2.3, 24 h seed-scale
+     with zero OOM kills). Treat the first 3 GB deployment as that soak. -->
+<clickhouse>
+    <!-- 0.5, not small's 0.7: on ~2.9 GB usable that's a ~1.45 GB ceiling,
+         which leaves room for the ~1.2 GB the rest of the stack needs. -->
+    <max_server_memory_usage_to_ram_ratio>0.5</max_server_memory_usage_to_ram_ratio>
+    <background_pool_size>2</background_pool_size>
+    <!-- must stay below background_pool_size or the startup sanity check
+         refuses to boot — the same rule small.xml calls out for its 4 slots -->
+    <merge_tree>
+        <number_of_free_entries_in_pool_to_execute_mutation>1</number_of_free_entries_in_pool_to_execute_mutation>
+        <number_of_free_entries_in_pool_to_lower_max_size_of_merge>1</number_of_free_entries_in_pool_to_lower_max_size_of_merge>
+        <number_of_free_entries_in_pool_to_execute_optimize_entire_partition>1</number_of_free_entries_in_pool_to_execute_optimize_entire_partition>
+    </merge_tree>
+    <background_schedule_pool_size>2</background_schedule_pool_size>
+    <background_buffer_flush_schedule_pool_size>2</background_buffer_flush_schedule_pool_size>
+    <mark_cache_size>134217728</mark_cache_size><!-- 128 MiB (small: 256 MiB) -->
+    <uncompressed_cache_size>0</uncompressed_cache_size>
+    <max_concurrent_queries>8</max_concurrent_queries>
+</clickhouse>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,8 @@ services:
       CLICKHOUSE_DB: setoku
     volumes:
       - ch_data:/var/lib/clickhouse
-      # memory/concurrency preset: small (4–8 GB boxes) | roomy (24 GB prototype)
+      # memory/concurrency preset, picked from RAM by deploy/ch-preset.sh:
+      # tiny (under ~3.3 GB) | small (4–8 GB boxes) | roomy (12 GB and up)
       - ./deploy/clickhouse/${SETOKU_CH_PRESET:-small}.xml:/etc/clickhouse-server/config.d/zz-setoku-preset.xml:ro
       # rolling TTL on ClickHouse's own telemetry tables (system.*_log) so they
       # can't outgrow the lake — see deploy/clickhouse/system-logs.xml

--- a/test/ch-preset.test.ts
+++ b/test/ch-preset.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Drift lock: deploy/bootstrap.sh sizes ClickHouse from the box's RAM via
+ * deploy/ch-preset.sh. Two things have to hold, and neither is visible by
+ * reading the shell script:
+ *
+ *   1. a 4 GB box stays on `small`. That is the one mapping we have real
+ *      evidence for (weeks of uptime, zero OOM kills), so a later tweak to the
+ *      thresholds must not quietly demote it to `tiny`.
+ *   2. every name the picker can emit has a matching preset XML. compose
+ *      bind-mounts `./deploy/clickhouse/${SETOKU_CH_PRESET}.xml`, so a name
+ *      without a file is a box that won't start.
+ *
+ * Spawns bash on purpose — the picker is shell, and running the real script is
+ * the only way to catch a syntax slip in it. ONE spawn for the whole file:
+ * process-per-case is enough concurrent load to starve the boot-warm timing in
+ * test/event-discovery.test.ts when the full suite runs.
+ */
+import { describe, it, expect } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+const SCRIPT = path.join(ROOT, "deploy", "ch-preset.sh");
+
+/** Every RAM figure this file asks about, resolved in a single bash process. */
+const INPUTS = [
+  "1900", "2900", "3299", "3300", "3814", "7900", "11671", "12000", "15800",
+  "24000", "512", "999999", "", "unknown", "3.5G", "-1",
+];
+
+const presets: Record<string, string> = await (async () => {
+  const script = `. "${SCRIPT}"\n${INPUTS.map(
+    (mb) => `printf '%s\\t%s\\n' ${JSON.stringify(mb)} "$(ch_preset_for_ram_mb ${JSON.stringify(mb)})"`,
+  ).join("\n")}\n`;
+  const proc = Bun.spawn({ cmd: ["bash", "-c", script], stdout: "pipe", stderr: "pipe" });
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0 || err.trim()) throw new Error(`ch-preset.sh failed (${code}): ${err}`);
+  return Object.fromEntries(
+    out.trim().split("\n").map((line) => {
+      const [mb, preset] = line.split("\t");
+      return [mb ?? "", preset ?? ""];
+    }),
+  );
+})();
+
+const presetFor = (ramMb: string) => presets[ramMb];
+
+describe("ch-preset.sh", () => {
+  // MemTotal as `free -m` reports it, which runs a few percent under the
+  // advertised size — these are the numbers the boxes actually print.
+  const CASES: [string, string, string][] = [
+    ["1900", "tiny", "2 GB box"],
+    ["2900", "tiny", "3 GB box — the case tiny.xml exists for"],
+    ["3299", "tiny", "just under the boundary"],
+    ["3300", "small", "just over the boundary"],
+    ["3814", "small", "4 GB box — proven on small, must not demote"],
+    ["7900", "small", "8 GB box — the size small.xml was soaked at"],
+    ["11671", "small", "12 GB box"],
+    ["12000", "roomy", "roomy starts here"],
+    ["15800", "roomy", "16 GB box"],
+    ["24000", "roomy", "24 GB prototype"],
+  ];
+
+  for (const [mb, want, why] of CASES) {
+    it(`${mb} MB → ${want} (${why})`, () => {
+      expect(presetFor(mb)).toBe(want);
+    });
+  }
+
+  it("falls back to small on an unreadable RAM figure, never to tiny", () => {
+    // A bad reading should land on the fixed default this file replaced, not
+    // silently starve ClickHouse on a box that has plenty of memory.
+    for (const junk of ["", "unknown", "3.5G", "-1"]) {
+      expect(presetFor(junk)).toBe("small");
+    }
+  });
+
+  it("has a preset XML for every name it can emit", () => {
+    const emitted = new Set<string>();
+    for (const mb of ["512", "2900", "3814", "7900", "24000", "999999"]) {
+      emitted.add(presetFor(mb));
+    }
+    expect(emitted.size).toBe(3); // tiny | small | roomy — a 4th needs a file + this bump
+    for (const name of emitted) {
+      const xml = path.join(ROOT, "deploy", "clickhouse", `${name}.xml`);
+      expect(fs.existsSync(xml)).toBe(true);
+    }
+  });
+
+  it("keeps tiny's merge-pool entries under its background_pool_size", () => {
+    // ClickHouse's startup sanity check refuses to boot if a
+    // number_of_free_entries_in_pool_to_* value is >= background_pool_size, so
+    // a box on `tiny` would crash-loop rather than start degraded.
+    const xml = fs.readFileSync(
+      path.join(ROOT, "deploy", "clickhouse", "tiny.xml"),
+      "utf8",
+    );
+    const pool = Number(/<background_pool_size>(\d+)</.exec(xml)?.[1]);
+    expect(pool).toBeGreaterThan(0);
+    const entries = [...xml.matchAll(/<number_of_free_entries_in_pool_to_\w+>(\d+)</g)];
+    expect(entries.length).toBe(3);
+    for (const [, value] of entries) expect(Number(value)).toBeLessThan(pool);
+  });
+});


### PR DESCRIPTION
Two changes aimed at the low end, both sized from measured high-water marks on the running boxes rather than sticker sizes.

## Swap

Neither box has any swap, and swappiness is the default 60. A small box runs with no slack at exactly one moment: `scripts/deploy.sh` runs `docker compose up -d --build server`, so an image build has to fit alongside the whole running stack.

`bootstrap.sh` gains a step that creates a 2G `/swapfile` when there's no swap and RAM is under 8 GB, and pins `vm.swappiness=10` so it stays an emergency cushion rather than a routine paging target (at 60 the kernel pages out ClickHouse and gateway anon pages just to grow page cache, which is the wrong trade while the gateway is answering a tool call). Skipped on non-ext4/xfs roots and when `/` has under 8G free. `dd` rather than `fallocate` because `swapon` rejects unwritten extents on ext4.

This does not add headroom. It turns the build spike from an OOM kill into a slow minute.

## ClickHouse preset from RAM

`SETOKU_CH_PRESET` was hardcoded to `small` at `.env` generation. `deploy/ch-preset.sh` now derives it, and a new `tiny` preset covers the 3 GB class.

Below ~3.3 GB, `small`'s 0.7×RAM ratio hands ClickHouse memory the rest of the stack has already committed. From the boxes: the gateway holds ~570 MB and does **not** shrink on a smaller box (the onnxruntime embedding arena), vector peaks ~350 MB, and caddy + postgres + pollers add ~300 MB. `tiny` halves the ceiling to 0.5 and the merge concurrency to 2, keeping `small`'s knob set rather than inventing new ones.

| reported RAM | preset |
|---|---|
| under 3300 MB (3 GB class) | `tiny` |
| 3300–12000 MB (4 and 8 GB) | `small` |
| 12000 MB and up | `roomy` |

A 4 GB box stays on `small` deliberately: that is the size with weeks of real uptime and zero OOM kills behind it. An unreadable RAM figure falls back to `small`, never `tiny`.

An existing `.env` is never rewritten. A re-run only prints a note when the box's RAM no longer matches the preset it was bootstrapped with.

## Verification

`tiny.xml` was booted against `clickhouse-server:25.3` under a 3 GB cgroup cap:

- starts clean, zero `<Error>` lines
- every knob applied (`changed=1`), `max_server_memory_usage` resolves to 1.5 GiB
- 1.2M rows across 6 parts `OPTIMIZE ... FINAL` down to 1 part with zero errors, 360 MiB RSS

It has **not** had the 24 h soak `small` got, and its header comment says so.

`bun test` green (591 pass, 0 fail), `bun run typecheck` clean.

## Note for a follow-up, not fixed here

`test/event-discovery.test.ts:133` ("boot warm") polls only 2s (40 × 50ms) for a background warm to finish. An early draft of the new test spawned one bash process per case, and that concurrent load alone was enough to make it fail in the full suite while passing in isolation. The new test uses a single spawn, so the suite is green, but that 2s budget is a latent flake that will bite in CI under load.

https://claude.ai/code/session_01U817dNBX5RWT9s33Xk1fs2