### PR TITLE
ch-preset: don't read BASH_SOURCE unguarded under set -u

### DIFF
--- a/deploy/ch-preset.sh
+++ b/deploy/ch-preset.sh
@@ -40,6 +40,10 @@ ch_preset_for_ram_mb() {
 ch_host_ram_mb() { free -m 2>/dev/null | awk '/^Mem:/{print $2}'; }
 
 # Executed directly (not sourced): print the preset for the given size, or this box's.
-if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+# BASH_SOURCE is unset when this file arrives on stdin (`bash -s < ch-preset.sh`,
+# how a remote apply feeds it over ssh), and callers run under `set -u` — so the
+# :- default is load-bearing, not defensive noise. Unset means "not a direct
+# run": define the functions and let the caller invoke them.
+if [ "${BASH_SOURCE[0]:-}" = "$0" ]; then
   ch_preset_for_ram_mb "${1:-$(ch_host_ram_mb)}"
 fi

--- a/test/ch-preset.test.ts
+++ b/test/ch-preset.test.ts
@@ -92,6 +92,31 @@ describe("ch-preset.sh", () => {
     }
   });
 
+  it("is safe to source from stdin under set -u", async () => {
+    // Regression: the direct-run guard read BASH_SOURCE[0], which is UNSET when
+    // the file arrives on stdin — the shape a remote apply uses to run the real
+    // bootstrap logic over ssh (`ssh box 'bash -s' < script`). Under the
+    // `set -euo pipefail` every caller here uses, that aborted the script.
+    const proc = Bun.spawn({
+      cmd: ["bash", "-s"],
+      stdin: new Blob([
+        `set -euo pipefail\n${fs.readFileSync(SCRIPT, "utf8")}\nch_preset_for_ram_mb 2900\n`,
+      ]),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    expect(err.trim()).toBe("");
+    expect(code).toBe(0);
+    // Exactly one line: arriving on stdin must NOT also trigger the direct-run
+    // branch, or a sourcing caller gets a stray preset on stdout.
+    expect(out.trim()).toBe("tiny");
+  });
+
   it("keeps tiny's merge-pool entries under its background_pool_size", () => {
     // ClickHouse's startup sanity check refuses to boot if a
     // number_of_free_entries_in_pool_to_* value is >= background_pool_size, so


### PR DESCRIPTION
Follow-up to #110, found while applying its swap step to the campsh box.

## The bug

The direct-run guard in `deploy/ch-preset.sh` read `${BASH_SOURCE[0]}`, which is **unset** when the file arrives on stdin rather than from a path. Every caller runs under `set -euo pipefail`, so that aborted the script:

```
bash: line 44: BASH_SOURCE[0]: unbound variable
```

The shipped bootstrap path was never affected — `bootstrap.sh` sources the file by path, where `BASH_SOURCE` is set. But "only works when read from a path" is a sharp edge on a file whose entire job is to be sourced by deploy tooling, and it bit immediately: the natural way to apply a bootstrap step to a live box is to pipe the real merged logic over ssh (`ssh box 'bash -s' < script`) rather than retyping it locally and hoping the transcription matches.

## The fix

`${BASH_SOURCE[0]:-}` treats unset as "not a direct run": define the functions, print nothing, let the caller invoke them. That's the correct semantics for the stdin case anyway.

The regression test pipes the script through `bash -s` under `set -u` and asserts both halves: clean exit, **and** exactly one line of output, since a stray auto-run would put a preset on a sourcing caller's stdout.

Confirmed the test actually catches it — against the old script it fails with the exact `unbound variable` message; against the fix, 14 pass.

## Applied

campsh (`15.204.112.28`, 3814 MB) now has the swap from #110, using this fixed script:

```
NAME      TYPE SIZE USED PRIO
/swapfile file   2G   0B   -1
swappiness: 10
/etc/fstab: /swapfile none swap sw 0 0
```

Re-running is a silent no-op, all 8 containers untouched, `/healthz` green. Disk 41% → 44%. hedgy is deliberately untouched: at 11671 MB it's over the 8 GB threshold, so bootstrap would skip the swapfile there.

`bun test` green (592 pass), `bun run typecheck` clean.

https://claude.ai/code/session_01U817dNBX5RWT9s33Xk1fs2