### PR TITLE
site: say who it’s for, in plainer copy

### DIFF
--- a/scripts/build-site-api.ts
+++ b/scripts/build-site-api.ts
@@ -198,7 +198,7 @@ function openapi(toolNames: string[]) {
       summary: "The HTTP surface of a self-hosted Setoku MCP knowledge server.",
       description:
         "Setoku is an open-source, self-hosted MCP server that gives an AI agent a read-only, " +
-        "audited view of a company's data plus the curated context needed to use it correctly.\n\n" +
+        "audited view of its operator's own data plus the curated context needed to use it correctly.\n\n" +
         "Every Setoku box exposes this API. There is no multi-tenant setoku.com API: the product " +
         "is single-tenant by design and runs on infrastructure you own, so point `host` at your " +
         "own deployment (or at the public demo box).\n\n" +
@@ -487,26 +487,44 @@ type Connector = { id: string; name: string; data: string };
  * WHEN TO USE SETOKU — the single most useful paragraph on this whole site for a
  * machine reader, and the one thing marketing copy never says out loud. Every
  * discovery file (llms.txt, the agent card, the skill index, index.md) states
- * the same three lists, so an agent gets the same answer wherever it looks.
+ * the same lists, so an agent gets the same answer wherever it looks.
  *
  * Kept honest in both directions: what Setoku is *wrong* for is published next
  * to what it is right for, because an agent that reaches for us on a question we
- * cannot answer wastes a turn and then distrusts the next answer too.
+ * cannot answer wastes a turn and then distrusts the next answer too. The
+ * do-not-use list therefore concedes the static-CSV case outright — that reader
+ * is better served by DuckDB, and saying so is what makes the rest credible.
+ *
+ * `who_its_for` exists because agents evaluating fit pattern-match against a
+ * list of subjects, not against prose. Until it was added, every one of these
+ * files said "company" and nothing said "person", so an agent asked whether a
+ * household should use Setoku correctly answered no — to what we had published,
+ * not to what the product does. The homepage h1 had rotated
+ * "company data / family data / personal data" for months; it was a JS rotator,
+ * so no fetcher ever saw the other two words.
  */
 const WHEN_TO_USE = {
   summary:
-    "Reach for Setoku when the answer lives in a specific company's own data and depends on " +
-    "that company's definitions.",
+    "Reach for Setoku when the answer lives in data its operator connected (a company's, a " +
+    "household's, or one person's) and depends on their own definitions rather than public knowledge.",
+  who_its_for: [
+    "A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.",
+    "A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.",
+    "One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files.",
+  ],
   use_when: [
-    "A question is about one company's own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.",
-    "You need the company's definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.",
-    "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.",
-    "Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.",
+    "A question is about the operator's own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.",
+    "The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today's answer.",
+    "You need the operator's definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.",
+    "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.",
+    "Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.",
+    "An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.",
     "You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner's own box.",
   ],
   do_not_use_when: [
     "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
-    "You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
+    "The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.",
+    "You need to write to the operator's database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
     "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
     "You want a model to run server-side. Setoku runs no inference; your own agent does the thinking.",
   ],
@@ -529,8 +547,8 @@ function mcpManifest(toolList: Tool[]) {
     name: "setoku",
     title: "Setoku",
     description:
-      "Self-hosted MCP knowledge server: a read-only, audited view of one company's data plus " +
-      "the curated context needed to use it correctly.",
+      "Self-hosted MCP knowledge server: a read-only, audited view of one operator's own data (a " +
+      "company's, a household's, or one person's), plus the curated context needed to use it correctly.",
     version: VERSION,
     license: "Apache-2.0",
     repository: { url: REPO, source: "github" },
@@ -584,11 +602,11 @@ function agentCard(skillList: Skill[], toolList: Tool[]) {
     protocolVersion: "0.3.0",
     name: "Setoku",
     description:
-      "Setoku makes an AI agent fluent in one company's data. It serves the company's curated " +
-      "context (metric definitions, gotchas, which table to trust) and a governed read-only " +
-      "query path into their warehouse, so an agent can answer business questions correctly and " +
-      "publish live views of the result. Self-hosted and single-tenant: the agent you are " +
-      "talking to runs on the operator's own box.",
+      "Setoku makes an AI agent fluent in one operator's own data: a company's, a household's, " +
+      "or one person's. It serves their curated context (metric definitions, gotchas, which table " +
+      "to trust) and a governed read-only query path into the data itself, so an agent answers " +
+      "from how they actually count things and can publish a live view of the result on a link. " +
+      "Self-hosted and single-tenant: it runs on the operator's own box.",
     version: VERSION,
     provider: { organization: "Hedgy Labs", url: SITE },
     documentationUrl: `${SITE}/docs`,
@@ -631,19 +649,21 @@ function agentCard(skillList: Skill[], toolList: Tool[]) {
         id: s.id,
         name: s.name,
         description: s.description,
-        tags: ["setoku", "mcp", "company-data", s.name],
+        tags: ["setoku", "mcp", "company-data", "personal-data", "household-data", s.name],
         examples: [`/setoku:${s.name}`],
       })),
       {
         id: "setoku:answer",
         name: "answer",
         description:
-          "Answer a question about the operator's own business data: retrieve the curated " +
-          "context for it (find_context), read the schema, then run a governed read-only query.",
-        tags: ["setoku", "mcp", "analytics", "sql", "company-data"],
+          "Answer a question about the operator's own data (a company's, a household's, or one " +
+          "person's): retrieve the curated context for it (find_context), read the schema, then " +
+          "run a governed read-only query.",
+        tags: ["setoku", "mcp", "analytics", "sql", "company-data", "personal-data", "household-data"],
         examples: [
           "What did we bill last month, using our definition of billed revenue?",
           "Which accounts churned in Q2, excluding the test tenant?",
+          "What did we spend on groceries last month, not counting the reimbursed work lunches?",
         ],
       },
       {
@@ -667,8 +687,9 @@ function agentSkillsIndex(skillList: Skill[]) {
   return {
     name: "Setoku",
     description:
-      "Skills for connecting an AI agent to one company's data and keeping the knowledge behind " +
-      "it correct. They ship in the Setoku Claude Code plugin and run against a Setoku box.",
+      "Skills for connecting an AI agent to the data one operator owns (a company's, a " +
+      "household's, or one person's) and keeping the knowledge behind it correct. They ship in " +
+      "the Setoku Claude Code plugin and run against a Setoku box.",
     version: VERSION,
     license: "Apache-2.0",
     homepage: SITE,
@@ -726,9 +747,9 @@ const steps = (xs: readonly string[]) => xs.map((x, i) => `${i + 1}. ${prose(x)}
 function indexMarkdown(toolList: Tool[], connectorList: Connector[], skillList: Skill[]) {
   return `# Setoku
 
-> Make any AI fluent in your company data.
+> Make any AI fluent in your own data.
 
-Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives an AI agent a read-only, audited view of a company’s data plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
+Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives an AI agent a read-only, audited view of the data you own (a company’s, a household’s, or your own), plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
 
 Version ${VERSION} · Apache-2.0 · <${REPO}>
 
@@ -737,6 +758,10 @@ This is the markdown twin of <${SITE}/>. The API reference is <${SITE}/docs> (ma
 ## When to use Setoku
 
 ${prose(WHEN_TO_USE.summary)}
+
+Who runs one:
+
+${bullets(WHEN_TO_USE.who_its_for)}
 
 Use it when:
 
@@ -828,7 +853,7 @@ Contact: hello@setoku.com · Issues: <${REPO}/issues>
 function llmsTxt(skillList: Skill[]) {
   return `# Setoku
 
-> Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives any AI agent a read-only, audited view of your company’s data plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
+> Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives any AI agent a read-only, audited view of the data you own (a company’s, a household’s, or your own), plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
 
 Setoku is single-tenant on purpose. There is no hosted Setoku service and no multi-tenant API: you run it on a box you own (one small VPS), and your data and your context stay there. That is the point of the product, not a gap in it. So the API described below is the API that *your* deployment exposes, not one hosted at setoku.com.
 
@@ -839,6 +864,10 @@ Two identities share one server and never overlap. An **analyst** token may quer
 ## When to use Setoku
 
 ${prose(WHEN_TO_USE.summary)}
+
+Who runs one:
+
+${bullets(WHEN_TO_USE.who_its_for)}
 
 Use it when:
 
@@ -912,6 +941,12 @@ Setoku is single-tenant and self-hosted: **there is no setoku.com API**. Everyth
 ## When to reach for Setoku
 
 ${prose(WHEN_TO_USE.summary)}
+
+Who runs one:
+
+${bullets(WHEN_TO_USE.who_its_for)}
+
+Reach for it when:
 
 ${bullets(WHEN_TO_USE.use_when)}
 
@@ -1030,7 +1065,7 @@ const NOTE =
 
 const index = {
   name: "Setoku",
-  tagline: "Make any AI fluent in your company data.",
+  tagline: "Make any AI fluent in your own data.",
   description: manifest.description,
   version: VERSION,
   license: "Apache-2.0",

--- a/scripts/build-site-api.ts
+++ b/scripts/build-site-api.ts
@@ -508,30 +508,30 @@ const WHEN_TO_USE = {
     "Reach for Setoku when the answer lives in data its operator connected (a company's, a " +
     "household's, or one person's) and depends on their own definitions rather than public knowledge.",
   who_its_for: [
-    "A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.",
-    "A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.",
-    "One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files.",
+    "A company: give agents team-by-team access to revenue, logs, and deploys, for debugging and analysis. Definitions like “active customer” get written down once.",
+    "A household: shared accounts and calendars, so the partner who doesn't write SQL gets the same answers.",
+    "One person: your own accounts and repos, queryable from your phone and the web as well as your desktop.",
   ],
   use_when: [
-    "A question is about the operator's own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.",
-    "The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today's answer.",
+    "The question is about the operator's own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.",
+    "The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.",
     "You need the operator's definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.",
     "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.",
-    "Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.",
-    "An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.",
-    "You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner's own box.",
+    "You want a dashboard on a link someone else can open, on live data, not a screenshot.",
+    "An agent will read untrusted text (mail, logs, chat) in the same session. That session can't rewrite what Setoku knows, so an injected instruction can't become a remembered fact.",
+    "You want the answer to be auditable later: every query and knowledge change is logged on your box.",
   ],
   do_not_use_when: [
     "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
-    "The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.",
+    "The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.",
     "You need to write to the operator's database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
     "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
-    "You want a model to run server-side. Setoku runs no inference; your own agent does the thinking.",
+    "You want a model to run server-side. Setoku runs no inference.",
   ],
   how_to_call: [
     "Connect to the box's MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person's bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.",
     "Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.",
-    "Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.",
+    "Then get_schema, then run_query.",
     "Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself.",
   ],
 } as const;
@@ -747,7 +747,7 @@ const steps = (xs: readonly string[]) => xs.map((x, i) => `${i + 1}. ${prose(x)}
 function indexMarkdown(toolList: Tool[], connectorList: Connector[], skillList: Skill[]) {
   return `# Setoku
 
-> Make any AI fluent in your own data.
+> Make any AI fluent in your data.
 
 Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives an AI agent a read-only, audited view of the data you own (a company’s, a household’s, or your own), plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
 
@@ -759,7 +759,7 @@ This is the markdown twin of <${SITE}/>. The API reference is <${SITE}/docs> (ma
 
 ${prose(WHEN_TO_USE.summary)}
 
-Who runs one:
+Who it’s for:
 
 ${bullets(WHEN_TO_USE.who_its_for)}
 
@@ -865,7 +865,7 @@ Two identities share one server and never overlap. An **analyst** token may quer
 
 ${prose(WHEN_TO_USE.summary)}
 
-Who runs one:
+Who it’s for:
 
 ${bullets(WHEN_TO_USE.who_its_for)}
 
@@ -942,7 +942,7 @@ Setoku is single-tenant and self-hosted: **there is no setoku.com API**. Everyth
 
 ${prose(WHEN_TO_USE.summary)}
 
-Who runs one:
+Who it’s for:
 
 ${bullets(WHEN_TO_USE.who_its_for)}
 
@@ -1065,7 +1065,7 @@ const NOTE =
 
 const index = {
   name: "Setoku",
-  tagline: "Make any AI fluent in your own data.",
+  tagline: "Make any AI fluent in your data.",
   description: manifest.description,
   version: VERSION,
   license: "Apache-2.0",

--- a/scripts/build-site-api.ts
+++ b/scripts/build-site-api.ts
@@ -506,7 +506,7 @@ type Connector = { id: string; name: string; data: string };
 const WHEN_TO_USE = {
   summary:
     "Reach for Setoku when the answer lives in data its operator connected (a company's, a " +
-    "household's, or one person's) and depends on their own definitions rather than public knowledge.",
+    "household's, or one person's) and depends on their own definitions, not public knowledge.",
   who_its_for: [
     "A company: give agents team-by-team access to revenue, logs, and deploys, for debugging and analysis. Definitions like “active customer” get written down once.",
     "A household: shared accounts and calendars, so the partner who doesn't write SQL gets the same answers.",
@@ -515,24 +515,24 @@ const WHEN_TO_USE = {
   use_when: [
     "The question is about the operator's own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.",
     "The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.",
-    "You need the operator's definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.",
-    "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.",
+    "You need the operator's definition of a term first: what counts as an active customer, which account is the joint one, which charges were reimbursed.",
+    "A naive query would be wrong in a way only an insider knows: soft-deleted rows, a test tenant, a transfer between your own accounts counted as income. You want that caveat before you run SQL.",
     "You want a dashboard on a link someone else can open, on live data, not a screenshot.",
     "An agent will read untrusted text (mail, logs, chat) in the same session. That session can't rewrite what Setoku knows, so an injected instruction can't become a remembered fact.",
     "You want the answer to be auditable later: every query and knowledge change is logged on your box.",
   ],
   do_not_use_when: [
-    "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
-    "The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.",
-    "You need to write to the operator's database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
-    "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
+    "The question is general knowledge or public data. Setoku only knows the data its operator connected.",
+    "The data is a static file on your disk. Query it locally. Setoku is for data that lives in other services and keeps changing.",
+    "You need to write to the operator's database. Every data path is read-only, enforced by database role. There is no write tool and no escape hatch.",
+    "You want a hosted API to sign up for. There is none. Setoku is self-hosted, and the endpoint you call is the operator's own box.",
     "You want a model to run server-side. Setoku runs no inference.",
   ],
   how_to_call: [
     "Connect to the box's MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person's bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.",
     "Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.",
     "Then get_schema, then run_query.",
-    "Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself.",
+    "If the context is wrong, call report_correction. It lands as a proposal for a human to accept. An agent session can't commit knowledge by itself.",
   ],
 } as const;
 
@@ -802,7 +802,7 @@ Server, by hand, on a fresh Ubuntu VPS (about $5–12/month):
 
 ## The tool surface
 
-${toolList.length} MCP tools. Which ones a session sees depends on its token’s role — that split is the security model, not a convenience.
+${toolList.length} MCP tools. Which ones a session sees depends on its token’s role. That split is the security model.
 
 | Tool | What it does | Role |
 | --- | --- | --- |
@@ -820,7 +820,7 @@ No connector for yours? \`/setoku:connect\` gives a coding agent the patterns to
 
 ## Security model
 
-- **Two identities, one membrane.** An analyst token may query the lake but holds no tool that commits knowledge. A curator token may commit knowledge but cannot read the lake. They never coexist on one session, so a prompt-injected session cannot weaponize the write path.
+- **Two identities, one membrane.** An analyst token may query the lake but holds no tool that commits knowledge. A curator token may commit knowledge but cannot read the lake. They never coexist on one session, so a prompt-injected session can’t reach the write path.
 - **Accepting knowledge is a human click** on the box’s admin page, outside the agent loop. No MCP tool creates users, grants access, or commits knowledge on its own.
 - **Reads are governed by database roles**, not by parsing SQL in our code. The engine enforces it.
 - **The credential never reaches the model.** Config names an environment variable; the gateway resolves it.

--- a/site/.well-known/agent-card.json
+++ b/site/.well-known/agent-card.json
@@ -49,7 +49,7 @@
     }
   ],
   "whenToUse": {
-    "summary": "Reach for Setoku when the answer lives in data its operator connected (a company's, a household's, or one person's) and depends on their own definitions rather than public knowledge.",
+    "summary": "Reach for Setoku when the answer lives in data its operator connected (a company's, a household's, or one person's) and depends on their own definitions, not public knowledge.",
     "who_its_for": [
       "A company: give agents team-by-team access to revenue, logs, and deploys, for debugging and analysis. Definitions like “active customer” get written down once.",
       "A household: shared accounts and calendars, so the partner who doesn't write SQL gets the same answers.",
@@ -58,24 +58,24 @@
     "use_when": [
       "The question is about the operator's own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.",
       "The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.",
-      "You need the operator's definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.",
-      "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.",
+      "You need the operator's definition of a term first: what counts as an active customer, which account is the joint one, which charges were reimbursed.",
+      "A naive query would be wrong in a way only an insider knows: soft-deleted rows, a test tenant, a transfer between your own accounts counted as income. You want that caveat before you run SQL.",
       "You want a dashboard on a link someone else can open, on live data, not a screenshot.",
       "An agent will read untrusted text (mail, logs, chat) in the same session. That session can't rewrite what Setoku knows, so an injected instruction can't become a remembered fact.",
       "You want the answer to be auditable later: every query and knowledge change is logged on your box."
     ],
     "do_not_use_when": [
-      "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
-      "The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.",
-      "You need to write to the operator's database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
-      "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
+      "The question is general knowledge or public data. Setoku only knows the data its operator connected.",
+      "The data is a static file on your disk. Query it locally. Setoku is for data that lives in other services and keeps changing.",
+      "You need to write to the operator's database. Every data path is read-only, enforced by database role. There is no write tool and no escape hatch.",
+      "You want a hosted API to sign up for. There is none. Setoku is self-hosted, and the endpoint you call is the operator's own box.",
       "You want a model to run server-side. Setoku runs no inference."
     ],
     "how_to_call": [
       "Connect to the box's MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person's bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.",
       "Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.",
       "Then get_schema, then run_query.",
-      "Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself."
+      "If the context is wrong, call report_correction. It lands as a proposal for a human to accept. An agent session can't commit knowledge by itself."
     ]
   },
   "skills": [

--- a/site/.well-known/agent-card.json
+++ b/site/.well-known/agent-card.json
@@ -51,30 +51,30 @@
   "whenToUse": {
     "summary": "Reach for Setoku when the answer lives in data its operator connected (a company's, a household's, or one person's) and depends on their own definitions rather than public knowledge.",
     "who_its_for": [
-      "A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.",
-      "A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.",
-      "One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files."
+      "A company: give agents team-by-team access to revenue, logs, and deploys, for debugging and analysis. Definitions like “active customer” get written down once.",
+      "A household: shared accounts and calendars, so the partner who doesn't write SQL gets the same answers.",
+      "One person: your own accounts and repos, queryable from your phone and the web as well as your desktop."
     ],
     "use_when": [
-      "A question is about the operator's own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.",
-      "The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today's answer.",
+      "The question is about the operator's own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.",
+      "The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.",
       "You need the operator's definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.",
       "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.",
-      "Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.",
-      "An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.",
-      "You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner's own box."
+      "You want a dashboard on a link someone else can open, on live data, not a screenshot.",
+      "An agent will read untrusted text (mail, logs, chat) in the same session. That session can't rewrite what Setoku knows, so an injected instruction can't become a remembered fact.",
+      "You want the answer to be auditable later: every query and knowledge change is logged on your box."
     ],
     "do_not_use_when": [
       "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
-      "The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.",
+      "The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.",
       "You need to write to the operator's database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
       "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
-      "You want a model to run server-side. Setoku runs no inference; your own agent does the thinking."
+      "You want a model to run server-side. Setoku runs no inference."
     ],
     "how_to_call": [
       "Connect to the box's MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person's bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.",
       "Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.",
-      "Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.",
+      "Then get_schema, then run_query.",
       "Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself."
     ]
   },

--- a/site/.well-known/agent-card.json
+++ b/site/.well-known/agent-card.json
@@ -1,7 +1,7 @@
 {
   "protocolVersion": "0.3.0",
   "name": "Setoku",
-  "description": "Setoku makes an AI agent fluent in one company's data. It serves the company's curated context (metric definitions, gotchas, which table to trust) and a governed read-only query path into their warehouse, so an agent can answer business questions correctly and publish live views of the result. Self-hosted and single-tenant: the agent you are talking to runs on the operator's own box.",
+  "description": "Setoku makes an AI agent fluent in one operator's own data: a company's, a household's, or one person's. It serves their curated context (metric definitions, gotchas, which table to trust) and a governed read-only query path into the data itself, so an agent answers from how they actually count things and can publish a live view of the result on a link. Self-hosted and single-tenant: it runs on the operator's own box.",
   "version": "0.21.0",
   "provider": {
     "organization": "Hedgy Labs",
@@ -49,17 +49,25 @@
     }
   ],
   "whenToUse": {
-    "summary": "Reach for Setoku when the answer lives in a specific company's own data and depends on that company's definitions.",
+    "summary": "Reach for Setoku when the answer lives in data its operator connected (a company's, a household's, or one person's) and depends on their own definitions rather than public knowledge.",
+    "who_its_for": [
+      "A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.",
+      "A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.",
+      "One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files."
+    ],
     "use_when": [
-      "A question is about one company's own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.",
-      "You need the company's definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.",
-      "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.",
-      "Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.",
+      "A question is about the operator's own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.",
+      "The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today's answer.",
+      "You need the operator's definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.",
+      "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.",
+      "Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.",
+      "An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.",
       "You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner's own box."
     ],
     "do_not_use_when": [
       "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
-      "You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
+      "The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.",
+      "You need to write to the operator's database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
       "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
       "You want a model to run server-side. Setoku runs no inference; your own agent does the thinking."
     ],
@@ -79,6 +87,8 @@
         "setoku",
         "mcp",
         "company-data",
+        "personal-data",
+        "household-data",
         "compact-knowledge"
       ],
       "examples": [
@@ -93,6 +103,8 @@
         "setoku",
         "mcp",
         "company-data",
+        "personal-data",
+        "household-data",
         "connect"
       ],
       "examples": [
@@ -107,6 +119,8 @@
         "setoku",
         "mcp",
         "company-data",
+        "personal-data",
+        "household-data",
         "curate"
       ],
       "examples": [
@@ -121,6 +135,8 @@
         "setoku",
         "mcp",
         "company-data",
+        "personal-data",
+        "household-data",
         "eval"
       ],
       "examples": [
@@ -135,6 +151,8 @@
         "setoku",
         "mcp",
         "company-data",
+        "personal-data",
+        "household-data",
         "generate"
       ],
       "examples": [
@@ -149,6 +167,8 @@
         "setoku",
         "mcp",
         "company-data",
+        "personal-data",
+        "household-data",
         "onboard"
       ],
       "examples": [
@@ -158,17 +178,20 @@
     {
       "id": "setoku:answer",
       "name": "answer",
-      "description": "Answer a question about the operator's own business data: retrieve the curated context for it (find_context), read the schema, then run a governed read-only query.",
+      "description": "Answer a question about the operator's own data (a company's, a household's, or one person's): retrieve the curated context for it (find_context), read the schema, then run a governed read-only query.",
       "tags": [
         "setoku",
         "mcp",
         "analytics",
         "sql",
-        "company-data"
+        "company-data",
+        "personal-data",
+        "household-data"
       ],
       "examples": [
         "What did we bill last month, using our definition of billed revenue?",
-        "Which accounts churned in Q2, excluding the test tenant?"
+        "Which accounts churned in Q2, excluding the test tenant?",
+        "What did we spend on groceries last month, not counting the reimbursed work lunches?"
       ]
     },
     {

--- a/site/.well-known/agent-skills/index.json
+++ b/site/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
   "homepage": "https://setoku.com",
   "documentation": "https://setoku.com/docs",
   "when_to_use": {
-    "summary": "Reach for Setoku when the answer lives in data its operator connected (a company's, a household's, or one person's) and depends on their own definitions rather than public knowledge.",
+    "summary": "Reach for Setoku when the answer lives in data its operator connected (a company's, a household's, or one person's) and depends on their own definitions, not public knowledge.",
     "who_its_for": [
       "A company: give agents team-by-team access to revenue, logs, and deploys, for debugging and analysis. Definitions like “active customer” get written down once.",
       "A household: shared accounts and calendars, so the partner who doesn't write SQL gets the same answers.",
@@ -15,24 +15,24 @@
     "use_when": [
       "The question is about the operator's own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.",
       "The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.",
-      "You need the operator's definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.",
-      "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.",
+      "You need the operator's definition of a term first: what counts as an active customer, which account is the joint one, which charges were reimbursed.",
+      "A naive query would be wrong in a way only an insider knows: soft-deleted rows, a test tenant, a transfer between your own accounts counted as income. You want that caveat before you run SQL.",
       "You want a dashboard on a link someone else can open, on live data, not a screenshot.",
       "An agent will read untrusted text (mail, logs, chat) in the same session. That session can't rewrite what Setoku knows, so an injected instruction can't become a remembered fact.",
       "You want the answer to be auditable later: every query and knowledge change is logged on your box."
     ],
     "do_not_use_when": [
-      "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
-      "The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.",
-      "You need to write to the operator's database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
-      "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
+      "The question is general knowledge or public data. Setoku only knows the data its operator connected.",
+      "The data is a static file on your disk. Query it locally. Setoku is for data that lives in other services and keeps changing.",
+      "You need to write to the operator's database. Every data path is read-only, enforced by database role. There is no write tool and no escape hatch.",
+      "You want a hosted API to sign up for. There is none. Setoku is self-hosted, and the endpoint you call is the operator's own box.",
       "You want a model to run server-side. Setoku runs no inference."
     ],
     "how_to_call": [
       "Connect to the box's MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person's bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.",
       "Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.",
       "Then get_schema, then run_query.",
-      "Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself."
+      "If the context is wrong, call report_correction. It lands as a proposal for a human to accept. An agent session can't commit knowledge by itself."
     ]
   },
   "install": [

--- a/site/.well-known/agent-skills/index.json
+++ b/site/.well-known/agent-skills/index.json
@@ -1,22 +1,30 @@
 {
   "name": "Setoku",
-  "description": "Skills for connecting an AI agent to one company's data and keeping the knowledge behind it correct. They ship in the Setoku Claude Code plugin and run against a Setoku box.",
+  "description": "Skills for connecting an AI agent to the data one operator owns (a company's, a household's, or one person's) and keeping the knowledge behind it correct. They ship in the Setoku Claude Code plugin and run against a Setoku box.",
   "version": "0.21.0",
   "license": "Apache-2.0",
   "homepage": "https://setoku.com",
   "documentation": "https://setoku.com/docs",
   "when_to_use": {
-    "summary": "Reach for Setoku when the answer lives in a specific company's own data and depends on that company's definitions.",
+    "summary": "Reach for Setoku when the answer lives in data its operator connected (a company's, a household's, or one person's) and depends on their own definitions rather than public knowledge.",
+    "who_its_for": [
+      "A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.",
+      "A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.",
+      "One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files."
+    ],
     "use_when": [
-      "A question is about one company's own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.",
-      "You need the company's definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.",
-      "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.",
-      "Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.",
+      "A question is about the operator's own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.",
+      "The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today's answer.",
+      "You need the operator's definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.",
+      "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.",
+      "Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.",
+      "An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.",
       "You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner's own box."
     ],
     "do_not_use_when": [
       "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
-      "You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
+      "The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.",
+      "You need to write to the operator's database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
       "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
       "You want a model to run server-side. Setoku runs no inference; your own agent does the thinking."
     ],

--- a/site/.well-known/agent-skills/index.json
+++ b/site/.well-known/agent-skills/index.json
@@ -8,30 +8,30 @@
   "when_to_use": {
     "summary": "Reach for Setoku when the answer lives in data its operator connected (a company's, a household's, or one person's) and depends on their own definitions rather than public knowledge.",
     "who_its_for": [
-      "A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.",
-      "A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.",
-      "One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files."
+      "A company: give agents team-by-team access to revenue, logs, and deploys, for debugging and analysis. Definitions like “active customer” get written down once.",
+      "A household: shared accounts and calendars, so the partner who doesn't write SQL gets the same answers.",
+      "One person: your own accounts and repos, queryable from your phone and the web as well as your desktop."
     ],
     "use_when": [
-      "A question is about the operator's own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.",
-      "The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today's answer.",
+      "The question is about the operator's own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.",
+      "The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.",
       "You need the operator's definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.",
       "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.",
-      "Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.",
-      "An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.",
-      "You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner's own box."
+      "You want a dashboard on a link someone else can open, on live data, not a screenshot.",
+      "An agent will read untrusted text (mail, logs, chat) in the same session. That session can't rewrite what Setoku knows, so an injected instruction can't become a remembered fact.",
+      "You want the answer to be auditable later: every query and knowledge change is logged on your box."
     ],
     "do_not_use_when": [
       "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
-      "The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.",
+      "The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.",
       "You need to write to the operator's database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
       "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
-      "You want a model to run server-side. Setoku runs no inference; your own agent does the thinking."
+      "You want a model to run server-side. Setoku runs no inference."
     ],
     "how_to_call": [
       "Connect to the box's MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person's bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.",
       "Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.",
-      "Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.",
+      "Then get_schema, then run_query.",
       "Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself."
     ]
   },

--- a/site/.well-known/mcp.json
+++ b/site/.well-known/mcp.json
@@ -1,7 +1,7 @@
 {
   "name": "setoku",
   "title": "Setoku",
-  "description": "Self-hosted MCP knowledge server: a read-only, audited view of one company's data plus the curated context needed to use it correctly.",
+  "description": "Self-hosted MCP knowledge server: a read-only, audited view of one operator's own data (a company's, a household's, or one person's), plus the curated context needed to use it correctly.",
   "version": "0.21.0",
   "license": "Apache-2.0",
   "repository": {
@@ -10,17 +10,25 @@
   },
   "documentation": "https://setoku.com/docs",
   "when_to_use": {
-    "summary": "Reach for Setoku when the answer lives in a specific company's own data and depends on that company's definitions.",
+    "summary": "Reach for Setoku when the answer lives in data its operator connected (a company's, a household's, or one person's) and depends on their own definitions rather than public knowledge.",
+    "who_its_for": [
+      "A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.",
+      "A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.",
+      "One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files."
+    ],
     "use_when": [
-      "A question is about one company's own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.",
-      "You need the company's definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.",
-      "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.",
-      "Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.",
+      "A question is about the operator's own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.",
+      "The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today's answer.",
+      "You need the operator's definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.",
+      "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.",
+      "Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.",
+      "An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.",
       "You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner's own box."
     ],
     "do_not_use_when": [
       "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
-      "You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
+      "The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.",
+      "You need to write to the operator's database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
       "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
       "You want a model to run server-side. Setoku runs no inference; your own agent does the thinking."
     ],

--- a/site/.well-known/mcp.json
+++ b/site/.well-known/mcp.json
@@ -12,30 +12,30 @@
   "when_to_use": {
     "summary": "Reach for Setoku when the answer lives in data its operator connected (a company's, a household's, or one person's) and depends on their own definitions rather than public knowledge.",
     "who_its_for": [
-      "A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.",
-      "A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.",
-      "One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files."
+      "A company: give agents team-by-team access to revenue, logs, and deploys, for debugging and analysis. Definitions like “active customer” get written down once.",
+      "A household: shared accounts and calendars, so the partner who doesn't write SQL gets the same answers.",
+      "One person: your own accounts and repos, queryable from your phone and the web as well as your desktop."
     ],
     "use_when": [
-      "A question is about the operator's own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.",
-      "The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today's answer.",
+      "The question is about the operator's own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.",
+      "The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.",
       "You need the operator's definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.",
       "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.",
-      "Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.",
-      "An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.",
-      "You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner's own box."
+      "You want a dashboard on a link someone else can open, on live data, not a screenshot.",
+      "An agent will read untrusted text (mail, logs, chat) in the same session. That session can't rewrite what Setoku knows, so an injected instruction can't become a remembered fact.",
+      "You want the answer to be auditable later: every query and knowledge change is logged on your box."
     ],
     "do_not_use_when": [
       "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
-      "The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.",
+      "The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.",
       "You need to write to the operator's database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
       "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
-      "You want a model to run server-side. Setoku runs no inference; your own agent does the thinking."
+      "You want a model to run server-side. Setoku runs no inference."
     ],
     "how_to_call": [
       "Connect to the box's MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person's bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.",
       "Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.",
-      "Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.",
+      "Then get_schema, then run_query.",
       "Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself."
     ]
   },

--- a/site/.well-known/mcp.json
+++ b/site/.well-known/mcp.json
@@ -10,7 +10,7 @@
   },
   "documentation": "https://setoku.com/docs",
   "when_to_use": {
-    "summary": "Reach for Setoku when the answer lives in data its operator connected (a company's, a household's, or one person's) and depends on their own definitions rather than public knowledge.",
+    "summary": "Reach for Setoku when the answer lives in data its operator connected (a company's, a household's, or one person's) and depends on their own definitions, not public knowledge.",
     "who_its_for": [
       "A company: give agents team-by-team access to revenue, logs, and deploys, for debugging and analysis. Definitions like “active customer” get written down once.",
       "A household: shared accounts and calendars, so the partner who doesn't write SQL gets the same answers.",
@@ -19,24 +19,24 @@
     "use_when": [
       "The question is about the operator's own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.",
       "The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.",
-      "You need the operator's definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.",
-      "A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.",
+      "You need the operator's definition of a term first: what counts as an active customer, which account is the joint one, which charges were reimbursed.",
+      "A naive query would be wrong in a way only an insider knows: soft-deleted rows, a test tenant, a transfer between your own accounts counted as income. You want that caveat before you run SQL.",
       "You want a dashboard on a link someone else can open, on live data, not a screenshot.",
       "An agent will read untrusted text (mail, logs, chat) in the same session. That session can't rewrite what Setoku knows, so an injected instruction can't become a remembered fact.",
       "You want the answer to be auditable later: every query and knowledge change is logged on your box."
     ],
     "do_not_use_when": [
-      "The question is general knowledge, or about public data — Setoku only knows the data its operator connected.",
-      "The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.",
-      "You need to write to the operator's database. Every data path is read-only, by database role; there is no write tool and no escape hatch.",
-      "You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator's own box.",
+      "The question is general knowledge or public data. Setoku only knows the data its operator connected.",
+      "The data is a static file on your disk. Query it locally. Setoku is for data that lives in other services and keeps changing.",
+      "You need to write to the operator's database. Every data path is read-only, enforced by database role. There is no write tool and no escape hatch.",
+      "You want a hosted API to sign up for. There is none. Setoku is self-hosted, and the endpoint you call is the operator's own box.",
       "You want a model to run server-side. Setoku runs no inference."
     ],
     "how_to_call": [
       "Connect to the box's MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person's bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.",
       "Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.",
       "Then get_schema, then run_query.",
-      "Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself."
+      "If the context is wrong, call report_correction. It lands as a proposal for a human to accept. An agent session can't commit knowledge by itself."
     ]
   },
   "remotes": [

--- a/site/api/index.json
+++ b/site/api/index.json
@@ -1,6 +1,6 @@
 {
   "name": "Setoku",
-  "tagline": "Make any AI fluent in your company data.",
+  "tagline": "Make any AI fluent in your own data.",
   "description": "Governed agentic BI on your Claude subscription. Setoku gives Claude a verified business-context layer (derived from your codebase) plus read-only, audited access to your database — so it answers business questions accurately instead of guessing from column names.",
   "version": "0.21.0",
   "license": "Apache-2.0",

--- a/site/api/index.json
+++ b/site/api/index.json
@@ -1,6 +1,6 @@
 {
   "name": "Setoku",
-  "tagline": "Make any AI fluent in your own data.",
+  "tagline": "Make any AI fluent in your data.",
   "description": "Governed agentic BI on your Claude subscription. Setoku gives Claude a verified business-context layer (derived from your codebase) plus read-only, audited access to your database — so it answers business questions accurately instead of guessing from column names.",
   "version": "0.21.0",
   "license": "Apache-2.0",

--- a/site/api/openapi.json
+++ b/site/api/openapi.json
@@ -4,7 +4,7 @@
     "title": "Setoku Gateway API",
     "version": "0.21.0",
     "summary": "The HTTP surface of a self-hosted Setoku MCP knowledge server.",
-    "description": "Setoku is an open-source, self-hosted MCP server that gives an AI agent a read-only, audited view of a company's data plus the curated context needed to use it correctly.\n\nEvery Setoku box exposes this API. There is no multi-tenant setoku.com API: the product is single-tenant by design and runs on infrastructure you own, so point `host` at your own deployment (or at the public demo box).\n\nThe primary interface is MCP over Streamable HTTP at `/mcp`, which carries 19 tools (see https://setoku.com/api/tools.json). The REST endpoints below are the credential-free surface: box health, and published apps.",
+    "description": "Setoku is an open-source, self-hosted MCP server that gives an AI agent a read-only, audited view of its operator's own data plus the curated context needed to use it correctly.\n\nEvery Setoku box exposes this API. There is no multi-tenant setoku.com API: the product is single-tenant by design and runs on infrastructure you own, so point `host` at your own deployment (or at the public demo box).\n\nThe primary interface is MCP over Streamable HTTP at `/mcp`, which carries 19 tools (see https://setoku.com/api/tools.json). The REST endpoints below are the credential-free surface: box health, and published apps.",
     "license": {
       "name": "Apache-2.0",
       "identifier": "Apache-2.0"

--- a/site/docs.md
+++ b/site/docs.md
@@ -6,18 +6,29 @@ Setoku is single-tenant and self-hosted: **there is no setoku.com API**. Everyth
 
 ## When to reach for Setoku
 
-Reach for Setoku when the answer lives in a specific company’s own data and depends on that company’s definitions.
+Reach for Setoku when the answer lives in data its operator connected (a company’s, a household’s, or one person’s) and depends on their own definitions rather than public knowledge.
 
-- A question is about one company’s own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.
-- You need the company’s definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.
-- A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.
-- Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.
+Who runs one:
+
+- A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.
+- A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.
+- One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files.
+
+Reach for it when:
+
+- A question is about the operator’s own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.
+- The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today’s answer.
+- You need the operator’s definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.
+- A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.
+- Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.
+- An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.
 - You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner’s own box.
 
 Not a fit when:
 
 - The question is general knowledge, or about public data — Setoku only knows the data its operator connected.
-- You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
+- The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.
+- You need to write to the operator’s database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
 - You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator’s own box.
 - You want a model to run server-side. Setoku runs no inference; your own agent does the thinking.
 

--- a/site/docs.md
+++ b/site/docs.md
@@ -8,29 +8,29 @@ Setoku is single-tenant and self-hosted: **there is no setoku.com API**. Everyth
 
 Reach for Setoku when the answer lives in data its operator connected (a company’s, a household’s, or one person’s) and depends on their own definitions rather than public knowledge.
 
-Who runs one:
+Who it’s for:
 
-- A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.
-- A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.
-- One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files.
+- A company: give agents team-by-team access to revenue, logs, and deploys, for debugging and analysis. Definitions like “active customer” get written down once.
+- A household: shared accounts and calendars, so the partner who doesn’t write SQL gets the same answers.
+- One person: your own accounts and repos, queryable from your phone and the web as well as your desktop.
 
 Reach for it when:
 
-- A question is about the operator’s own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.
-- The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today’s answer.
+- The question is about the operator’s own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.
+- The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.
 - You need the operator’s definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.
 - A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.
-- Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.
-- An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.
-- You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner’s own box.
+- You want a dashboard on a link someone else can open, on live data, not a screenshot.
+- An agent will read untrusted text (mail, logs, chat) in the same session. That session can’t rewrite what Setoku knows, so an injected instruction can’t become a remembered fact.
+- You want the answer to be auditable later: every query and knowledge change is logged on your box.
 
 Not a fit when:
 
 - The question is general knowledge, or about public data — Setoku only knows the data its operator connected.
-- The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.
+- The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.
 - You need to write to the operator’s database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
 - You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator’s own box.
-- You want a model to run server-side. Setoku runs no inference; your own agent does the thinking.
+- You want a model to run server-side. Setoku runs no inference.
 
 ## MCP endpoint
 
@@ -57,7 +57,7 @@ Callable right now against the demo box:
 
 1. Connect to the box’s MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person’s bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.
 2. Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.
-3. Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.
+3. Then get_schema, then run_query.
 4. Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself.
 
 **Every session** — the analyst surface. Reads data and curated context, and may only *propose* knowledge changes:

--- a/site/docs.md
+++ b/site/docs.md
@@ -6,7 +6,7 @@ Setoku is single-tenant and self-hosted: **there is no setoku.com API**. Everyth
 
 ## When to reach for Setoku
 
-Reach for Setoku when the answer lives in data its operator connected (a company’s, a household’s, or one person’s) and depends on their own definitions rather than public knowledge.
+Reach for Setoku when the answer lives in data its operator connected (a company’s, a household’s, or one person’s) and depends on their own definitions, not public knowledge.
 
 Who it’s for:
 
@@ -18,18 +18,18 @@ Reach for it when:
 
 - The question is about the operator’s own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.
 - The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.
-- You need the operator’s definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.
-- A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.
+- You need the operator’s definition of a term first: what counts as an active customer, which account is the joint one, which charges were reimbursed.
+- A naive query would be wrong in a way only an insider knows: soft-deleted rows, a test tenant, a transfer between your own accounts counted as income. You want that caveat before you run SQL.
 - You want a dashboard on a link someone else can open, on live data, not a screenshot.
 - An agent will read untrusted text (mail, logs, chat) in the same session. That session can’t rewrite what Setoku knows, so an injected instruction can’t become a remembered fact.
 - You want the answer to be auditable later: every query and knowledge change is logged on your box.
 
 Not a fit when:
 
-- The question is general knowledge, or about public data — Setoku only knows the data its operator connected.
-- The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.
-- You need to write to the operator’s database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
-- You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator’s own box.
+- The question is general knowledge or public data. Setoku only knows the data its operator connected.
+- The data is a static file on your disk. Query it locally. Setoku is for data that lives in other services and keeps changing.
+- You need to write to the operator’s database. Every data path is read-only, enforced by database role. There is no write tool and no escape hatch.
+- You want a hosted API to sign up for. There is none. Setoku is self-hosted, and the endpoint you call is the operator’s own box.
 - You want a model to run server-side. Setoku runs no inference.
 
 ## MCP endpoint
@@ -58,7 +58,7 @@ Callable right now against the demo box:
 1. Connect to the box’s MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person’s bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.
 2. Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.
 3. Then get_schema, then run_query.
-4. Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself.
+4. If the context is wrong, call report_correction. It lands as a proposal for a human to accept. An agent session can’t commit knowledge by itself.
 
 **Every session** — the analyst surface. Reads data and curated context, and may only *propose* knowledge changes:
 

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -141,6 +141,41 @@ curl https://setoku.com/api/tools.json</pre>
         </div>
       </section>
 
+      <section id="fit">
+        <h2 class="man">WHO RUNS ONE</h2>
+        <div class="body">
+          <p>
+            One box holds the data of one operator. Usually that is a company,
+            but nothing here assumes a payroll: the same box, the same tools
+            and the same approval step work at any size.
+          </p>
+          <dl class="kv">
+            <dt>A company<span class="t">a token per person</span></dt>
+            <dd>
+              Revenue, churn, pipeline, deploys, support load, and the
+              definitions everyone argues about written down once.
+            </dd>
+            <dt>A household<span class="t">two people, one box</span></dt>
+            <dd>
+              Joint finances, mail, calendars. The partner who doesn’t write SQL
+              asks in plain language, or opens a link that stays current.
+            </dd>
+            <dt>One person<span class="t">reachable everywhere</span></dt>
+            <dd>
+              Your own bank, mail and repos, queryable from phone, web and
+              desktop rather than only from the machine holding the files.
+            </dd>
+          </dl>
+          <p>
+            Not a fit for a static file you already have on disk: if a CSV
+            answers the question and won’t change, query it locally. Setoku
+            earns its keep on data that lives elsewhere and keeps moving (a
+            bank, a budgeting service, a mailbox, an issue tracker), where a
+            hand-made export is stale on arrival.
+          </p>
+        </div>
+      </section>
+
       <section id="resources">
         <h2 class="man">RESOURCES</h2>
         <div class="body">
@@ -355,6 +390,13 @@ curl https://setoku.com/api/tools.json</pre>
             The load-bearing security design, and the thing most worth
             understanding before you build against Setoku: <b>two identities,
             one server, never on the same session.</b>
+          </p>
+          <p>
+            This is not role-based access control for a big org, and it is not
+            optional overhead on a small box. It is prompt-injection defense,
+            and it matters at one user: the moment an agent reads your email or
+            your logs, it is reading text a stranger wrote. The split is what
+            stops that text from rewriting what Setoku knows.
           </p>
           <dl class="kv">
             <dt>Analyst<span class="t">reads the lake · proposes only</span></dt>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -141,38 +141,24 @@ curl https://setoku.com/api/tools.json</pre>
         </div>
       </section>
 
-      <section id="fit">
-        <h2 class="man">WHO RUNS ONE</h2>
+      <section id="who-its-for">
+        <h2 class="man">WHO’S IT FOR</h2>
         <div class="body">
-          <p>
-            One box holds the data of one operator. Usually that is a company,
-            but nothing here assumes a payroll: the same box, the same tools
-            and the same approval step work at any size.
-          </p>
           <dl class="kv">
             <dt>A company<span class="t">a token per person</span></dt>
             <dd>
-              Revenue, churn, pipeline, deploys, support load, and the
-              definitions everyone argues about written down once.
+              Every agent on your team gets full knowledge of revenue, logs and
+              deploys. Definitions like what counts as an active customer get
+              written down once.
             </dd>
-            <dt>A household<span class="t">two people, one box</span></dt>
+            <dt>A household<span class="t">one family, one box</span></dt>
+            <dd>Share bank accounts and calendars.</dd>
+            <dt>One person<span class="t">reachable from anywhere</span></dt>
             <dd>
-              Joint finances, mail, calendars. The partner who doesn’t write SQL
-              asks in plain language, or opens a link that stays current.
-            </dd>
-            <dt>One person<span class="t">reachable everywhere</span></dt>
-            <dd>
-              Your own bank, mail and repos, queryable from phone, web and
-              desktop rather than only from the machine holding the files.
+              Your own accounts and repos, queryable from your phone and the web
+              as well as your desktop.
             </dd>
           </dl>
-          <p>
-            Not a fit for a static file you already have on disk: if a CSV
-            answers the question and won’t change, query it locally. Setoku
-            earns its keep on data that lives elsewhere and keeps moving (a
-            bank, a budgeting service, a mailbox, an issue tracker), where a
-            hand-made export is stale on arrival.
-          </p>
         </div>
       </section>
 

--- a/site/index.html
+++ b/site/index.html
@@ -6,7 +6,7 @@
     <title>Setoku · data knowledge MCP server</title>
     <meta
       name="description"
-      content="Setoku is an open-source MCP server that gives your AI a read-only view of your company’s data, plus the context to use it correctly."
+      content="Setoku is an open-source MCP server that gives your AI a read-only view of the data you own (a company’s, a household’s, or your own), plus the context to use it correctly."
     />
     <link rel="canonical" href="https://setoku.com/" />
     <meta property="og:type" content="website" />
@@ -14,7 +14,7 @@
     <meta property="og:title" content="Setoku · data knowledge MCP server" />
     <meta
       property="og:description"
-      content="An open-source MCP server that gives your AI a read-only view of your company’s data, plus the context to use it correctly."
+      content="An open-source MCP server that gives your AI a read-only view of the data you own (a company’s, a household’s, or your own), plus the context to use it correctly."
     />
     <meta property="og:url" content="https://setoku.com/" />
     <meta property="og:image" content="https://setoku.com/assets/og.png" />
@@ -22,7 +22,7 @@
     <meta property="og:image:height" content="630" />
     <meta
       property="og:image:alt"
-      content="A sprout drawn in ASCII art above the line: setoku — make any AI fluent in your company data."
+      content="A sprout drawn in ASCII art above the line: setoku — make any AI fluent in your own data."
     />
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
@@ -61,7 +61,7 @@
             "@id": "https://setoku.com/#website",
             "url": "https://setoku.com/",
             "name": "Setoku",
-            "description": "Setoku is an open-source, self-hosted MCP server that gives your AI a read-only view of your company data, plus the context to use it correctly.",
+            "description": "Setoku is an open-source, self-hosted MCP server that gives your AI a read-only view of the data you own (a company’s, a household’s, or your own), plus the context to use it correctly.",
             "inLanguage": "en",
             "publisher": { "@id": "https://setoku.com/#org" }
           },
@@ -93,7 +93,7 @@
             "applicationSubCategory": "MCP server",
             "operatingSystem": "Linux",
             "url": "https://setoku.com/",
-            "description": "Setoku is a small self-hosted MCP knowledge server plus Claude Code skills for hooking up your data. It gives your AI a read-only, audited way to query your data and remembers what that data means — the metric definitions and the gotchas — so it answers the way your business actually computes things. No AI model runs on the server.",
+            "description": "Setoku is a small self-hosted MCP knowledge server plus Claude Code skills for hooking up your data: a company’s, a household’s, or your own. It gives your AI a read-only, audited way to query it and remembers what that data means (the metric definitions, the gotchas), so it answers the way you actually count things. No AI model runs on the server.",
             "license": "https://www.apache.org/licenses/LICENSE-2.0",
             "downloadUrl": "https://github.com/Hedgy-Labs/setoku",
             "codeRepository": "https://github.com/Hedgy-Labs/setoku",
@@ -109,7 +109,7 @@
             },
             "featureList": [
               "MCP server over Streamable HTTP for any MCP client",
-              "Curated business context: metric definitions, entity docs, and gotchas",
+              "Curated context for your own data: metric definitions, entity docs, and gotchas",
               "Read-only, audited SQL against a ClickHouse lake and a read-only mirror of your database",
               "Publish live dashboards and apps to a shareable link",
               "Human approval for every change to curated knowledge"
@@ -197,8 +197,8 @@
             <b>setoku</b> &mdash; make any AI fluent in your
             <span
               class="rotator"
-              data-words="company data,family data,personal data"
-              >company data</span
+              data-words="own data,company data,family data,personal data"
+              >own data</span
             >
           </h1>
         </div>
@@ -209,13 +209,13 @@
         <div class="body">
 <p>
             Setoku is a small self-hosted MCP knowledge server + Claude Code
-            skills for hooking up your data. It does two things: it gives your
-            AI a read-only way to query your data, and it remembers what that
-            data means (the metric definitions, the gotchas), getting better the
-            more you use it. Ask for a dashboard and publish it to a link your
-            whole team can view, on live data. The MCP works with whatever AI
-            you already have, and no model runs on the server, so no added
-            inference cost.
+            skills for hooking up your data: your company’s, your household’s,
+            or your own. It does two things: it gives your AI a read-only way to
+            query that data, and it remembers what the data means (the metric
+            definitions, the gotchas), getting better the more you use it. Ask
+            for a dashboard and publish it to a link the people you share with
+            can open, on live data. The MCP works with whatever AI you already
+            have, and no model runs on the server, so no added inference cost.
           </p>
           <p class="dim">
             Open source &middot; MCP server &middot; Apache-2.0 &middot;
@@ -225,6 +225,43 @@
               rel="noopener"
               >GitHub ↗</a
             >
+          </p>
+        </div>
+      </section>
+
+      <section id="who">
+        <h2 class="man">WHO RUNS ONE</h2>
+        <div class="body">
+          <p>
+            One box holds the data of one operator. That operator is usually a
+            company, but nothing in Setoku assumes a payroll: the same box, the
+            same tools, the same approval step work at any size.
+          </p>
+          <dl class="kv">
+            <dt>A company<span class="t">a token per person</span></dt>
+            <dd>
+              Revenue, churn, pipeline, deploys, support load. The definitions
+              everyone argues about get written down once: what counts as an
+              active customer, which refunds are excluded, which table people
+              actually trust.
+            </dd>
+            <dt>A household<span class="t">two people, one box</span></dt>
+            <dd>
+              Joint finances, mail, calendars. Both partners ask about the same
+              numbers, and the one who doesn’t write SQL still gets an answer,
+              or a link to a dashboard that stays current on its own.
+            </dd>
+            <dt>One person<span class="t">reachable everywhere</span></dt>
+            <dd>
+              Your own bank, mail, and repos, queryable from every client you
+              use (phone, web, desktop), rather than only from the machine that
+              happens to hold the files.
+            </dd>
+          </dl>
+          <p class="dim">
+            Not for a static CSV you already have on disk: if a file answers the
+            question and won’t change, query it locally. Setoku earns its keep
+            on data that lives somewhere else and keeps moving.
           </p>
         </div>
       </section>
@@ -349,7 +386,7 @@ Other         <span class="bar">█▌</span>                            <span c
             <dt>App tools<span class="t">publish_app · update_app</span></dt>
             <dd>
               Turn an answer into a small web app on live data, published at a
-              link anyone on the team can open. No SQL required.
+              link the people you share with can open. No SQL required.
             </dd>
           </dl>
           <p>You set it up with <b>Claude Code</b> skills:</p>
@@ -363,8 +400,8 @@ Other         <span class="bar">█▌</span>                            <span c
               custom integration.
             </li>
             <li>
-              <span class="cmd">/setoku:generate</span> writes business context
-              from your code.
+              <span class="cmd">/setoku:generate</span> writes context from
+              your code.
             </li>
             <li>
               <span class="cmd">/setoku:curate</span> reviews and approves
@@ -384,8 +421,9 @@ Other         <span class="bar">█▌</span>                            <span c
         <div class="body">
           <p>
             Ask Claude to build a dashboard on your data. Then publish it to a
-            link as a Setoku App, the data stays live, and your whole team can
-            view it. Nothing to deploy, no frontend to maintain.
+            link as a Setoku App, the data stays live, and whoever you share it
+            with can open it, a teammate or your partner. Nothing to deploy,
+            no frontend to maintain.
           </p>
           <dl class="kv">
             <dt>Vibe dashboarding<span class="t">sandbox safety</span></dt>
@@ -561,6 +599,8 @@ SETOKU_ADMIN_USER=you ./deploy/bootstrap.sh</pre>
   <span class="lbl">│</span> <span class="cmd">Render</span>     <span class="lbl">│</span> deploys &amp; logs                   <span class="lbl">│</span>
   <span class="lbl">│</span> <span class="cmd">Slack</span>      <span class="lbl">│</span> messages                         <span class="lbl">│</span>
   <span class="lbl">│</span> <span class="cmd">Mercury</span>    <span class="lbl">│</span> banking &amp; finance                <span class="lbl">│</span>
+  <span class="lbl">│</span> <span class="cmd">Monarch</span>    <span class="lbl">│</span> personal finance &amp; net worth     <span class="lbl">│</span>
+  <span class="lbl">│</span> <span class="cmd">Gmail</span>      <span class="lbl">│</span> personal email                   <span class="lbl">│</span>
   <span class="lbl">└────────────┴──────────────────────────────────┘</span>
 </pre>
           </div>

--- a/site/index.html
+++ b/site/index.html
@@ -22,7 +22,7 @@
     <meta property="og:image:height" content="630" />
     <meta
       property="og:image:alt"
-      content="A sprout drawn in ASCII art above the line: setoku — make any AI fluent in your own data."
+      content="A sprout drawn in ASCII art above the line: setoku — make any AI fluent in your data."
     />
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
@@ -197,8 +197,8 @@
             <b>setoku</b> &mdash; make any AI fluent in your
             <span
               class="rotator"
-              data-words="own data,company data,family data,personal data"
-              >own data</span
+              data-words="data,company data,family data,personal data"
+              >data</span
             >
           </h1>
         </div>
@@ -209,13 +209,13 @@
         <div class="body">
 <p>
             Setoku is a small self-hosted MCP knowledge server + Claude Code
-            skills for hooking up your data: your company’s, your household’s,
-            or your own. It does two things: it gives your AI a read-only way to
-            query that data, and it remembers what the data means (the metric
-            definitions, the gotchas), getting better the more you use it. Ask
-            for a dashboard and publish it to a link the people you share with
-            can open, on live data. The MCP works with whatever AI you already
-            have, and no model runs on the server, so no added inference cost.
+            skills for hooking up your data. It does two things: it gives your
+            AI a read-only way to query that data, and it remembers what the
+            data means (the metric definitions, the gotchas), getting better
+            the more you use it. Ask for a dashboard and publish it to a link
+            the people you share with can open, on live data. The MCP works
+            with whatever AI you already have, and no model runs on the server,
+            so no added inference cost.
           </p>
           <p class="dim">
             Open source &middot; MCP server &middot; Apache-2.0 &middot;
@@ -229,40 +229,27 @@
         </div>
       </section>
 
-      <section id="who">
-        <h2 class="man">WHO RUNS ONE</h2>
+      <section id="who-its-for">
+        <h2 class="man">WHO IT’S FOR</h2>
         <div class="body">
-          <p>
-            One box holds the data of one operator. That operator is usually a
-            company, but nothing in Setoku assumes a payroll: the same box, the
-            same tools, the same approval step work at any size.
-          </p>
           <dl class="kv">
             <dt>A company<span class="t">a token per person</span></dt>
             <dd>
-              Revenue, churn, pipeline, deploys, support load. The definitions
-              everyone argues about get written down once: what counts as an
-              active customer, which refunds are excluded, which table people
-              actually trust.
+              Give agents team-by-team access to revenue, logs, and deploys,
+              for debugging and analysis. Definitions like “active customer”
+              get written down once.
             </dd>
-            <dt>A household<span class="t">two people, one box</span></dt>
+            <dt>A household<span class="t">one family, one box</span></dt>
             <dd>
-              Joint finances, mail, calendars. Both partners ask about the same
-              numbers, and the one who doesn’t write SQL still gets an answer,
-              or a link to a dashboard that stays current on its own.
+              Shared accounts and calendars, so the partner who doesn’t write
+              SQL gets the same answers.
             </dd>
-            <dt>One person<span class="t">reachable everywhere</span></dt>
+            <dt>One person<span class="t">reachable from anywhere</span></dt>
             <dd>
-              Your own bank, mail, and repos, queryable from every client you
-              use (phone, web, desktop), rather than only from the machine that
-              happens to hold the files.
+              Your own accounts and repos, queryable from your phone and the web
+              as well as your desktop.
             </dd>
           </dl>
-          <p class="dim">
-            Not for a static CSV you already have on disk: if a file answers the
-            question and won’t change, query it locally. Setoku earns its keep
-            on data that lives somewhere else and keeps moving.
-          </p>
         </div>
       </section>
 

--- a/site/index.md
+++ b/site/index.md
@@ -1,8 +1,8 @@
 # Setoku
 
-> Make any AI fluent in your company data.
+> Make any AI fluent in your own data.
 
-Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives an AI agent a read-only, audited view of a company’s data plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
+Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives an AI agent a read-only, audited view of the data you own (a company’s, a household’s, or your own), plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
 
 Version 0.21.0 · Apache-2.0 · <https://github.com/Hedgy-Labs/setoku>
 
@@ -10,20 +10,29 @@ This is the markdown twin of <https://setoku.com/>. The API reference is <https:
 
 ## When to use Setoku
 
-Reach for Setoku when the answer lives in a specific company’s own data and depends on that company’s definitions.
+Reach for Setoku when the answer lives in data its operator connected (a company’s, a household’s, or one person’s) and depends on their own definitions rather than public knowledge.
+
+Who runs one:
+
+- A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.
+- A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.
+- One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files.
 
 Use it when:
 
-- A question is about one company’s own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.
-- You need the company’s definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.
-- A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.
-- Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.
+- A question is about the operator’s own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.
+- The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today’s answer.
+- You need the operator’s definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.
+- A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.
+- Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.
+- An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.
 - You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner’s own box.
 
 Do not use it when:
 
 - The question is general knowledge, or about public data — Setoku only knows the data its operator connected.
-- You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
+- The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.
+- You need to write to the operator’s database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
 - You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator’s own box.
 - You want a model to run server-side. Setoku runs no inference; your own agent does the thinking.
 

--- a/site/index.md
+++ b/site/index.md
@@ -10,7 +10,7 @@ This is the markdown twin of <https://setoku.com/>. The API reference is <https:
 
 ## When to use Setoku
 
-Reach for Setoku when the answer lives in data its operator connected (a company’s, a household’s, or one person’s) and depends on their own definitions rather than public knowledge.
+Reach for Setoku when the answer lives in data its operator connected (a company’s, a household’s, or one person’s) and depends on their own definitions, not public knowledge.
 
 Who it’s for:
 
@@ -22,18 +22,18 @@ Use it when:
 
 - The question is about the operator’s own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.
 - The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.
-- You need the operator’s definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.
-- A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.
+- You need the operator’s definition of a term first: what counts as an active customer, which account is the joint one, which charges were reimbursed.
+- A naive query would be wrong in a way only an insider knows: soft-deleted rows, a test tenant, a transfer between your own accounts counted as income. You want that caveat before you run SQL.
 - You want a dashboard on a link someone else can open, on live data, not a screenshot.
 - An agent will read untrusted text (mail, logs, chat) in the same session. That session can’t rewrite what Setoku knows, so an injected instruction can’t become a remembered fact.
 - You want the answer to be auditable later: every query and knowledge change is logged on your box.
 
 Do not use it when:
 
-- The question is general knowledge, or about public data — Setoku only knows the data its operator connected.
-- The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.
-- You need to write to the operator’s database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
-- You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator’s own box.
+- The question is general knowledge or public data. Setoku only knows the data its operator connected.
+- The data is a static file on your disk. Query it locally. Setoku is for data that lives in other services and keeps changing.
+- You need to write to the operator’s database. Every data path is read-only, enforced by database role. There is no write tool and no escape hatch.
+- You want a hosted API to sign up for. There is none. Setoku is self-hosted, and the endpoint you call is the operator’s own box.
 - You want a model to run server-side. Setoku runs no inference.
 
 ## How an agent calls it
@@ -41,7 +41,7 @@ Do not use it when:
 1. Connect to the box’s MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person’s bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.
 2. Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.
 3. Then get_schema, then run_query.
-4. Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself.
+4. If the context is wrong, call report_correction. It lands as a proposal for a human to accept. An agent session can’t commit knowledge by itself.
 
 ## Try it without installing anything
 
@@ -71,7 +71,7 @@ Server, by hand, on a fresh Ubuntu VPS (about $5–12/month):
 
 ## The tool surface
 
-19 MCP tools. Which ones a session sees depends on its token’s role — that split is the security model, not a convenience.
+19 MCP tools. Which ones a session sees depends on its token’s role. That split is the security model.
 
 | Tool | What it does | Role |
 | --- | --- | --- |
@@ -119,7 +119,7 @@ No connector for yours? `/setoku:connect` gives a coding agent the patterns to w
 
 ## Security model
 
-- **Two identities, one membrane.** An analyst token may query the lake but holds no tool that commits knowledge. A curator token may commit knowledge but cannot read the lake. They never coexist on one session, so a prompt-injected session cannot weaponize the write path.
+- **Two identities, one membrane.** An analyst token may query the lake but holds no tool that commits knowledge. A curator token may commit knowledge but cannot read the lake. They never coexist on one session, so a prompt-injected session can’t reach the write path.
 - **Accepting knowledge is a human click** on the box’s admin page, outside the agent loop. No MCP tool creates users, grants access, or commits knowledge on its own.
 - **Reads are governed by database roles**, not by parsing SQL in our code. The engine enforces it.
 - **The credential never reaches the model.** Config names an environment variable; the gateway resolves it.

--- a/site/index.md
+++ b/site/index.md
@@ -1,6 +1,6 @@
 # Setoku
 
-> Make any AI fluent in your own data.
+> Make any AI fluent in your data.
 
 Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives an AI agent a read-only, audited view of the data you own (a company’s, a household’s, or your own), plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
 
@@ -12,35 +12,35 @@ This is the markdown twin of <https://setoku.com/>. The API reference is <https:
 
 Reach for Setoku when the answer lives in data its operator connected (a company’s, a household’s, or one person’s) and depends on their own definitions rather than public knowledge.
 
-Who runs one:
+Who it’s for:
 
-- A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.
-- A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.
-- One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files.
+- A company: give agents team-by-team access to revenue, logs, and deploys, for debugging and analysis. Definitions like “active customer” get written down once.
+- A household: shared accounts and calendars, so the partner who doesn’t write SQL gets the same answers.
+- One person: your own accounts and repos, queryable from your phone and the web as well as your desktop.
 
 Use it when:
 
-- A question is about the operator’s own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.
-- The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today’s answer.
+- The question is about the operator’s own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.
+- The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.
 - You need the operator’s definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.
 - A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.
-- Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.
-- An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.
-- You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner’s own box.
+- You want a dashboard on a link someone else can open, on live data, not a screenshot.
+- An agent will read untrusted text (mail, logs, chat) in the same session. That session can’t rewrite what Setoku knows, so an injected instruction can’t become a remembered fact.
+- You want the answer to be auditable later: every query and knowledge change is logged on your box.
 
 Do not use it when:
 
 - The question is general knowledge, or about public data — Setoku only knows the data its operator connected.
-- The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.
+- The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.
 - You need to write to the operator’s database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
 - You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator’s own box.
-- You want a model to run server-side. Setoku runs no inference; your own agent does the thinking.
+- You want a model to run server-side. Setoku runs no inference.
 
 ## How an agent calls it
 
 1. Connect to the box’s MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person’s bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.
 2. Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.
-3. Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.
+3. Then get_schema, then run_query.
 4. Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself.
 
 ## Try it without installing anything

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -12,35 +12,35 @@ Two identities share one server and never overlap. An **analyst** token may quer
 
 Reach for Setoku when the answer lives in data its operator connected (a company’s, a household’s, or one person’s) and depends on their own definitions rather than public knowledge.
 
-Who runs one:
+Who it’s for:
 
-- A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.
-- A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.
-- One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files.
+- A company: give agents team-by-team access to revenue, logs, and deploys, for debugging and analysis. Definitions like “active customer” get written down once.
+- A household: shared accounts and calendars, so the partner who doesn’t write SQL gets the same answers.
+- One person: your own accounts and repos, queryable from your phone and the web as well as your desktop.
 
 Use it when:
 
-- A question is about the operator’s own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.
-- The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today’s answer.
+- The question is about the operator’s own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.
+- The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.
 - You need the operator’s definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.
 - A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.
-- Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.
-- An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.
-- You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner’s own box.
+- You want a dashboard on a link someone else can open, on live data, not a screenshot.
+- An agent will read untrusted text (mail, logs, chat) in the same session. That session can’t rewrite what Setoku knows, so an injected instruction can’t become a remembered fact.
+- You want the answer to be auditable later: every query and knowledge change is logged on your box.
 
 Do not use it when:
 
 - The question is general knowledge, or about public data — Setoku only knows the data its operator connected.
-- The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.
+- The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.
 - You need to write to the operator’s database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
 - You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator’s own box.
-- You want a model to run server-side. Setoku runs no inference; your own agent does the thinking.
+- You want a model to run server-side. Setoku runs no inference.
 
 How an agent should call it:
 
 1. Connect to the box’s MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person’s bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.
 2. Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.
-3. Then get_schema, then run_query. Reading context before querying is the difference between a right answer and a plausible one.
+3. Then get_schema, then run_query.
 4. Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself.
 
 The same guidance, machine-readable, is in [/.well-known/mcp.json](https://setoku.com/.well-known/mcp.json), [/.well-known/agent-card.json](https://setoku.com/.well-known/agent-card.json), and [/.well-known/agent-skills/index.json](https://setoku.com/.well-known/agent-skills/index.json).

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,6 +1,6 @@
 # Setoku
 
-> Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives any AI agent a read-only, audited view of your company’s data plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
+> Setoku is an open-source, self-hosted MCP (Model Context Protocol) knowledge server. It gives any AI agent a read-only, audited view of the data you own (a company’s, a household’s, or your own), plus the curated context needed to use it correctly: the metric definitions, the gotchas, the reasons a naive query is wrong.
 
 Setoku is single-tenant on purpose. There is no hosted Setoku service and no multi-tenant API: you run it on a box you own (one small VPS), and your data and your context stay there. That is the point of the product, not a gap in it. So the API described below is the API that *your* deployment exposes, not one hosted at setoku.com.
 
@@ -10,20 +10,29 @@ Two identities share one server and never overlap. An **analyst** token may quer
 
 ## When to use Setoku
 
-Reach for Setoku when the answer lives in a specific company’s own data and depends on that company’s definitions.
+Reach for Setoku when the answer lives in data its operator connected (a company’s, a household’s, or one person’s) and depends on their own definitions rather than public knowledge.
+
+Who runs one:
+
+- A company: one box, a token per person, and the definitions everyone argues about written down once: what counts as an active customer, which refunds are excluded, which table people actually trust.
+- A household: joint finances, mail, and calendars on one box, so both partners can ask about the same numbers and the one who does not write SQL still gets an answer.
+- One person: your own bank, mail, and repos, reachable from every client you use (phone, web, desktop), instead of only from the machine holding the files.
 
 Use it when:
 
-- A question is about one company’s own operations — revenue, churn, pipeline, usage, spend, deploys, support load — and the data sits in their database, Slack, GitHub, email, or bank.
-- You need the company’s definition of a term before you can answer: what counts as an active customer, which refunds are excluded, which table is the one people actually trust.
-- A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a migration that split a table) and you want that caveat before you run SQL.
-- Someone wants a live, shareable view of that data — a dashboard or small app on a link their non-technical teammates can open, refreshing against real data rather than a pasted screenshot.
+- A question is about the operator’s own affairs (revenue, churn, pipeline, deploys and support load for a company; spending, budgets, net worth and mail for a person or a household) and the data sits in their database, Slack, GitHub, email, or bank.
+- The data has no fresh local copy. A bank, a budgeting service, a mail account and an issue tracker all keep changing, so a hand-made export is stale on arrival and the question needs today’s answer.
+- You need the operator’s definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.
+- A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.
+- Someone wants a live, shareable view of that data: a dashboard or small app on a link a non-technical teammate, or your partner, can open, refreshing against real data rather than a pasted screenshot.
+- An agent will read untrusted text (mail, logs, chat) in the same session it answers from. The session that reads it holds no tool that can rewrite what Setoku knows, so a prompt-injection attempt in an email cannot become a remembered fact.
 - You want your answer, and the reasoning behind it, to be auditable later: every query and every knowledge change is logged on the owner’s own box.
 
 Do not use it when:
 
 - The question is general knowledge, or about public data — Setoku only knows the data its operator connected.
-- You need to write to the business database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
+- The data is one static file you already have on disk. If a CSV export answers the question and will not change, query it locally; Setoku earns its keep on data that lives somewhere else and keeps moving.
+- You need to write to the operator’s database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
 - You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator’s own box.
 - You want a model to run server-side. Setoku runs no inference; your own agent does the thinking.
 

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -10,7 +10,7 @@ Two identities share one server and never overlap. An **analyst** token may quer
 
 ## When to use Setoku
 
-Reach for Setoku when the answer lives in data its operator connected (a company’s, a household’s, or one person’s) and depends on their own definitions rather than public knowledge.
+Reach for Setoku when the answer lives in data its operator connected (a company’s, a household’s, or one person’s) and depends on their own definitions, not public knowledge.
 
 Who it’s for:
 
@@ -22,18 +22,18 @@ Use it when:
 
 - The question is about the operator’s own revenue, deploys, spending, mail, or repos. The data lives in their database, Slack, GitHub, email, or bank.
 - The data keeps changing (a bank, an inbox, an issue tracker), so an export is stale on arrival.
-- You need the operator’s definition of a term before you can answer: what counts as an active customer, which account is the joint one, which charges were reimbursed and are therefore not really spend.
-- A naive query would be wrong in a way only an insider knows (soft-deleted rows, a test tenant, a transfer between two of your own accounts double-counted as income) and you want that caveat before you run SQL.
+- You need the operator’s definition of a term first: what counts as an active customer, which account is the joint one, which charges were reimbursed.
+- A naive query would be wrong in a way only an insider knows: soft-deleted rows, a test tenant, a transfer between your own accounts counted as income. You want that caveat before you run SQL.
 - You want a dashboard on a link someone else can open, on live data, not a screenshot.
 - An agent will read untrusted text (mail, logs, chat) in the same session. That session can’t rewrite what Setoku knows, so an injected instruction can’t become a remembered fact.
 - You want the answer to be auditable later: every query and knowledge change is logged on your box.
 
 Do not use it when:
 
-- The question is general knowledge, or about public data — Setoku only knows the data its operator connected.
-- The data is one static file you already have on disk. If a file answers the question and will not change, query it locally; Setoku is for data that lives in other services and keeps changing.
-- You need to write to the operator’s database. Every data path is read-only, by database role; there is no write tool and no escape hatch.
-- You are looking for a hosted, multi-tenant API to sign up for. There is none: Setoku is single-tenant and self-hosted, and the endpoint you call is the operator’s own box.
+- The question is general knowledge or public data. Setoku only knows the data its operator connected.
+- The data is a static file on your disk. Query it locally. Setoku is for data that lives in other services and keeps changing.
+- You need to write to the operator’s database. Every data path is read-only, enforced by database role. There is no write tool and no escape hatch.
+- You want a hosted API to sign up for. There is none. Setoku is self-hosted, and the endpoint you call is the operator’s own box.
 - You want a model to run server-side. Setoku runs no inference.
 
 How an agent should call it:
@@ -41,7 +41,7 @@ How an agent should call it:
 1. Connect to the box’s MCP endpoint (Streamable HTTP) at `https://<their-box>/mcp` with the person’s bearer token, or paste `https://<their-box>/mcp/<token>` into a connector dialog that has no header field.
 2. Call find_context FIRST, every time. It returns the curated notes for the question, including which tables to trust and which to avoid.
 3. Then get_schema, then run_query.
-4. Found something the context got wrong? Call report_correction. It lands as a proposal for a human to accept — an agent session can never commit knowledge by itself.
+4. If the context is wrong, call report_correction. It lands as a proposal for a human to accept. An agent session can’t commit knowledge by itself.
 
 The same guidance, machine-readable, is in [/.well-known/mcp.json](https://setoku.com/.well-known/mcp.json), [/.well-known/agent-card.json](https://setoku.com/.well-known/agent-card.json), and [/.well-known/agent-skills/index.json](https://setoku.com/.well-known/agent-skills/index.json).
 

--- a/site/openapi.json
+++ b/site/openapi.json
@@ -4,7 +4,7 @@
     "title": "Setoku Gateway API",
     "version": "0.21.0",
     "summary": "The HTTP surface of a self-hosted Setoku MCP knowledge server.",
-    "description": "Setoku is an open-source, self-hosted MCP server that gives an AI agent a read-only, audited view of a company's data plus the curated context needed to use it correctly.\n\nEvery Setoku box exposes this API. There is no multi-tenant setoku.com API: the product is single-tenant by design and runs on infrastructure you own, so point `host` at your own deployment (or at the public demo box).\n\nThe primary interface is MCP over Streamable HTTP at `/mcp`, which carries 19 tools (see https://setoku.com/api/tools.json). The REST endpoints below are the credential-free surface: box health, and published apps.",
+    "description": "Setoku is an open-source, self-hosted MCP server that gives an AI agent a read-only, audited view of its operator's own data plus the curated context needed to use it correctly.\n\nEvery Setoku box exposes this API. There is no multi-tenant setoku.com API: the product is single-tenant by design and runs on infrastructure you own, so point `host` at your own deployment (or at the public demo box).\n\nThe primary interface is MCP over Streamable HTTP at `/mcp`, which carries 19 tools (see https://setoku.com/api/tools.json). The REST endpoints below are the credential-free surface: box health, and published apps.",
     "license": {
       "name": "Apache-2.0",
       "identifier": "Apache-2.0"


### PR DESCRIPTION
Rewrites the who-it’s-for and when-to-use copy on every surface agents read (homepage, index.md, docs.md, llms.txt, mcp.json, agent-card.json) via the shared `WHEN_TO_USE` block in `scripts/build-site-api.ts`.

- The company line now says team-by-team access to revenue, logs, and deploys. “Every agent gets full knowledge” was never true (access is per token, per source family).
- Shorter sentences throughout; stacked clauses split, quotable closers dropped.
- Tagline: “Make any AI fluent in your data.”
- “Who runs one” → “Who it’s for”.

Derived files regenerated with `bun run build:site`; `test/site-api.test.ts` and the full fast suite pass.

https://claude.ai/code/session_0144v3FJKvxpKHqXsbSCwpmN