### PR TITLE
Keep a public app public when its author re-publishes it

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -405,9 +405,10 @@ Replaces `publish_report` / `list_published` / `unpublish_report`:
   state-only app; only a zero-panel full HTML document is a static report.
 - **`update_app({ id, title?, html?, panels?, params?, refreshSeconds? })`** — edit
   an app **you authored**, in place (same id/link). Only the author can edit;
-  `panels` / `params` each replace the whole set (re-validated + dry-run). Changing
-  `panels` on a *public* app reverts it to team-only — the data it exposes changed,
-  so an admin must re-approve (the human public-promotion gate, I9).
+  `panels` / `params` each replace the whole set (re-validated + dry-run). The edit
+  lands on the app's existing link: a public app stays public (and keeps any shared
+  password), so the change is live for everyone holding that link — see "Editing a
+  public app" below.
 - **`list_apps()`** / **`unpublish_app({ id })`** — unchanged semantics from the
   old list/unpublish.
 - **`get_app({ id })`** — read-only inspection of panel definitions + last-run
@@ -458,6 +459,23 @@ the deferred next step — it pairs with `update_app` for a see-then-fix loop.
   **public** exfil — is closed by reusing the report rule verbatim: **the agent
   can only publish team-only; flipping to public is a human click in the web console**
   (the agent holds no web session).
