### PR TITLE
Surface what a box actually holds, before any tool call

### DIFF
--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -29,6 +29,7 @@ import { extractSql } from "./lib/lint";
 import { queryCaptureNudge, panelCaptureNote } from "./lib/nudge";
 import { mirroredTables, mirrorNameOf, queryableTableName, type MirroredTable } from "./lib/mirror";
 import { LAKE_SOURCES, BEAT_LIVE_MS, BUSINESS_FAMILY, familyOf, familySlug, lakeFamilies, lakeRolesFor } from "./lib/sources";
+import { rosterLine, serverInstructions, type BoxRoster } from "./lib/roster";
 import {
   deniedFamiliesFor,
   docHidden,
@@ -104,6 +105,15 @@ export interface GatewayDeps {
    * base table only. Shared across per-request servers, like `store`.
    */
   derivedSynonyms?: DerivedSynonyms | null;
+  /**
+   * What this box actually holds, from the cached Sources probe (lib/roster).
+   * Pushed into the MCP `instructions` and the entry-point tool descriptions so
+   * a client learns the connector's subject matter WITHOUT calling a tool —
+   * the discoverability gap that let a personal-finance box read as a
+   * work-analytics one. Null (probe cold or failed) → the descriptions fall
+   * back to their source-agnostic text; nothing breaks, it's just less helpful.
+   */
+  roster?: BoxRoster | null;
 }
 
 /** Lake table → its source (for family resolution). Built once at module load,
@@ -192,9 +202,21 @@ export function buildServer({
   role,
   embedIndex = null,
   derivedSynonyms = null,
+  roster = null,
 }: GatewayDeps): McpServer {
 const { canWrite, denyLakeRead, canDraft, canReject } = capabilitiesFor(role);
-const server = new McpServer({ name: "setoku", version: VERSION });
+// Server-level instructions ride the initialize response — read once, before
+// any tool call, which is exactly when a client decides what this connector is
+// FOR. Everything else here is only read by a client that already chose to look.
+const server = new McpServer(
+  { name: "setoku", version: VERSION },
+  { instructions: serverInstructions(roster, { canWrite, denyLakeRead }) },
+);
+// Prefix for the entry-point tools' descriptions: the connected-source roster,
+// so "what data is behind this?" is answerable from the tool list alone.
+const holds = rosterLine(roster);
+const withRoster = (description: string): string =>
+  holds ? `${holds} ${description}` : description;
 
 // Per-user source access (I9): the ClickHouse roles to activate for THIS
 // session's lake reads, from the identity's denied families. Computed per
@@ -414,14 +436,17 @@ server.registerTool(
   "find_context",
   {
     annotations: { readOnlyHint: true },
-    title: "Find business context (verified + unverified)",
-    description:
-      "ALWAYS call FIRST, the instant a data/business question arrives — before any planning, schema " +
-      "exploration, or reasoning about what a term means; call it with the question, THEN reason over " +
-      "what it returns. Retrieves verified business context (entity semantics, canonical metric " +
+    title: "Find context for this connector's data (verified + unverified)",
+    description: withRoster(
+      "ALWAYS call FIRST, the instant a question about this connector's data arrives — before any " +
+      "planning, schema exploration, or reasoning about what a term means; call it with the question, THEN " +
+      "reason over what it returns. Retrieves verified context (entity semantics, canonical metric " +
       "definitions, known-good queries, gotchas, and pending unverified team knowledge) for a " +
-      "natural-language question. Trust it over your own inference from table/column names — it encodes " +
-      "how this business actually computes things.",
+      "natural-language question. Trust it over your own inference from table/column names — it " +
+      "encodes how the numbers here are actually computed. A thin result means the KNOWLEDGE is thin, " +
+      "never that the data is absent: check list_sources / get_schema before saying anything is " +
+      "unavailable.",
+    ),
     inputSchema: {
       question: z
         .string()
@@ -520,6 +545,18 @@ server.registerTool(
         "",
       );
     }
+    // Retrieval came back with nothing: the exact moment a reader concludes
+    // "Setoku doesn't cover this" and stops. It doesn't follow — the knowledge
+    // store being silent on a topic says nothing about what data is connected.
+    // So name the sources here too, where the wrong inference gets made. Gated
+    // on a genuine miss (not merely uncovered TERMS, which is a vocabulary
+    // mismatch) so it stays rare enough to keep reading.
+    if (!top.length && holds) {
+      coverage.push(
+        `Before concluding this box can't answer the question: ${holds} Call list_sources for the current, table-level list.`,
+        "",
+      );
+    }
     out.push(...coverage);
     if (selectedGotchas.length) {
       out.push("## Gotchas (read carefully — these prevent wrong answers)");
@@ -547,6 +584,8 @@ server.registerTool(
       });
       // An empty store is where pointers matter MOST — dropping them here would
       // hand the emptiest box the least help, having already paid for the lookup.
+      // `coverage` carries the roster line too (top.length is 0 here), so an
+      // empty knowledge store still says what the box HOLDS.
       return text([NO_KNOWLEDGE_HINT, ...(coverage.length ? ["", ...coverage] : [])].join("\n"));
     }
     if (top.length === 0) {
@@ -1031,12 +1070,14 @@ server.registerTool(
   {
     annotations: { readOnlyHint: true, openWorldHint: true },
     title: "List connected data sources (capabilities)",
-    description:
-      "Lists what Setoku can query RIGHT NOW: the biz.* Postgres mirror, data-lake tables (logs, " +
-      "product events, finance, chat) with what each holds, and the knowledge store. Capabilities are " +
-      "DYNAMIC, so call this whenever unsure whether Setoku has data for a question, BEFORE telling the " +
-      'user it isn\'t available. Everything is queried via run_query dialect:"clickhouse" — business ' +
-      "tables as biz.<table>, lake tables as setoku.<table>.",
+    description: withRoster(
+      "Lists what this box can query RIGHT NOW, table by table: the biz.* Postgres mirror, every " +
+      "connected lake source with what it holds, and the knowledge store. Capabilities are DYNAMIC and " +
+      "change without this tool list changing — so call this whenever unsure whether Setoku has data " +
+      "for a question, and ALWAYS before telling the user something isn't available. Everything is " +
+      'queried via run_query dialect:"clickhouse" — business tables as biz.<table>, lake tables as ' +
+      "setoku.<table>.",
+    ),
     inputSchema: {},
   },
   async () => {
@@ -1209,12 +1250,13 @@ server.registerTool(
   {
     annotations: { readOnlyHint: true, openWorldHint: true },
     title: "Queryable schema (biz.* mirror + lake, permission-scoped)",
-    description:
+    description: withRoster(
       "Describes every table you can query, straight from ClickHouse metadata: the biz.* Postgres " +
-      "mirror and the setoku.* lake tables (the gateway has no direct direct Postgres path). " +
+      "mirror and the setoku.* lake tables (the gateway has no direct Postgres path). " +
       "With no arguments: compact list of all tables + column names, biz.* first. With `tables`: full " +
       "detail (column types + the table's ORDER BY key) for those tables. Tables not listed here are " +
       "off-limits — do not query them.",
+    ),
     inputSchema: {
       tables: z
         .array(z.string())
@@ -1358,14 +1400,15 @@ server.registerTool(
   {
     annotations: { readOnlyHint: true, openWorldHint: true },
     title: "Run a read-only SQL query (capped + audited)",
-    description:
+    description: withRoster(
       "Executes ONE read-only ClickHouse SQL statement (statement timeout + row cap; audited with your " +
-      "identity): the biz.* Postgres mirror plus the lake (logs/events/Slack archive). The direct " +
-      "direct Postgres path is retired — business tables are read as biz.<table>. Engine-enforced " +
+      "identity): the biz.* Postgres mirror plus every connected lake source. The direct " +
+      "Postgres path is retired — business tables are read as biz.<table>. Engine-enforced " +
       "readonly and engine-enforced table access. " +
       "Workflow: find_context first, prefer canonical metric SQL via get_metric, always include an explicit " +
       "LIMIT, never SELECT * on wide tables. Writes/DDL are rejected. Discover tables with get_schema or " +
       "SHOW TABLES / DESCRIBE <table>.",
+    ),
     inputSchema: {
       sql: z.string().describe("A single SELECT/WITH/EXPLAIN statement (ClickHouse SQL)"),
       dialect: z

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -436,7 +436,7 @@ server.registerTool(
   "find_context",
   {
     annotations: { readOnlyHint: true },
-    title: "Find context for this connector's data (verified + unverified)",
+    title: "Find context for this connector's data",
     description: withRoster(
       "ALWAYS call FIRST, the instant a question about this connector's data arrives — before any " +
       "planning, schema exploration, or reasoning about what a term means; call it with the question, THEN " +
@@ -657,7 +657,7 @@ server.registerTool(
   "list_entities",
   {
     annotations: { readOnlyHint: true },
-    title: "List documented business entities",
+    title: "List everything in the knowledge store",
     description:
       "Lists every documented entity, metric, and canonical query in the knowledge store " +
       "(name + one-line summary). Cheap index — use it to discover what context exists.",
@@ -879,7 +879,7 @@ server.registerTool(
   "resolve_correction",
   {
     annotations: { readOnlyHint: false, destructiveHint: false },
-    title: "Resolve a pending correction (curator)",
+    title: "Resolve a pending correction",
     description:
       "Marks a pending correction accepted or rejected. Curation workflow: on accept, ALSO fold the knowledge " +
       "into the store via upsert_context (a gotcha bullet, a metric doc, an entity edit) — resolving alone only " +
@@ -902,7 +902,7 @@ server.registerTool(
   "upsert_context",
   {
     annotations: { readOnlyHint: false, destructiveHint: false },
-    title: "Create or update a knowledge doc (generate/curate workflows)",
+    title: "Create or update a knowledge doc",
     description:
       "Writes a context document into the knowledge store: entity, metric, query, overview, or gotcha. " +
       "Used by the /setoku:generate and /setoku:curate workflows — do NOT use it mid-analysis to record " +
@@ -989,7 +989,7 @@ server.registerTool(
   "draft_correction",
   {
     annotations: { readOnlyHint: false, destructiveHint: false },
-    title: "Attach a drafted doc-edit to a pending correction (auto-draft)",
+    title: "Attach a drafted doc-edit to a pending correction",
     description:
       "Writes a DRAFT — the exact upsert payload approving the correction would commit — plus advisory FLAGS " +
       "onto a pending correction, so the human curator reviews a finished change instead of a raw note. This " +
@@ -1038,7 +1038,7 @@ server.registerTool(
   "reject_correction",
   {
     annotations: { readOnlyHint: false, destructiveHint: false },
-    title: "Auto-reject a pending correction (janitor, reject-only)",
+    title: "Auto-reject a pending correction",
     description:
       "Rejects a pending correction — queue status only, grants ZERO knowledge authority. Use ONLY for items " +
       "that fail OBJECTIVE checks: drafted SQL errors, references a denied table, malformed, an exact duplicate " +
@@ -1069,7 +1069,7 @@ server.registerTool(
   "list_sources",
   {
     annotations: { readOnlyHint: true, openWorldHint: true },
-    title: "List connected data sources (capabilities)",
+    title: "List connected data sources",
     description: withRoster(
       "Lists what this box can query RIGHT NOW, table by table: the biz.* Postgres mirror, every " +
       "connected lake source with what it holds, and the knowledge store. Capabilities are DYNAMIC and " +
@@ -1249,7 +1249,7 @@ server.registerTool(
   "get_schema",
   {
     annotations: { readOnlyHint: true, openWorldHint: true },
-    title: "Queryable schema (biz.* mirror + lake, permission-scoped)",
+    title: "Every table and column you can query",
     description: withRoster(
       "Describes every table you can query, straight from ClickHouse metadata: the biz.* Postgres " +
       "mirror and the setoku.* lake tables (the gateway has no direct Postgres path). " +
@@ -1399,7 +1399,7 @@ server.registerTool(
   "run_query",
   {
     annotations: { readOnlyHint: true, openWorldHint: true },
-    title: "Run a read-only SQL query (capped + audited)",
+    title: "Run a read-only SQL query",
     description: withRoster(
       "Executes ONE read-only ClickHouse SQL statement (statement timeout + row cap; audited with your " +
       "identity): the biz.* Postgres mirror plus every connected lake source. The direct " +
@@ -1846,7 +1846,7 @@ server.registerTool(
   "app_guide",
   {
     annotations: { readOnlyHint: true },
-    title: "How to build a Setoku app (read before publish_app / update_app)",
+    title: "How to build a Setoku app",
     description:
       "Call this FIRST whenever you're about to author or edit an app — the same way you call find_context " +
       "before querying. Returns the full template + Setoku.* helper + panels/params/state contract you need " +
@@ -1863,7 +1863,7 @@ server.registerTool(
   "publish_app",
   {
     annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
-    title: "Publish a live app to the box (team-shareable URL)",
+    title: "Publish a live app to the box",
     description:
       "Publishes an app backed by LIVE data and returns a shareable URL. Use this to SHARE a result with " +
       "the team as a link that stays current — not for answering in-session. " +
@@ -1953,7 +1953,7 @@ server.registerTool(
   "update_app",
   {
     annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
-    title: "Edit an app you published (in place, same link)",
+    title: "Edit an app you published",
     description:
       "Updates an app you created — keeping its id and shareable link. Pass only what changes: `title`, `html` " +
       "(new template), `panels` (REPLACES the whole panel set), `params` (REPLACES all inputs), and/or `refreshSeconds`. " +
@@ -2153,7 +2153,7 @@ server.registerTool(
   "get_app",
   {
     annotations: { readOnlyHint: true },
-    title: "Inspect an app — its full template + panels (how it's built)",
+    title: "Inspect an app — its full template and panels",
     description:
       "Returns everything needed to edit a published app in place: the full presentation TEMPLATE " +
       "(the exact `html`/JS you'd pass back to update_app), its interactive `params`, and each panel's " +

--- a/plugin/gateway/http.ts
+++ b/plugin/gateway/http.ts
@@ -33,7 +33,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { buildServer, warmDiscoveryCaches, type TokenRole } from "./app";
 import { EmbedIndex } from "./lib/embed-index";
 import { DerivedSynonyms } from "./lib/derived-synonyms";
-import { loadConfig, resolveProjectDir, connectorName } from "./lib/config";
+import { loadConfig, resolveProjectDir, connectorName, boxName } from "./lib/config";
 import { notifyActivity } from "./lib/notify";
 import { gatherEgress, setEgressThreshold, egressTick } from "./lib/egress";
 import {
@@ -162,9 +162,9 @@ const probeCache = new Map<string, { at: number; value: unknown }>();
 // defeating the point of the cache. The promise is cleared when it settles.
 const probeInflight = new Map<string, Promise<unknown>>();
 const denyKey = (denied: Set<string>): string => [...denied].sort().join(",");
-async function cachedProbe<T>(key: string, produce: () => Promise<T>): Promise<T> {
+async function cachedProbe<T>(key: string, produce: () => Promise<T>, ttlMs = PROBE_TTL_MS): Promise<T> {
   const hit = probeCache.get(key);
-  if (hit && Date.now() - hit.at < PROBE_TTL_MS) return hit.value as T;
+  if (hit && Date.now() - hit.at < ttlMs) return hit.value as T;
   const pending = probeInflight.get(key);
   if (pending) return pending as Promise<T>;
   const p = (async () => {
@@ -742,6 +742,7 @@ echo "    how many companies are paying us right now?"
 // Lake source tables we know how to surface (shared with the list_sources MCP
 // tool) — query only the ones that actually exist; see gatherSources().
 import { LAKE_SOURCES, BUSINESS_FAMILY, familyOf, familySlug, lakeFamilies, sourceAccessDisabled } from "./lib/sources";
+import { rosterFrom, type BoxRoster } from "./lib/roster";
 import {
   deniedFamiliesFor,
   metricDocHidden,
@@ -871,6 +872,46 @@ async function gatherSources(denied: Set<string> = new Set()): Promise<SourcesDa
   for (const d of visibleKnowledge) byType[d.type] = (byType[d.type] ?? 0) + 1;
 
   return { mirror, lake, knowledge: { docs: visibleKnowledge.length, byType } };
+}
+
+/**
+ * What this box holds, for the MCP surface (lib/roster) — the connected-source
+ * roster that rides the server `instructions` and the entry-point tool
+ * descriptions, so a client learns the connector's subject matter without
+ * calling a tool.
+ *
+ * Cached far longer than the Sources page (5 min, vs 10s): which sources are
+ * CONNECTED changes on the order of days, while row counts change constantly,
+ * and this runs on the MCP request path — every tools/list and every tools/call
+ * — where the ~17-query fan-out would otherwise be a standing tax on a small
+ * box. Stale entries are served immediately and refreshed behind the request,
+ * so only the very first call after boot ever waits. It reuses the Sources
+ * probe's own cache, so a warm /admin Sources page costs this nothing.
+ *
+ * Failure is silent by design: a null roster degrades the descriptions to their
+ * source-agnostic text. A cold or broken lake must never fail an MCP request.
+ */
+const ROSTER_TTL_MS = 5 * 60_000;
+async function rosterFor(denied: Set<string>): Promise<BoxRoster | null> {
+  const key = `roster:${denyKey(denied)}`;
+  const build = async (): Promise<BoxRoster | null> => {
+    try {
+      const sources = await cachedProbe(`sources:${denyKey(denied)}`, () => gatherSources(denied));
+      return rosterFrom(sources, boxName(projectDir), Date.now());
+    } catch {
+      return null;
+    }
+  };
+  const hit = probeCache.get(key) as { at: number; value: BoxRoster | null } | undefined;
+  if (hit && Date.now() - hit.at < ROSTER_TTL_MS) return hit.value;
+  const refreshed = cachedProbe(key, build, ROSTER_TTL_MS);
+  // Stale-while-revalidate: an existing (expired) snapshot answers now and the
+  // refresh lands for the next request. Only a cold cache blocks.
+  if (hit) {
+    void refreshed.catch(() => {});
+    return hit.value;
+  }
+  return refreshed;
 }
 
 /**
@@ -2899,6 +2940,9 @@ const httpServer = http.createServer(async (req, res) => {
       role: auth.role,
       embedIndex,
       derivedSynonyms,
+      // Deny-scoped like every other probe: a restricted member's tool
+      // descriptions must not advertise a family they can't query.
+      roster: await rosterFor(deniedFamiliesFor(store.sourceDenies(auth.identity))),
     });
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,

--- a/plugin/gateway/lib/config.ts
+++ b/plugin/gateway/lib/config.ts
@@ -67,6 +67,17 @@ export function slugifyName(raw: string | undefined | null): string {
 }
 
 /**
+ * The short human name for THIS box ("campsh"), unslugified: SETOKU_NAME (env)
+ * wins over config.name. Null when neither is set. connectorName() slugifies
+ * this, and the MCP roster (lib/roster) prints it, so the precedence lives here
+ * once rather than drifting between the two.
+ */
+export function boxName(projectDir: string): string | null {
+  const res = loadConfig(projectDir);
+  return process.env.SETOKU_NAME ?? (res.ok ? res.config.name : undefined) ?? null;
+}
+
+/**
  * The Claude Code connector name for this box: `<slug>-setoku`, from
  * SETOKU_NAME (env) or config.name, else the bare `setoku`. `suffix` appends a
  * role for the operator-only connectors (e.g. "curator" → `<slug>-setoku-curator`).
@@ -74,9 +85,7 @@ export function slugifyName(raw: string | undefined | null): string {
  * a restart.
  */
 export function connectorName(projectDir: string, suffix = ""): string {
-  const res = loadConfig(projectDir);
-  const raw = process.env.SETOKU_NAME ?? (res.ok ? res.config.name : undefined);
-  const slug = slugifyName(raw);
+  const slug = slugifyName(boxName(projectDir));
   const base = slug ? `${slug}-setoku` : "setoku";
   return suffix ? `${base}-${suffix}` : base;
 }

--- a/plugin/gateway/lib/roster.ts
+++ b/plugin/gateway/lib/roster.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * The box roster — what THIS deployment actually holds, rendered into the two
+ * surfaces a client reads BEFORE it calls any tool: the MCP server
+ * `instructions` (sent once, at connect) and the entry-point tool descriptions.
+ *
+ * Why this exists: every static string in the tool surface used to say
+ * "business" — business context, biz.*, Slack archive. On a box whose lake is
+ * Monarch + Gmail, that teaches a client the connector is a work-analytics tool,
+ * and it then answers "I don't have access to your personal finances" without
+ * calling anything. `list_sources` had the truth all along, but only in its
+ * RETURN value: you had to already suspect the answer to call the tool that
+ * tells you. Discovery that requires calling the discovery tool isn't discovery.
+ *
+ * So the roster is derived from the same live probe the /admin Sources page
+ * reads (one cached snapshot, no new ClickHouse load) and pushed OUT to where a
+ * client looks first.
+ */
+
+import { BEAT_LIVE_MS, familyOf } from "./sources";
+import type { SourcesData } from "./approval";
+
+/**
+ * Plain-language domain for each source family — what a person would say the
+ * data IS, not the vendor that supplies it. "Monarch" means nothing to a reader
+ * asking about their mortgage; "personal finance" does.
+ *
+ * Keyed by the family label (the part before " · " in a LAKE_SOURCES `source`),
+ * so adding a connector to a family it already belongs to needs nothing here. A
+ * family with no entry falls back to its own label, which is never wrong — only
+ * less helpful. `test/roster.test.ts` fails if a family loses its phrase.
+ */
+export const FAMILY_DOMAIN: Record<string, string> = {
+  Monarch: "personal finance: transactions, balances, net worth, budgets, investment holdings",
+  Gmail: "personal email: senders, subjects, bodies",
+  GitHub: "software development activity: issues, pull requests, commits, code review",
+  Mercury: "business banking: balances, transactions, burn, runway",
+  Slack: "team chat archive: channel messages and thread replies",
+  Vercel: "web hosting logs: requests, build and runtime errors, latency",
+  Render: "app server logs: stdout/stderr, deploy and runtime errors",
+  "First-party events": "product analytics: first-party events the app emits",
+  Postgres: "the application database, mirrored table-for-table as biz.*",
+};
+
+/** Families that are plumbing, not a thing anyone "has data about". */
+const NOT_A_DOMAIN = new Set(["Unrouted (raw)", "Postgres mirror"]);
+
+export interface BoxRoster {
+  /** Short human name for this box (config.name, e.g. "campsh"), or null. */
+  box: string | null;
+  /** Connected source families, in LAKE_SOURCES order. */
+  families: string[];
+  /** Count of biz.* mirrored tables (0 when no mirror runs here). */
+  mirrored: number;
+  /** Curated docs visible to this identity. */
+  docs: number;
+}
+
+/**
+ * The families that are actually CONNECTED: at least one table holding rows, or
+ * a connector beating within the liveness window. Bootstrap creates every lake
+ * table up front, so existence alone proves nothing — and a family whose poller
+ * is merely paused still has queryable history, so rows alone don't either.
+ * (Same rule list_sources and the Sources page draw, in one place.)
+ */
+export function connectedFamilies(tables: SourcesData["lake"]["tables"], nowMs: number): string[] {
+  const live = new Set<string>();
+  for (const t of tables) {
+    const family = familyOf(t.source);
+    if (NOT_A_DOMAIN.has(family)) continue;
+    const beatMs = t.beat ? Date.parse(t.beat) : NaN;
+    const flowing = Number.isFinite(beatMs) && nowMs - beatMs < BEAT_LIVE_MS;
+    if ((t.rows ?? 0) > 0 || flowing) live.add(family);
+  }
+  return [...live];
+}
+
+/** Build the roster from the /admin Sources snapshot. */
+export function rosterFrom(sources: SourcesData, box: string | null, nowMs: number): BoxRoster {
+  return {
+    box,
+    families: connectedFamilies(sources.lake.tables, nowMs),
+    mirrored: sources.mirror.tables.length,
+    docs: sources.knowledge.docs,
+  };
+}
+
+/** `["Monarch", "Gmail"]` → `"personal finance …; personal email …"`. */
+function domains(families: string[]): string[] {
+  return families.map((f) => FAMILY_DOMAIN[f] ?? f);
+}
+
+/**
+ * The one-line roster prepended to the entry-point tool descriptions — the only
+ * text a client is guaranteed to read before deciding whether this connector is
+ * relevant. Null when nothing is connected (say nothing rather than promise an
+ * empty box).
+ *
+ * Deliberately omits the box name: this line repeats across every entry-point
+ * tool, and the box name already prefixes each of their names (the connector
+ * installs as `<box>-setoku`). It's carried once, in serverInstructions.
+ */
+export function rosterLine(roster: BoxRoster | null): string | null {
+  if (!roster) return null;
+  const parts = domains(roster.families);
+  if (roster.mirrored > 0) parts.push(FAMILY_DOMAIN.Postgres);
+  if (!parts.length) return null;
+  return `THIS CONNECTOR'S DATA covers: ${parts.join("; ")}.`;
+}
+
+/**
+ * MCP server `instructions` — sent once in the initialize response, before any
+ * tool call. This is the highest-leverage string we own: it is read exactly when
+ * a client is forming its prior about what the connector is for, which is the
+ * moment the old surface got wrong.
+ *
+ * The standing rule at the end is the actual bug fix. "I don't think Setoku has
+ * that" is a claim about capability, and the client is not entitled to make it
+ * from the tool names alone — list_sources is cheap and authoritative.
+ */
+export function serverInstructions(
+  roster: BoxRoster | null,
+  caps: { canWrite: boolean; denyLakeRead: boolean },
+): string {
+  const box = roster?.box ? `the "${roster.box}" box` : "this box";
+  const lines = [
+    `Setoku is the governed query path into ONE company's or person's own data (${box}), and nothing ` +
+      `else. What it holds is set by whoever deployed it: it may be company data, personal data, or ` +
+      `both. Do not assume from the connector's name.`,
+    "",
+  ];
+
+  const parts = roster ? domains(roster.families) : [];
+  if (roster && roster.mirrored > 0) {
+    parts.push(`${FAMILY_DOMAIN.Postgres} (${roster.mirrored} table${roster.mirrored === 1 ? "" : "s"})`);
+  }
+  if (parts.length) {
+    lines.push("Connected right now:", ...parts.map((p) => `- ${p}`), "");
+  } else if (roster) {
+    lines.push(
+      "No source is flowing into this box yet — call list_sources for the current state before " +
+        "telling the user what is or isn't available.",
+      "",
+    );
+  }
+
+  lines.push(
+    "How to use it:",
+    "- Call find_context FIRST on any question about this data — it returns what the numbers MEAN " +
+      "here (definitions, gotchas, canonical SQL), which you cannot infer from column names.",
+    `- Query with run_query, dialect:"clickhouse". get_schema lists every table you may touch.`,
+  );
+  if (roster && roster.docs === 0) {
+    lines.push(
+      "- The knowledge store is empty, so find_context will come back thin. That says nothing about " +
+        "what data exists — check get_schema, and say what you assumed.",
+    );
+  }
+  if (caps.denyLakeRead) {
+    lines.push(
+      "- This is a CURATOR session: you can commit knowledge but cannot read the data itself. Switch " +
+        "to the everyday connector to query.",
+    );
+  } else if (!caps.canWrite) {
+    lines.push(
+      "- You cannot commit knowledge from this session. Capture anything the user teaches you with " +
+        "report_correction; a human approves it in /admin.",
+    );
+  }
+
+  lines.push(
+    "",
+    "STANDING RULE: never tell the user Setoku doesn't have data for something without calling " +
+      "list_sources (and, for a specific table, get_schema) in that same turn. Connected sources " +
+      "change without the tool list changing, the knowledge store being quiet on a topic is not " +
+      "evidence the data is missing, and a wrong 'I don't have access to that' is the single " +
+      "worst answer this connector can give — it sends the user away from data they own.",
+  );
+  return lines.join("\n");
+}

--- a/site/.well-known/agent-card.json
+++ b/site/.well-known/agent-card.json
@@ -190,12 +190,12 @@
   "tools": [
     {
       "name": "find_context",
-      "description": "Find context for this connector's data (verified + unverified)",
+      "description": "Find context for this connector's data",
       "role": "analyst"
     },
     {
       "name": "list_entities",
-      "description": "List documented business entities",
+      "description": "List everything in the knowledge store",
       "role": "analyst"
     },
     {
@@ -220,52 +220,52 @@
     },
     {
       "name": "resolve_correction",
-      "description": "Resolve a pending correction (curator)",
+      "description": "Resolve a pending correction",
       "role": "curator"
     },
     {
       "name": "upsert_context",
-      "description": "Create or update a knowledge doc (generate/curate workflows)",
+      "description": "Create or update a knowledge doc",
       "role": "curator"
     },
     {
       "name": "draft_correction",
-      "description": "Attach a drafted doc-edit to a pending correction (auto-draft)",
+      "description": "Attach a drafted doc-edit to a pending correction",
       "role": "janitor"
     },
     {
       "name": "reject_correction",
-      "description": "Auto-reject a pending correction (janitor, reject-only)",
+      "description": "Auto-reject a pending correction",
       "role": "janitor"
     },
     {
       "name": "list_sources",
-      "description": "List connected data sources (capabilities)",
+      "description": "List connected data sources",
       "role": "analyst"
     },
     {
       "name": "get_schema",
-      "description": "Queryable schema (biz.* mirror + lake, permission-scoped)",
+      "description": "Every table and column you can query",
       "role": "analyst"
     },
     {
       "name": "run_query",
-      "description": "Run a read-only SQL query (capped + audited)",
+      "description": "Run a read-only SQL query",
       "role": "analyst"
     },
     {
       "name": "app_guide",
-      "description": "How to build a Setoku app (read before publish_app / update_app)",
+      "description": "How to build a Setoku app",
       "role": "analyst"
     },
     {
       "name": "publish_app",
-      "description": "Publish a live app to the box (team-shareable URL)",
+      "description": "Publish a live app to the box",
       "role": "analyst"
     },
     {
       "name": "update_app",
-      "description": "Edit an app you published (in place, same link)",
+      "description": "Edit an app you published",
       "role": "analyst"
     },
     {
@@ -275,7 +275,7 @@
     },
     {
       "name": "get_app",
-      "description": "Inspect an app — its full template + panels (how it's built)",
+      "description": "Inspect an app — its full template and panels",
       "role": "analyst"
     },
     {

--- a/site/.well-known/agent-card.json
+++ b/site/.well-known/agent-card.json
@@ -190,7 +190,7 @@
   "tools": [
     {
       "name": "find_context",
-      "description": "Find business context (verified + unverified)",
+      "description": "Find context for this connector's data (verified + unverified)",
       "role": "analyst"
     },
     {

--- a/site/.well-known/mcp.json
+++ b/site/.well-known/mcp.json
@@ -62,7 +62,7 @@
   "tools": [
     {
       "name": "find_context",
-      "title": "Find business context (verified + unverified)",
+      "title": "Find context for this connector's data (verified + unverified)",
       "role": "analyst",
       "readOnly": true
     },

--- a/site/.well-known/mcp.json
+++ b/site/.well-known/mcp.json
@@ -62,13 +62,13 @@
   "tools": [
     {
       "name": "find_context",
-      "title": "Find context for this connector's data (verified + unverified)",
+      "title": "Find context for this connector's data",
       "role": "analyst",
       "readOnly": true
     },
     {
       "name": "list_entities",
-      "title": "List documented business entities",
+      "title": "List everything in the knowledge store",
       "role": "analyst",
       "readOnly": true
     },
@@ -98,61 +98,61 @@
     },
     {
       "name": "resolve_correction",
-      "title": "Resolve a pending correction (curator)",
+      "title": "Resolve a pending correction",
       "role": "curator",
       "readOnly": false
     },
     {
       "name": "upsert_context",
-      "title": "Create or update a knowledge doc (generate/curate workflows)",
+      "title": "Create or update a knowledge doc",
       "role": "curator",
       "readOnly": false
     },
     {
       "name": "draft_correction",
-      "title": "Attach a drafted doc-edit to a pending correction (auto-draft)",
+      "title": "Attach a drafted doc-edit to a pending correction",
       "role": "janitor",
       "readOnly": false
     },
     {
       "name": "reject_correction",
-      "title": "Auto-reject a pending correction (janitor, reject-only)",
+      "title": "Auto-reject a pending correction",
       "role": "janitor",
       "readOnly": false
     },
     {
       "name": "list_sources",
-      "title": "List connected data sources (capabilities)",
+      "title": "List connected data sources",
       "role": "analyst",
       "readOnly": true
     },
     {
       "name": "get_schema",
-      "title": "Queryable schema (biz.* mirror + lake, permission-scoped)",
+      "title": "Every table and column you can query",
       "role": "analyst",
       "readOnly": true
     },
     {
       "name": "run_query",
-      "title": "Run a read-only SQL query (capped + audited)",
+      "title": "Run a read-only SQL query",
       "role": "analyst",
       "readOnly": true
     },
     {
       "name": "app_guide",
-      "title": "How to build a Setoku app (read before publish_app / update_app)",
+      "title": "How to build a Setoku app",
       "role": "analyst",
       "readOnly": true
     },
     {
       "name": "publish_app",
-      "title": "Publish a live app to the box (team-shareable URL)",
+      "title": "Publish a live app to the box",
       "role": "analyst",
       "readOnly": false
     },
     {
       "name": "update_app",
-      "title": "Edit an app you published (in place, same link)",
+      "title": "Edit an app you published",
       "role": "analyst",
       "readOnly": false
     },
@@ -164,7 +164,7 @@
     },
     {
       "name": "get_app",
-      "title": "Inspect an app — its full template + panels (how it's built)",
+      "title": "Inspect an app — its full template and panels",
       "role": "analyst",
       "readOnly": true
     },

--- a/site/api/tools.json
+++ b/site/api/tools.json
@@ -10,7 +10,7 @@
   "tools": [
     {
       "name": "find_context",
-      "title": "Find business context (verified + unverified)",
+      "title": "Find context for this connector's data (verified + unverified)",
       "role": "analyst",
       "readOnly": true
     },

--- a/site/api/tools.json
+++ b/site/api/tools.json
@@ -10,13 +10,13 @@
   "tools": [
     {
       "name": "find_context",
-      "title": "Find context for this connector's data (verified + unverified)",
+      "title": "Find context for this connector's data",
       "role": "analyst",
       "readOnly": true
     },
     {
       "name": "list_entities",
-      "title": "List documented business entities",
+      "title": "List everything in the knowledge store",
       "role": "analyst",
       "readOnly": true
     },
@@ -46,61 +46,61 @@
     },
     {
       "name": "resolve_correction",
-      "title": "Resolve a pending correction (curator)",
+      "title": "Resolve a pending correction",
       "role": "curator",
       "readOnly": false
     },
     {
       "name": "upsert_context",
-      "title": "Create or update a knowledge doc (generate/curate workflows)",
+      "title": "Create or update a knowledge doc",
       "role": "curator",
       "readOnly": false
     },
     {
       "name": "draft_correction",
-      "title": "Attach a drafted doc-edit to a pending correction (auto-draft)",
+      "title": "Attach a drafted doc-edit to a pending correction",
       "role": "janitor",
       "readOnly": false
     },
     {
       "name": "reject_correction",
-      "title": "Auto-reject a pending correction (janitor, reject-only)",
+      "title": "Auto-reject a pending correction",
       "role": "janitor",
       "readOnly": false
     },
     {
       "name": "list_sources",
-      "title": "List connected data sources (capabilities)",
+      "title": "List connected data sources",
       "role": "analyst",
       "readOnly": true
     },
     {
       "name": "get_schema",
-      "title": "Queryable schema (biz.* mirror + lake, permission-scoped)",
+      "title": "Every table and column you can query",
       "role": "analyst",
       "readOnly": true
     },
     {
       "name": "run_query",
-      "title": "Run a read-only SQL query (capped + audited)",
+      "title": "Run a read-only SQL query",
       "role": "analyst",
       "readOnly": true
     },
     {
       "name": "app_guide",
-      "title": "How to build a Setoku app (read before publish_app / update_app)",
+      "title": "How to build a Setoku app",
       "role": "analyst",
       "readOnly": true
     },
     {
       "name": "publish_app",
-      "title": "Publish a live app to the box (team-shareable URL)",
+      "title": "Publish a live app to the box",
       "role": "analyst",
       "readOnly": false
     },
     {
       "name": "update_app",
-      "title": "Edit an app you published (in place, same link)",
+      "title": "Edit an app you published",
       "role": "analyst",
       "readOnly": false
     },
@@ -112,7 +112,7 @@
     },
     {
       "name": "get_app",
-      "title": "Inspect an app — its full template + panels (how it's built)",
+      "title": "Inspect an app — its full template and panels",
       "role": "analyst",
       "readOnly": true
     },

--- a/site/docs.md
+++ b/site/docs.md
@@ -51,7 +51,7 @@ Callable right now against the demo box:
 
 **Every session** — the analyst surface. Reads data and curated context, and may only *propose* knowledge changes:
 
-- `find_context` — Find business context (verified + unverified)
+- `find_context` — Find context for this connector’s data (verified + unverified)
 - `list_entities` — List documented business entities
 - `describe_entity` — Full context doc for one entity
 - `get_metric` — Canonical metric definition

--- a/site/docs.md
+++ b/site/docs.md
@@ -51,31 +51,31 @@ Callable right now against the demo box:
 
 **Every session** — the analyst surface. Reads data and curated context, and may only *propose* knowledge changes:
 
-- `find_context` — Find context for this connector’s data (verified + unverified)
-- `list_entities` — List documented business entities
+- `find_context` — Find context for this connector’s data
+- `list_entities` — List everything in the knowledge store
 - `describe_entity` — Full context doc for one entity
 - `get_metric` — Canonical metric definition
 - `report_correction` (writes) — Record a context correction / clarification
 - `list_corrections` — List pending knowledge corrections
-- `list_sources` — List connected data sources (capabilities)
-- `get_schema` — Queryable schema (biz.* mirror + lake, permission-scoped)
-- `run_query` — Run a read-only SQL query (capped + audited)
-- `app_guide` — How to build a Setoku app (read before publish_app / update_app)
-- `publish_app` (writes) — Publish a live app to the box (team-shareable URL)
-- `update_app` (writes) — Edit an app you published (in place, same link)
+- `list_sources` — List connected data sources
+- `get_schema` — Every table and column you can query
+- `run_query` — Run a read-only SQL query
+- `app_guide` — How to build a Setoku app
+- `publish_app` (writes) — Publish a live app to the box
+- `update_app` (writes) — Edit an app you published
 - `list_apps` — List apps published to the box
-- `get_app` — Inspect an app — its full template + panels (how it’s built)
+- `get_app` — Inspect an app — its full template and panels
 - `unpublish_app` (writes) — Archive a published app
 
 **Curator sessions only.** Commits curated knowledge:
 
-- `resolve_correction` — Resolve a pending correction (curator)
-- `upsert_context` — Create or update a knowledge doc (generate/curate workflows)
+- `resolve_correction` — Resolve a pending correction
+- `upsert_context` — Create or update a knowledge doc
 
 **Janitor sessions only.** Drafts and auto-rejects pending corrections, commits nothing:
 
-- `draft_correction` — Attach a drafted doc-edit to a pending correction (auto-draft)
-- `reject_correction` — Auto-reject a pending correction (janitor, reject-only)
+- `draft_correction` — Attach a drafted doc-edit to a pending correction
+- `reject_correction` — Auto-reject a pending correction
 
 A session has exactly one role, and the two role-scoped groups are *registered* only for that role: a session without it does not get a refusal, the tool is simply absent from its `tools/list`.
 

--- a/site/index.md
+++ b/site/index.md
@@ -66,7 +66,7 @@ Server, by hand, on a fresh Ubuntu VPS (about $5–12/month):
 
 | Tool | What it does | Role |
 | --- | --- | --- |
-| `find_context` | Find business context (verified + unverified) | analyst |
+| `find_context` | Find context for this connector’s data (verified + unverified) | analyst |
 | `list_entities` | List documented business entities | analyst |
 | `describe_entity` | Full context doc for one entity | analyst |
 | `get_metric` | Canonical metric definition | analyst |

--- a/site/index.md
+++ b/site/index.md
@@ -66,24 +66,24 @@ Server, by hand, on a fresh Ubuntu VPS (about $5–12/month):
 
 | Tool | What it does | Role |
 | --- | --- | --- |
-| `find_context` | Find context for this connector’s data (verified + unverified) | analyst |
-| `list_entities` | List documented business entities | analyst |
+| `find_context` | Find context for this connector’s data | analyst |
+| `list_entities` | List everything in the knowledge store | analyst |
 | `describe_entity` | Full context doc for one entity | analyst |
 | `get_metric` | Canonical metric definition | analyst |
 | `report_correction` | Record a context correction / clarification | analyst |
 | `list_corrections` | List pending knowledge corrections | analyst |
-| `resolve_correction` | Resolve a pending correction (curator) | curator |
-| `upsert_context` | Create or update a knowledge doc (generate/curate workflows) | curator |
-| `draft_correction` | Attach a drafted doc-edit to a pending correction (auto-draft) | janitor |
-| `reject_correction` | Auto-reject a pending correction (janitor, reject-only) | janitor |
-| `list_sources` | List connected data sources (capabilities) | analyst |
-| `get_schema` | Queryable schema (biz.* mirror + lake, permission-scoped) | analyst |
-| `run_query` | Run a read-only SQL query (capped + audited) | analyst |
-| `app_guide` | How to build a Setoku app (read before publish_app / update_app) | analyst |
-| `publish_app` | Publish a live app to the box (team-shareable URL) | analyst |
-| `update_app` | Edit an app you published (in place, same link) | analyst |
+| `resolve_correction` | Resolve a pending correction | curator |
+| `upsert_context` | Create or update a knowledge doc | curator |
+| `draft_correction` | Attach a drafted doc-edit to a pending correction | janitor |
+| `reject_correction` | Auto-reject a pending correction | janitor |
+| `list_sources` | List connected data sources | analyst |
+| `get_schema` | Every table and column you can query | analyst |
+| `run_query` | Run a read-only SQL query | analyst |
+| `app_guide` | How to build a Setoku app | analyst |
+| `publish_app` | Publish a live app to the box | analyst |
+| `update_app` | Edit an app you published | analyst |
 | `list_apps` | List apps published to the box | analyst |
-| `get_app` | Inspect an app — its full template + panels (how it’s built) | analyst |
+| `get_app` | Inspect an app — its full template and panels | analyst |
 | `unpublish_app` | Archive a published app | analyst |
 
 ## Skills

--- a/test/roster.test.ts
+++ b/test/roster.test.ts
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The roster is what a client reads about this box BEFORE it calls any tool —
+// the MCP `instructions` and the entry-point tool descriptions.
+//
+// The bug it exists to fix: a box whose lake is Monarch + Gmail presented a tool
+// surface that only ever said "business context", "biz.*", "Slack archive", so a
+// client concluded the connector was a work-analytics tool and answered "I don't
+// have access to your personal finances" — about data sitting in the lake — with
+// no tool call at all. `list_sources` knew better, but only in its return value.
+//
+// So these tests assert the property that actually failed: a personal-finance
+// box must SAY personal finance, in the strings a client reads for free.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import type { Subprocess } from "bun";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { spawnGateway, waitHealthy, connect, call as gwCall, FIXTURES } from "./lib/gateway";
+import { startFakeLake, type FakeLake } from "./lib/fakelake";
+import { KnowledgeStore } from "../plugin/gateway/lib/store";
+
+import {
+  FAMILY_DOMAIN,
+  connectedFamilies,
+  rosterFrom,
+  rosterLine,
+  serverInstructions,
+  type BoxRoster,
+} from "../plugin/gateway/lib/roster";
+import { BEAT_LIVE_MS, LAKE_SOURCES, familyOf } from "../plugin/gateway/lib/sources";
+
+const NOW = Date.parse("2026-08-21T12:00:00Z");
+const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+const ANALYST = { canWrite: false, denyLakeRead: false };
+
+/** A campsh-shaped box: Monarch + Gmail flowing, GitHub with history, and the
+ *  never-connected tables bootstrap creates for every other source. */
+const campshTables = () => [
+  { table: "monarch_transactions", source: "Monarch · transactions", rows: 8_400, last: iso(3_600_000), beat: iso(60_000) },
+  { table: "monarch_net_worth", source: "Monarch · net worth", rows: 900, last: iso(3_600_000), beat: iso(60_000) },
+  { table: "gmail_messages", source: "Gmail", rows: 4_800, last: iso(7_200_000), beat: iso(120_000) },
+  { table: "github_issues", source: "GitHub · issues", rows: 310, last: iso(86_400_000), beat: null },
+  { table: "logs_vercel", source: "Vercel", rows: 0, last: null, beat: null },
+  { table: "slack_messages", source: "Slack", rows: 0, last: null, beat: null },
+  { table: "ingest_raw", source: "Unrouted (raw)", rows: 12, last: iso(1_000), beat: null },
+];
+
+const campshRoster = (over: Partial<BoxRoster> = {}): BoxRoster => ({
+  ...rosterFrom(
+    {
+      mirror: { tables: [] },
+      lake: { configured: true, ok: true, tables: campshTables() },
+      knowledge: { docs: 6, byType: {} },
+    },
+    "campsh",
+    NOW,
+  ),
+  ...over,
+});
+
+describe("connectedFamilies", () => {
+  test("a family with rows is connected even when its poller is not beating", () => {
+    // GitHub history stays queryable after the poller stops. Liveness is about
+    // the pipeline; the roster is about what you can ask questions of.
+    expect(connectedFamilies(campshTables(), NOW)).toContain("GitHub");
+  });
+
+  test("a beating connector counts before its first row lands", () => {
+    const tables = [{ table: "monarch_budgets", source: "Monarch · budgets", rows: 0, last: null, beat: iso(60_000) }];
+    expect(connectedFamilies(tables, NOW)).toEqual(["Monarch"]);
+  });
+
+  test("tables that exist but were never connected are excluded", () => {
+    // Bootstrap creates every lake table up front, so existence proves nothing —
+    // listing Vercel here would promise data the box does not have.
+    const families = connectedFamilies(campshTables(), NOW);
+    expect(families).not.toContain("Vercel");
+    expect(families).not.toContain("Slack");
+  });
+
+  test("a stale beat with no rows does not count", () => {
+    const tables = [{ table: "logs_render", source: "Render", rows: 0, last: null, beat: iso(BEAT_LIVE_MS * 2) }];
+    expect(connectedFamilies(tables, NOW)).toEqual([]);
+  });
+
+  test("plumbing is not a domain", () => {
+    expect(connectedFamilies(campshTables(), NOW)).not.toContain("Unrouted (raw)");
+  });
+});
+
+describe("rosterLine", () => {
+  test("names the DOMAIN, not the vendor — the words the user's question uses", () => {
+    // "Monarch" answers nothing for someone asking about their mortgage.
+    const line = rosterLine(campshRoster())!;
+    expect(line).toContain("personal finance");
+    expect(line).toContain("personal email");
+    expect(line).not.toContain("Vercel");
+  });
+
+  test("omits the box name — it already prefixes every tool name", () => {
+    // The connector installs as `<box>-setoku`, and this line repeats across
+    // four tool descriptions; the name is carried once, in the instructions.
+    expect(rosterLine(campshRoster())).not.toContain("campsh");
+  });
+
+  test("mentions the biz.* mirror only when one is running", () => {
+    expect(rosterLine(campshRoster())).not.toContain("biz.*");
+    const mirrored = campshRoster({ mirrored: 12 });
+    expect(rosterLine(mirrored)).toContain("biz.*");
+  });
+
+  test("says nothing rather than promising an empty box", () => {
+    expect(rosterLine(campshRoster({ families: [], mirrored: 0 }))).toBeNull();
+    expect(rosterLine(null)).toBeNull();
+  });
+});
+
+describe("serverInstructions", () => {
+  test("the regression: a personal-finance box says so before any tool call", () => {
+    const out = serverInstructions(campshRoster(), ANALYST);
+    expect(out).toContain("personal finance");
+    expect(out).toContain("personal email");
+  });
+
+  test("carries the box name once", () => {
+    expect(serverInstructions(campshRoster(), ANALYST)).toContain("campsh");
+  });
+
+  test("does not let the connector's name imply its subject", () => {
+    expect(serverInstructions(campshRoster(), ANALYST)).toContain("Do not assume from the connector's name");
+  });
+
+  test("forbids the answer that caused this — 'we don't have that', unchecked", () => {
+    expect(serverInstructions(campshRoster(), ANALYST)).toContain("list_sources");
+    expect(serverInstructions(campshRoster(), ANALYST)).toMatch(/never tell the user Setoku doesn't have data/i);
+  });
+
+  test("an empty knowledge store is flagged as thin CONTEXT, not missing data", () => {
+    const out = serverInstructions(campshRoster({ docs: 0 }), ANALYST);
+    expect(out).toMatch(/says nothing about\s+what data exists/);
+  });
+
+  test("a box with nothing flowing points at list_sources instead of guessing", () => {
+    const out = serverInstructions(campshRoster({ families: [], mirrored: 0 }), ANALYST);
+    expect(out).toContain("No source is flowing");
+    expect(out).toContain("list_sources");
+  });
+
+  test("a curator session is told it cannot read the lake (the membrane)", () => {
+    const out = serverInstructions(campshRoster(), { canWrite: true, denyLakeRead: true });
+    expect(out).toContain("CURATOR session");
+    expect(out).not.toContain("report_correction");
+  });
+
+  test("an analyst session is pointed at report_correction, not upsert_context", () => {
+    const out = serverInstructions(campshRoster(), ANALYST);
+    expect(out).toContain("report_correction");
+    expect(out).not.toContain("upsert_context");
+  });
+
+  test("degrades to source-agnostic text when the probe is cold", () => {
+    // A cold or broken lake must never fail an MCP request; it just gets the
+    // generic description back.
+    const out = serverInstructions(null, ANALYST);
+    expect(out).toContain("Setoku is the governed query path");
+    expect(out).not.toContain("Connected right now");
+  });
+});
+
+describe("FAMILY_DOMAIN covers the catalog", () => {
+  test("every source family has a plain-language phrase", () => {
+    // Drift guard: a new connector whose family lands here with no phrase would
+    // silently fall back to its vendor label, reintroducing the original bug for
+    // that source. Adding a table to an EXISTING family needs nothing.
+    const missing = [...new Set(LAKE_SOURCES.map((s) => familyOf(s.source)))]
+      .filter((f) => f !== "Unrouted (raw)" && f !== "Postgres mirror")
+      .filter((f) => !FAMILY_DOMAIN[f]);
+    expect(missing).toEqual([]);
+  });
+
+  test("phrases describe the data, never just repeat the vendor", () => {
+    for (const [family, phrase] of Object.entries(FAMILY_DOMAIN)) {
+      expect(phrase.toLowerCase()).not.toBe(family.toLowerCase());
+      expect(phrase.length).toBeGreaterThan(family.length);
+    }
+  });
+});
+
+/* ------------------------- end-to-end over real MCP ------------------------ */
+
+// The unit tests above pin the strings. This block pins that they actually
+// REACH a client — through the initialize response and tools/list, off a live
+// lake probe — because every layer in between (the cached probe, the deny
+// scoping, the per-request buildServer) is where this could silently become a
+// no-op again.
+describe("the roster reaches an MCP client", () => {
+  const PORT = 38779;
+  const BASE = `http://127.0.0.1:${PORT}`;
+  let tmpRepo: string;
+  let proc: Subprocess;
+  let lake: FakeLake;
+
+  // A Monarch + Gmail box: those two tables hold rows, every other lake table
+  // exists (bootstrap creates them all) but is empty.
+  const WITH_ROWS = ["monarch_transactions", "monarch_accounts", "gmail_messages"];
+
+  beforeAll(async () => {
+    lake = startFakeLake((sql) => {
+      if (sql.includes("GROUP BY connector")) return { columns: ["connector", "beat"], rows: [] };
+      if (sql.includes("target_table AS target")) return { columns: ["target", "source", "as_of"], rows: [] };
+      if (sql.includes("count() AS rows")) {
+        const hit = WITH_ROWS.some((t) => sql.includes(`FROM setoku.${t}`));
+        return { columns: ["rows", "last"], rows: [{ rows: hit ? 500 : 0, last: "2026-08-21 00:00:00" }] };
+      }
+      return { rows: [{ ok: 1 }] };
+    });
+
+    tmpRepo = fs.mkdtempSync(path.join(os.tmpdir(), "setoku-roster-"));
+    fs.cpSync(path.join(FIXTURES, "setoku"), path.join(tmpRepo, ".setoku"), { recursive: true });
+    {
+      const s = new KnowledgeStore(path.join(tmpRepo, "knowledge.db"));
+      // Dana is denied Monarch — her tool descriptions must not advertise it.
+      s.setSourceDenies("dana@co.test", ["monarch"], "admin@co.test");
+      s.db.close();
+    }
+    proc = spawnGateway({
+      SETOKU_PROJECT_DIR: tmpRepo,
+      SETOKU_DB_PATH: path.join(tmpRepo, "knowledge.db"),
+      SETOKU_LAKE_URL: lake.url,
+      SETOKU_HTTP_PORT: String(PORT),
+      SETOKU_NAME: "campsh",
+      SETOKU_TOKENS: "tok-ann=ann@co.test,tok-dana=dana@co.test",
+    });
+    await waitHealthy(BASE);
+  }, 30_000);
+
+  afterAll(() => {
+    proc?.kill();
+    lake?.stop();
+    if (tmpRepo) fs.rmSync(tmpRepo, { recursive: true, force: true });
+  });
+
+  const describeOf = async (client: Awaited<ReturnType<typeof connect>>, name: string) => {
+    const { tools } = await client.listTools();
+    return tools.find((t) => t.name === name)?.description ?? "";
+  };
+
+  test("initialize carries what the box holds, and the box's name", async () => {
+    const client = await connect(BASE, "tok-ann");
+    const instructions = client.getInstructions() ?? "";
+    expect(instructions).toContain("personal finance");
+    expect(instructions).toContain("personal email");
+    expect(instructions).toContain("campsh");
+    await client.close();
+  });
+
+  test("tools/list alone answers 'is this connector about my finances?'", async () => {
+    // THE regression. A client that reads the tool list and nothing else must
+    // come away knowing this box holds personal finance data.
+    const client = await connect(BASE, "tok-ann");
+    for (const tool of ["find_context", "list_sources", "get_schema", "run_query"]) {
+      expect(await describeOf(client, tool)).toContain("personal finance");
+    }
+    await client.close();
+  });
+
+  test("a never-connected source is not advertised", async () => {
+    const client = await connect(BASE, "tok-ann");
+    const d = await describeOf(client, "find_context");
+    expect(d).not.toContain("team chat archive"); // Slack: table exists, no rows
+    expect(d).not.toContain("web hosting logs"); // Vercel: same
+    await client.close();
+  });
+
+  test("a denied family is absent from that identity's descriptions (I9)", async () => {
+    const client = await connect(BASE, "tok-dana");
+    const d = await describeOf(client, "find_context");
+    expect(d).not.toContain("personal finance");
+    expect(d).toContain("personal email"); // Gmail is not denied
+    expect(client.getInstructions() ?? "").not.toContain("personal finance");
+    await client.close();
+  });
+
+  test("find_context that retrieves nothing still names the sources", async () => {
+    // The empty-store path: "no curated knowledge" must not read as "no data".
+    const client = await connect(BASE, "tok-ann");
+    const res = await gwCall(client, "find_context", { question: "what did we spend on the mortgage" });
+    expect(res.text).toContain("personal finance");
+    expect(res.text).toContain("list_sources");
+    await client.close();
+  });
+});


### PR DESCRIPTION
## The bug

My wife asked our `campsh-setoku` box a personal-finance question. It said it knew nothing. She asked it to use Setoku, and got:

> No — Setoku, based on what I can see, is connected here as the analytics/data tool tied to your own business (Setoku, the company you work on, and Hedgy) — it's for querying business data schemas, metrics, and reports, not personal finance or Monarch account data. It wouldn't have any access to your personal mortgage, rent, or investment accounts.

The box has `monarch_transactions`, `monarch_net_worth`, `monarch_budgets`, `monarch_holdings`, `monarch_accounts`, and `gmail_messages`. It made that call without invoking a single tool.

## Why

It was reading the manual, and the manual was wrong. Everything a client sees *before it calls anything* was a static string, and every one of those strings said "business":

- `find_context` — *"verified **business** context… how this **business** actually computes things"* — the tool we tell it to call FIRST
- `run_query` — *"the biz.\* Postgres mirror plus the lake (logs/events/**Slack archive**)"*
- `get_schema` — *"the biz.\* Postgres mirror"*
- `new McpServer({ name, version })` passed no `instructions` at all — the SDK has supported the field since long before our `^1.12`, and we'd never used it.

`list_sources` knew the truth the whole time, but only in its **return value**. You had to already suspect the answer to call the tool that tells you. Discovery that requires calling the discovery tool isn't discovery.

## The fix

Push the roster out to where a client looks first.

**`lib/roster.ts`** derives what the box holds from the same Sources probe `/admin` already reads, and names the **domain** rather than the vendor — "personal finance", not "Monarch", because "Monarch" answers nothing for someone asking about a mortgage. A family counts as connected on rows **or** a live beat: bootstrap creates every lake table up front (so existence proves nothing), and a paused poller still has queryable history (so rows aren't required either).

**Server `instructions`** now carry it in the initialize response, ending with a standing rule:

> never tell the user Setoku doesn't have data for something without calling `list_sources` … a wrong "I don't have access to that" is the single worst answer this connector can give — it sends the user away from data they own.

**The four entry-point tools** prefix it onto their descriptions, so `tools/list` alone answers "is this connector about my finances?":

```
THIS CONNECTOR'S DATA covers: personal finance: transactions, balances, net worth,
budgets, investment holdings; personal email: senders, subjects, bodies; software
development activity: issues, pull requests, commits, code review.
```

**`find_context` repeats it on an empty retrieval** — the exact moment the wrong inference gets made. A quiet knowledge store is not an empty box.

**"business" stops being the universal framing.** It's simply false on a personal box, and it was load-bearing in the copy the model reasons from.

## Notes

- **Deny-scoped (I9).** A member denied Monarch sees no mention of it in their descriptions *or* their instructions — covered by an end-to-end test.
- **No standing query load.** 5-minute cache with stale-while-revalidate, layered on the existing 10s Sources cache, so only the first call after boot ever waits and a warm `/admin` costs it nothing. Deliberate, given how small these boxes are on purpose.
- **Fails soft.** A cold or broken lake degrades to the source-agnostic text; it never fails an MCP request.
- The box name rides the instructions only. It already prefixes every tool name via the connector (`<box>-setoku`), so repeating it across four descriptions is waste. Its `SETOKU_NAME`-over-`config.name` precedence moved into `config.boxName()` so it can't drift from `connectorName()`.

## Tests

`test/roster.test.ts` — 25 tests. Unit coverage on the connected-ness rule and both rendered strings, then an end-to-end block that spawns the real gateway against a fake lake and asserts the roster arrives through `initialize` and `tools/list`, that a never-connected source is never advertised, that a denied family is absent, and that an empty `find_context` still names the sources. Full suite green (583 pass), typecheck clean, site artifacts regenerated.

https://claude.ai/code/session_013sEpYHPyUK5ys5oHTBEN6u