+- **Editing a public app does not re-gate it.** An `update_app` that changes
+  panels or params on a public app used to drop it back to team-only until an
+  admin re-approved the link. In practice that fired on every ordinary iteration
+  of an app whose whole point was to be public: the link went dark mid-session,
+  and the human clicking it back was re-approving their own edit, one they had
+  just asked for. The gate now sits where I9 actually puts it — on **promotion**,
+  which no agent can perform — and an edit rides on the link the human already
+  blessed. The residual risk is real and named: an injection-driven `update_app`
+  on an already-public app can change what that link exposes without a further
+  click. What still stands against it: only the app's **author** can edit it, and
+  panels run under that creator's source grants, so an edit can never expose more
+  than its author may already read (per-source denies still bite); every edit is
+  audited with a `public` marker saying the change landed on a live link
+  (`update_app` and the web restore alike); each edit appends a version snapshot a
+  human can restore; the team's activity notification announces agent edits on
+  boxes that have a notify webhook configured; and locking an app freezes it
+  against agent edits entirely.
 - **Renders run under the gateway role, not a session.** Panel re-execution
   carries no `denyLakeRead` — the membrane is enforced at *authorship* (a curator
   session can't publish a lake-backed panel), not at render. So a public

--- a/plugin/gateway/app.ts
+++ b/plugin/gateway/app.ts
@@ -1917,8 +1917,8 @@ server.registerTool(
       "Changing `panels` or `params` re-validates and dry-runs every panel against the new params. " +
       "Only the app's AUTHOR can edit it, and a LOCKED app rejects all edits (the author or an admin " +
       "locks/unlocks from the web UI) — copy a locked app with get_app → publish_app instead. " +
-      "Note: changing `panels` or `params` on an app that's currently public reverts it to team-only — an admin " +
-      "must re-approve it for the public link, since the data it exposes changed. " +
+      "An edit lands on the app's EXISTING link: a public app stays public (and keeps any shared password), so " +
+      "your changes are live for everyone holding that link the moment this returns. " +
       "Pass a `message` describing WHAT changed — it shows in the app's version history and the team's activity " +
       "notification. " +
       "The `html` template + `Setoku.*` helper + panels/params contract is documented by app_guide — call it if you haven't.",
@@ -1974,12 +1974,12 @@ server.registerTool(
       return errorText(`message is ${note.length} chars — keep it under ${MAX_UPDATE_MESSAGE_CHARS} (a one-line summary of what changed).`);
 
     // Panels AND params both determine what the panels compute (params bind into
-    // the SQL), so a change to EITHER must be validated and re-seeded — and, on a
-    // public app, re-gated (I9). Re-run the shared prep over the EFFECTIVE panel
-    // set against the EFFECTIVE params whenever either changes: this validates the
-    // new param defaults/names, re-checks every existing panel still compiles
-    // against the new params (a removed/renamed param would otherwise 500 the app
-    // at render), and re-seeds the default-variant cache.
+    // the SQL), so a change to EITHER must be validated and re-seeded. Re-run the
+    // shared prep over the EFFECTIVE panel set against the EFFECTIVE params
+    // whenever either changes: this validates the new param defaults/names,
+    // re-checks every existing panel still compiles against the new params (a
+    // removed/renamed param would otherwise 500 the app at render), and re-seeds
+    // the default-variant cache.
     const panelsChanged = panels !== undefined;
     const paramsChanged = params !== undefined;
     const dataChanged = panelsChanged || paramsChanged;
@@ -2021,17 +2021,14 @@ server.registerTool(
     // Re-seed the cache for the re-derived panels (updatePublished cleared the old rows).
     if (seeds) for (const s of seeds) store.putPanelCache(tid, s.key, { columns: s.columns, rows: s.rows, rowCount: s.rowCount, truncated: s.truncated, error: null });
 
-    // Panels OR params alter what the public link exposes — if it was public,
-    // revert to team so an admin re-approves (the human promotion gate, I9).
-    let reverted = false;
-    if (dataChanged && meta.visibility === "public") {
-      store.setReportVisibility(tid, "team");
-      reverted = true;
-    }
     store.audit(user, "update_app", {
       id: tid,
       changed: [newTitle !== undefined && "title", html !== undefined && "html", panelsChanged && "panels", paramsChanged && "params", refreshSeconds !== undefined && "refreshSeconds"].filter(Boolean),
-      reverted,
+      // Did this edit land on a live PUBLIC link? Marked for EVERY facet, not
+      // just panels/params — an html-only edit changes what public viewers see
+      // too. The audit log is where that shows up: I9's human gate stands on
+      // PROMOTION, which no agent can do, not on every later edit.
+      public: meta.visibility === "public",
       model: modelName,
     });
     // Nudge any browser currently viewing this app to refetch (SSE live-refresh)
@@ -2050,7 +2047,7 @@ server.registerTool(
     void notifyActivity(projectDir, {
       kind: "app_updated",
       title: newTitle ?? meta.title,
-      url: publishUrl(tid, reverted ? "team" : meta.visibility),
+      url: publishUrl(tid, meta.visibility),
       by: user,
       changed: changedFacets,
       message: note,
@@ -2059,8 +2056,7 @@ server.registerTool(
     const finalHtml = html ?? store.getPublished(tid)?.body ?? "";
     const finalPanels = normalized ?? meta.panels ?? [];
     return text(
-      `Updated "${meta.title}" → ${publishUrl(tid, reverted ? "team" : meta.visibility)} (same link).` +
-        (reverted ? "\n\n⚠ Panels or params changed on a PUBLIC app — reverted to team-only; an admin must re-publish it publicly from /admin." : "") +
+      `Updated "${meta.title}" → ${publishUrl(tid, meta.visibility)} (same link).` +
         (await publishNotes(finalHtml, finalPanels)),
     );
   },

--- a/plugin/gateway/http.ts
+++ b/plugin/gateway/http.ts
@@ -2416,21 +2416,17 @@ const httpServer = http.createServer(async (req, res) => {
           // Restore an earlier version (#58) — author-or-admin, same gate as
           // rename. Copies the chosen snapshot's content forward as a NEW version
           // (append-only, so the restore is itself undoable) and clears the panel
-          // cache (restored panels recompute on next view). If the restored
-          // content changes what a PUBLIC app exposes, it drops to team-only — an
-          // admin must re-publish it (the human promotion gate, I9), mirroring
-          // update_app.
+          // cache (restored panels recompute on next view). Like update_app, it
+          // lands on the app's existing link: a public app stays public.
           if (api === "revert") {
             const body = (await readBody(req)) as { id?: string; seq?: number } | undefined;
             const id = (body?.id ?? "").trim();
             const seq = Number(body?.seq);
             if (!Number.isInteger(seq) || seq < 1) return json(400, { ok: false, error: "Bad version." });
             if (!mayMutateApp(id)) return;
-            const meta = store.getPublishedMeta(id); // current state (for the visibility check)
+            const meta = store.getPublishedMeta(id); // for the audit's public-link marker
             const snap = store.getAppRevision(id, seq);
-            if (!meta || !snap) return json(404, { ok: false, error: "No such version." });
-            const norm = (v: unknown): string => JSON.stringify(v ?? []);
-            const dataChanged = norm(snap.panels) !== norm(meta.panels) || norm(snap.params) !== norm(meta.params);
+            if (!snap) return json(404, { ok: false, error: "No such version." });
             const ok = store.updatePublished(
               id,
               {
@@ -2446,11 +2442,6 @@ const httpServer = http.createServer(async (req, res) => {
             // non-2xx; a `flash` here would be dropped and shown as "HTTP 409".
             if (!ok)
               return json(409, { ok: false, error: "Couldn’t restore that version. The app may have just been archived." });
-            let reverted = false;
-            if (dataChanged && meta.visibility === "public") {
-              store.setReportVisibility(id, "team");
-              reverted = true;
-            }
             // Re-seed the cache from the restored version and check its panels
             // still run — the snapshot was valid when saved, but the schema/config
             // may have drifted since. Uses the same governed viewer render path
@@ -2469,15 +2460,17 @@ const httpServer = http.createServer(async (req, res) => {
                 // A re-seed failure must not fail the restore; the next view recomputes.
               }
             }
-            store.audit(session.identity, "revert_app", { id, seq, reverted, brokenPanels: !!panelWarning });
-            emitAppChanged(id, "restored"); // other open viewers reload the restored content
-            return json(200, {
-              ok: true,
-              flash:
-                (reverted
-                  ? `Restored version ${seq}. Its data changed, so it reverted to team-only; an admin can re-publish it publicly.`
-                  : `Restored version ${seq}.`) + panelWarning,
+            // Same marker update_app records: a restore also rewrites what a live
+            // public link serves (an older panel set can predate the promotion),
+            // so the audit row has to say the link was live.
+            store.audit(session.identity, "revert_app", {
+              id,
+              seq,
+              brokenPanels: !!panelWarning,
+              public: meta?.visibility === "public",
             });
+            emitAppChanged(id, "restored"); // other open viewers reload the restored content
+            return json(200, { ok: true, flash: `Restored version ${seq}.` + panelWarning });
           }
 
           // Restore an archived app. Author-or-admin, but (unlike the other

--- a/test/apps-integration.test.ts
+++ b/test/apps-integration.test.ts
@@ -207,7 +207,7 @@ describe("get_app — full round-trip (template + params + panels) (#59)", () =>
   });
 });
 
-describe("update_app — params are first-class (validate + I9 re-gate)", () => {
+describe("update_app — params are first-class (validated on every edit)", () => {
   it("rejects a params-only update whose new default doesn't coerce", async () => {
     const c = await gwConnect(BASE, "tok_boss", "pub");
     const id = idOf((await call(c, "publish_app", { title: "p1", html: "<div id=kpi></div>", panels: [REGION_PANEL], params: [REGION_PARAM] })).text);
@@ -223,7 +223,7 @@ describe("update_app — params are first-class (validate + I9 re-gate)", () => 
     expect(r.isError).toBeTruthy();
     expect(r.text.toLowerCase()).toContain("undeclared param");
   });
-  it("reverts a PUBLIC app to team-only when params change (I9 human re-approval)", async () => {
+  it("keeps a PUBLIC app public when params change — the link survives a re-publish", async () => {
     const c = await gwConnect(BASE, "tok_boss", "pub");
     const id = idOf((await call(c, "publish_app", { title: "p3", html: "<div id=kpi></div>", panels: [REGION_PANEL], params: [REGION_PARAM] })).text);
     const { cookie, csrf } = await login();
@@ -233,11 +233,10 @@ describe("update_app — params are first-class (validate + I9 re-gate)", () => 
       body: JSON.stringify({ id, visibility: "public" }),
     });
     expect((await setVis.json()).ok).toBe(true);
-    // A params-only edit widens what the public link exposes → must re-gate.
     const r = await call(c, "update_app", { id, params: [{ ...REGION_PARAM, options: [{ value: "NA" }, { value: "EMEA" }, { value: "APAC" }, { value: "LATAM" }] }] });
     expect(r.isError).toBeFalsy();
-    expect(r.text.toLowerCase()).toContain("reverted to team-only");
-    expect((await fetch(`${BASE}/p/${id}`)).status).toBe(404); // no longer public
+    expect(r.text).toContain(`/p/${id}`); // the reply still hands back the public link
+    expect((await fetch(`${BASE}/p/${id}`)).status).toBe(200); // and it still serves
   });
 });
 

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1512,7 +1512,7 @@ describe("live apps (end-to-end render path)", () => {
     expect((await fetch(`${BASE}/p/${soId}/data`)).status).toBe(404);
   }, 20_000);
 
-  it("update_app is author-gated, edits in place, injects the chart runtime, and reverts public on panel change", async () => {
+  it("update_app is author-gated, edits in place, injects the chart runtime, and keeps a public link live", async () => {
     const alice = await connect("tok-alice");
     const pub = await call(alice, "publish_app", {
       title: "Alice board",
@@ -1538,16 +1538,16 @@ describe("live apps (end-to-end render path)", () => {
     });
     expect((await fetch(`${BASE}/p/${id}`)).status).toBe(200);
 
-    // the author edits PANELS → reverts to team-only (re-approval needed)
+    // the author edits PANELS → the SAME link keeps serving, now with the new panel
     const alice2 = await connect("tok-alice");
     const upd = await call(alice2, "update_app", {
       id,
       panels: [{ key: "a", sql: "SELECT count(*) AS n FROM biz.orders WHERE status='paid'", dialect: "clickhouse" }],
     });
     expect(upd.isError).toBe(false);
-    expect(upd.text.toLowerCase()).toContain("reverted to team");
+    expect(upd.text).toContain(`/p/${id}`); // still the public URL it had
     await alice2.close();
-    expect((await fetch(`${BASE}/p/${id}`)).status).toBe(404); // public link gone
+    expect((await fetch(`${BASE}/p/${id}`)).status).toBe(200); // link never goes dark on a re-publish
 
     // the team frame serves the new code, with the chart runtime injected
     const frame = await (await fetch(`${BASE}/admin/frame/${id}`, { headers: { cookie: boss.cookie } })).text();


### PR DESCRIPTION
Reported in Slack: re-publishing an app flipped it from public back to private, and it wasn't clear whether the shared password had been wiped (it hadn't — the argon2id hash stays dormant on the row and re-applies when the app goes public again).

## Cause

`update_app` reverted a **public** app to team-only whenever `panels` or `params` changed, as an I9 re-approval gate. Content-only edits didn't trip it, so from the outside it looked arbitrary. The web "restore version" handler mirrored the same rule.

That gate fired on every ordinary iteration of an app whose whole point was to be public: the link went dark mid-session, and the human clicking it back was re-approving an edit they had just asked for.

## Change

- `update_app` no longer touches visibility. The reply hands back the same `/p/<id>` link the app already had.
- The web `revert` handler likewise leaves the link alone.
- Both paths audit a `public` marker saying the change landed on a live link — on `update_app` it covers every facet (an `html`-only edit changes what public viewers see too).
- Tool description and `docs/apps.md` updated.

No store, SPA, or bundle changes; no migration.

## Residual risk (documented, not glossed)

An injection-driven `update_app` on an already-public app can now change what that link exposes without a further human click. `docs/apps.md` records the decision and what still stands against it: author-only edits, panels running under the creator's source grants (an edit can't expose more than its author may already read), the audit marker, per-edit version snapshots a human can restore, activity notifications where a webhook is configured, and app locking.

The promotion gate itself is untouched: an agent still cannot make an app public.

## Tests

- `test/http.test.ts` and `test/apps-integration.test.ts` flipped from asserting the revert to asserting the link still serves (200) after a panel change and after a params change.
- Fast suite 604 pass / 0 fail; `tsc --noEmit` clean; browser e2e 8/8.

https://claude.ai/code/session_01FdWBn4TE3fxok6NFd33Lzo